### PR TITLE
git: update .gitIgnore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target/
 .soroban/
+.DS_Store
+.vscode/


### PR DESCRIPTION
### What

update the .gitignore so that git would ignore .DS_Store and .vscode/* files.

### Why

This would allow the developers run `git status --porcelain` effectively and confirm that no changes were introduced.

### Known limitations

N/A
