### PR TITLE
cmd/soroban-rpc: print xdr version

### DIFF
--- a/cmd/soroban-rpc/main.go
+++ b/cmd/soroban-rpc/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stellar/go/network"
 	"github.com/stellar/go/support/config"
 	supportlog "github.com/stellar/go/support/log"
+	goxdr "github.com/stellar/go/xdr"
 	localConfig "github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/config"
 	"github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/daemon"
 )
@@ -123,6 +124,7 @@ func main() {
 					branch = ""
 				}
 				fmt.Printf("soroban-rpc %s (%s) %s\n", localConfig.Version, localConfig.CommitHash, branch)
+				fmt.Printf("stellar-xdr %s\n", goxdr.CommitHash)
 			}
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/sirupsen/logrus v1.4.1
 	github.com/spf13/cobra v0.0.0-20160830174925-9c28e4bbd74e
 	github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189
-	github.com/stellar/go v0.0.0-20221024165153-36c7c5dffc5a
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/mod v0.6.0
 )
@@ -53,6 +52,7 @@ require (
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/spf13/cast v0.0.0-20150508191742-4d07383ffe94 // indirect
 	github.com/spf13/jwalterweatherman v0.0.0-20141219030609-3d60171a6431 // indirect
+	github.com/stellar/go v0.0.0-20221130151413-77a05889334f
 	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.0 // indirect
 	golang.org/x/crypto v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -112,8 +112,8 @@ github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475 h1:RtZIgreTwcayPTOw7G5
 github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189 h1:fvB1AFbBd6SfI9Rd0ooAJp8uLkZDbZaLFHi7ZnNP6uI=
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
-github.com/stellar/go v0.0.0-20221024165153-36c7c5dffc5a h1:00HRtvA3Ts0vXZZKWyHcUXBZXFfP2HnopShTMYTX+eA=
-github.com/stellar/go v0.0.0-20221024165153-36c7c5dffc5a/go.mod h1:AbsNBrmclUvQcs0EeN+LDhubhX7tyo18r5fw0SCz/oM=
+github.com/stellar/go v0.0.0-20221130151413-77a05889334f h1:ZKf9XwvizoE0F4VQ49Qs8aXn8zhyuw6vX0ng/VVh2Sc=
+github.com/stellar/go v0.0.0-20221130151413-77a05889334f/go.mod h1:AbsNBrmclUvQcs0EeN+LDhubhX7tyo18r5fw0SCz/oM=
 github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee h1:fbVs0xmXpBvVS4GBeiRmAE3Le70ofAqFMch1GTiq/e8=
 github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
### What

update soroban-rpc version printing to include the xdr version

### Why

To improve tooling building transparency

### Known limitations

N/A

### How does it look ?

```bash
> soroban-rpc version
soroban-rpc 0.2.1 (1f9220d764358c1515b2ed53d3c512c8765b5769) tsachi/addXdrVersion
stellar-xdr d194cc6cd79e3b368c43477556b0084e81b9dcbc
```
