### PR TITLE
soroban-rpc: separate the daemon from the main function

### DIFF
--- a/cmd/soroban-rpc/internal/config/config.go
+++ b/cmd/soroban-rpc/internal/config/config.go
@@ -1,0 +1,13 @@
+package config
+
+import "github.com/sirupsen/logrus"
+
+type LocalConfig struct {
+	EndPoint          string
+	HorizonURL        string
+	StellarCoreURL    string
+	NetworkPassphrase string
+	LogLevel          logrus.Level
+	TxConcurrency     int
+	TxQueueSize       int
+}

--- a/cmd/soroban-rpc/internal/daemon/daemon.go
+++ b/cmd/soroban-rpc/internal/daemon/daemon.go
@@ -13,7 +13,8 @@ import (
 	"github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/methods"
 )
 
-func Start(logger *supportlog.Entry, cfg config.LocalConfig) (exitCode int) {
+func Start(cfg config.LocalConfig) (exitCode int) {
+	logger := supportlog.New()
 	logger.SetLevel(cfg.LogLevel)
 
 	hc := &horizonclient.Client{

--- a/cmd/soroban-rpc/internal/daemon/daemon.go
+++ b/cmd/soroban-rpc/internal/daemon/daemon.go
@@ -1,0 +1,57 @@
+package daemon
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/stellar/go/clients/horizonclient"
+	"github.com/stellar/go/clients/stellarcore"
+	supporthttp "github.com/stellar/go/support/http"
+	supportlog "github.com/stellar/go/support/log"
+	"github.com/stellar/soroban-tools/cmd/soroban-rpc/internal"
+	"github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/config"
+	"github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/methods"
+)
+
+func Start(logger *supportlog.Entry, cfg config.LocalConfig) (exitCode int) {
+	logger.SetLevel(cfg.LogLevel)
+
+	hc := &horizonclient.Client{
+		HorizonURL: cfg.HorizonURL,
+		HTTP: &http.Client{
+			Timeout: horizonclient.HorizonTimeout,
+		},
+		AppName: "Soroban RPC",
+	}
+	hc.SetHorizonTimeout(horizonclient.HorizonTimeout)
+
+	transactionProxy := methods.NewTransactionProxy(
+		hc,
+		cfg.TxConcurrency,
+		cfg.TxQueueSize,
+		cfg.NetworkPassphrase,
+		5*time.Minute,
+	)
+
+	handler, err := internal.NewJSONRPCHandler(internal.HandlerParams{
+		AccountStore:     methods.AccountStore{Client: hc},
+		Logger:           logger,
+		TransactionProxy: transactionProxy,
+		CoreClient:       &stellarcore.Client{URL: cfg.StellarCoreURL},
+	})
+	if err != nil {
+		logger.Fatalf("could not create handler: %v", err)
+	}
+	supporthttp.Run(supporthttp.Config{
+		ListenAddr: cfg.EndPoint,
+		Handler:    handler,
+		OnStarting: func() {
+			logger.Infof("Starting Soroban JSON RPC server on %v", cfg.EndPoint)
+			handler.Start()
+		},
+		OnStopping: func() {
+			handler.Close()
+		},
+	})
+	return 0
+}

--- a/cmd/soroban-rpc/main.go
+++ b/cmd/soroban-rpc/main.go
@@ -20,7 +20,6 @@ func main() {
 	var endpoint, horizonURL, stellarCoreURL, networkPassphrase string
 	var txConcurrency, txQueueSize int
 	var logLevel logrus.Level
-	logger := supportlog.New()
 
 	configOpts := config.ConfigOptions{
 		{
@@ -103,16 +102,18 @@ func main() {
 				TxConcurrency:     txConcurrency,
 				TxQueueSize:       txQueueSize,
 			}
-			exitCode := daemon.Start(logger, config)
+			exitCode := daemon.Start(config)
 			os.Exit(exitCode)
 		},
 	}
 
 	if err := configOpts.Init(cmd); err != nil {
-		logger.WithError(err).Fatal("could not parse config options")
+		supportlog.New().WithError(err).Fatal("could not parse config options")
+		os.Exit(-1)
 	}
 
 	if err := cmd.Execute(); err != nil {
-		logger.WithError(err).Fatal("could not run")
+		supportlog.New().WithError(err).Fatal("could not run")
+		os.Exit(-1)
 	}
 }


### PR DESCRIPTION
### What

Break the soroban-rpc daemon out of the main function. 

### Why

That would allow us to write tests that invoke a server while bypassing the command line processor.

### Known limitations

N/A
