### PR TITLE
soroban-rpc: Update the docker building file for the soroban-rpc to match the new location

### DIFF
--- a/cmd/soroban-rpc/docker/Dockerfile
+++ b/cmd/soroban-rpc/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.19.1 as build
 
 ADD . /src/soroban-rpc
 WORKDIR /src/soroban-rpc
-RUN go build -o /bin/soroban-rpc ./exp/services/soroban-rpc
+RUN go build -o /bin/soroban-rpc ./cmd/soroban-rpc
 
 
 FROM ubuntu:20.04


### PR DESCRIPTION
### What

Update the docker building file for the soroban-rpc to match the new location.

### Why

The location has changed due to the porting of the utility between repos.
This PR is a pre-req to the quickstart update.

### Known limitations

N/A
