### PR TITLE
soroban-rpc: Add version information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,12 @@ export RUSTFLAGS=-Dwarnings -Dclippy::all -Dclippy::pedantic
 
 REPOSITORY_VERSION ?= "$(shell git describe --tags --always --abbrev=0 --match='v[0-9]*.[0-9]*.[0-9]*' 2> /dev/null | sed 's/^.//')"
 REPOSITORY_COMMIT_HASH := "$(shell git rev-parse HEAD)"
+REPOSITORY_BRANCH := "$(shell git rev-parse --abbrev-ref HEAD)"
 BUILD_TIMESTAMP ?= $(shell date '+%Y-%m-%dT%H:%M:%S')
 GOLDFLAGS :=	-X 'github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/config.Version=${REPOSITORY_VERSION}' \
 				-X 'github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/config.CommitHash=${REPOSITORY_COMMIT_HASH}' \
-				-X 'github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/config.BuildTimestamp=${BUILD_TIMESTAMP}'
+				-X 'github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/config.BuildTimestamp=${BUILD_TIMESTAMP}' \
+				-X 'github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/config.Branch=${REPOSITORY_BRANCH}'
 
 # update the Cargo.lock every time the Cargo.toml changes.
 Cargo.lock: Cargo.toml

--- a/Makefile
+++ b/Makefile
@@ -2,17 +2,24 @@ all: check build test
 
 export RUSTFLAGS=-Dwarnings -Dclippy::all -Dclippy::pedantic
 
+REPOSITORY_VERSION ?= "$(shell git describe --tags --always --abbrev=0 --match='v[0-9]*.[0-9]*.[0-9]*' 2> /dev/null | sed 's/^.//')"
+REPOSITORY_COMMIT_HASH := "$(shell git rev-parse HEAD)"
+BUILD_TIMESTAMP ?= $(shell date '+%Y-%m-%dT%H:%M:%S')
+GOLDFLAGS :=	-X 'github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/config.Version=${REPOSITORY_VERSION}' \
+				-X 'github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/config.CommitHash=${REPOSITORY_COMMIT_HASH}' \
+				-X 'github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/config.BuildTimestamp=${BUILD_TIMESTAMP}'
+
 # update the Cargo.lock every time the Cargo.toml changes.
 Cargo.lock: Cargo.toml
 	cargo update --workspace
 
 install: Cargo.lock
 	cargo install --path .
-	go install ./...
+	go install -ldflags="${GOLDFLAGS}" ./...
 
 build: Cargo.lock
 	cargo build
-	go build ./...
+	go build -ldflags="${GOLDFLAGS}" ./...
 
 build-test-wasms: Cargo.lock
 	cargo build --package 'test_*' --profile test-wasms --target wasm32-unknown-unknown

--- a/cmd/soroban-rpc/internal/config/version.go
+++ b/cmd/soroban-rpc/internal/config/version.go
@@ -1,0 +1,12 @@
+package config
+
+var (
+	// Version is the soroban-rpc version number, which is injected during build time.
+	Version = "0.1.0"
+
+	// CommitHash is the soroban-rpc git commit hash, which is injected during build time.
+	CommitHash = ""
+
+	// BuildTimestamp is the timestamp at which the soroban-rpc was built, injected during build time.
+	BuildTimestamp = ""
+)

--- a/cmd/soroban-rpc/internal/config/version.go
+++ b/cmd/soroban-rpc/internal/config/version.go
@@ -2,11 +2,14 @@ package config
 
 var (
 	// Version is the soroban-rpc version number, which is injected during build time.
-	Version = "0.1.0"
+	Version = "0.0.0"
 
 	// CommitHash is the soroban-rpc git commit hash, which is injected during build time.
 	CommitHash = ""
 
 	// BuildTimestamp is the timestamp at which the soroban-rpc was built, injected during build time.
 	BuildTimestamp = ""
+
+	// Branch is the git branch from which the soroban-rpc was built, injected during build time.
+	Branch = ""
 )

--- a/cmd/soroban-rpc/main.go
+++ b/cmd/soroban-rpc/main.go
@@ -107,6 +107,20 @@ func main() {
 		},
 	}
 
+	versionCmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print version information and exit",
+		Run: func(_ *cobra.Command, _ []string) {
+			if localConfig.CommitHash == "" {
+				fmt.Printf("soroban-rpc dev\n")
+			} else {
+				fmt.Printf("soroban-rpc %s (%s)\n", localConfig.Version, localConfig.CommitHash)
+			}
+		},
+	}
+
+	cmd.AddCommand(versionCmd)
+
 	if err := configOpts.Init(cmd); err != nil {
 		supportlog.New().WithError(err).Fatal("could not parse config options")
 		os.Exit(-1)

--- a/cmd/soroban-rpc/main.go
+++ b/cmd/soroban-rpc/main.go
@@ -114,7 +114,15 @@ func main() {
 			if localConfig.CommitHash == "" {
 				fmt.Printf("soroban-rpc dev\n")
 			} else {
-				fmt.Printf("soroban-rpc %s (%s)\n", localConfig.Version, localConfig.CommitHash)
+				// avoid printing the branch for the main branch
+				// ( since that's what the end-user would typically have )
+				// but keep it for internal build ( so that we'll know from which branch it
+				// was built )
+				branch := localConfig.Branch
+				if branch == "main" {
+					branch = ""
+				}
+				fmt.Printf("soroban-rpc %s (%s) %s\n", localConfig.Version, localConfig.CommitHash, branch)
 			}
 		},
 	}


### PR DESCRIPTION
### What

Add version information to soroban-rpc

### Why

Before making the next release, we should version and timestamp our released binaries.

### Known limitations

N/A


### Run

```bash
> soroban-rpc version
soroban-rpc 0.2.1 (e224d8745a92ba3d626f795587bf55d1fd154474)
```
