### PR TITLE
Add a more generic getLedgerEntry rpc method

### DIFF
--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -17,7 +17,7 @@ jobs:
     env:
       SOROBAN_RPC_INTEGRATION_TESTS_ENABLED: true
       SOROBAN_RPC_INTEGRATION_TESTS_CAPTIVE_CORE_BIN: /usr/bin/stellar-core
-      PROTOCOL_19_CORE_DEBIAN_PKG_VERSION: 19.5.1-1111.eba1d3de9.focal~soroban
+      PROTOCOL_19_CORE_DEBIAN_PKG_VERSION: 19.5.1-1131.f55f88376.focal~soroban
     steps:
       - uses: actions/checkout@v3
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,9 +43,9 @@ checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.6"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba45b8163c49ab5f972e59a8a5a03b6d2972619d486e19ec9fe744f7c2753d3c"
+checksum = "fa3d466004a8b4cb1bc34044240a2fd29d17607e2e3bd613eb44fd48e8100da3"
 dependencies = [
  "bstr 1.0.1",
  "doc-comment",
@@ -57,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "assert_fs"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429b32ede0cb31afd9f6cb1e8f06f1e32a4c75ed9290f9f4d3cda0c5981e061"
+checksum = "d94b2a3f3786ff2996a98afbd6b4e5b7e890d685ccf67577f508ee2342c71cc9"
 dependencies = [
  "doc-comment",
  "globwalk",
@@ -1312,9 +1312,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "predicates"
-version = "2.1.3"
+version = "2.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6bd09a7f7e68f3f0bf710fb7ab9c4615a488b58b5f653382a687701e458c92"
+checksum = "f54fc5dc63ed3bbf19494623db4f3af16842c0d975818e469022d09e53f0aa05"
 dependencies = [
  "difflib",
  "itertools",
@@ -1842,8 +1842,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-auth"
-version = "0.2.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=27a24b8#27a24b81c411eb5dfea32f14809d0def6d9adeb1"
+version = "0.3.0"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=501379d#501379da86286918f4953fe7323038ea5d264ada"
 dependencies = [
  "soroban-sdk",
 ]
@@ -1870,7 +1870,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.6",
- "soroban-env-host 0.0.9 (git+https://github.com/stellar/rs-soroban-env?rev=eda2ab7)",
+ "soroban-env-host 0.0.10 (git+https://github.com/stellar/rs-soroban-env?rev=c148051)",
  "soroban-sdk",
  "soroban-spec",
  "soroban-token-spec",
@@ -1884,12 +1884,12 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=eda2ab7#eda2ab70fbc2a9f78a12f54a211e308d1b6ac1b7"
+version = "0.0.10"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=c148051#c14805161b54ba272108ba0503057683f2a688a2"
 dependencies = [
  "crate-git-revision 0.0.3",
  "serde",
- "soroban-env-macros 0.0.9 (git+https://github.com/stellar/rs-soroban-env?rev=eda2ab7)",
+ "soroban-env-macros 0.0.10 (git+https://github.com/stellar/rs-soroban-env?rev=c148051)",
  "soroban-wasmi",
  "static_assertions",
  "stellar-xdr",
@@ -1897,11 +1897,12 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=eda2ab70#eda2ab70fbc2a9f78a12f54a211e308d1b6ac1b7"
+version = "0.0.10"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=c1480516#c14805161b54ba272108ba0503057683f2a688a2"
 dependencies = [
  "crate-git-revision 0.0.3",
- "soroban-env-macros 0.0.9 (git+https://github.com/stellar/rs-soroban-env?rev=eda2ab70)",
+ "serde",
+ "soroban-env-macros 0.0.10 (git+https://github.com/stellar/rs-soroban-env?rev=c1480516)",
  "soroban-wasmi",
  "static_assertions",
  "stellar-xdr",
@@ -1909,17 +1910,17 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=eda2ab70#eda2ab70fbc2a9f78a12f54a211e308d1b6ac1b7"
+version = "0.0.10"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=c1480516#c14805161b54ba272108ba0503057683f2a688a2"
 dependencies = [
- "soroban-env-common 0.0.9 (git+https://github.com/stellar/rs-soroban-env?rev=eda2ab70)",
+ "soroban-env-common 0.0.10 (git+https://github.com/stellar/rs-soroban-env?rev=c1480516)",
  "static_assertions",
 ]
 
 [[package]]
 name = "soroban-env-host"
-version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=eda2ab7#eda2ab70fbc2a9f78a12f54a211e308d1b6ac1b7"
+version = "0.0.10"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=c148051#c14805161b54ba272108ba0503057683f2a688a2"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -1932,8 +1933,8 @@ dependencies = [
  "num-integer",
  "num-traits",
  "sha2 0.10.6",
- "soroban-env-common 0.0.9 (git+https://github.com/stellar/rs-soroban-env?rev=eda2ab7)",
- "soroban-native-sdk-macros 0.0.9 (git+https://github.com/stellar/rs-soroban-env?rev=eda2ab7)",
+ "soroban-env-common 0.0.10 (git+https://github.com/stellar/rs-soroban-env?rev=c148051)",
+ "soroban-native-sdk-macros 0.0.10 (git+https://github.com/stellar/rs-soroban-env?rev=c148051)",
  "soroban-wasmi",
  "static_assertions",
  "tinyvec",
@@ -1941,8 +1942,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=eda2ab70#eda2ab70fbc2a9f78a12f54a211e308d1b6ac1b7"
+version = "0.0.10"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=c1480516#c14805161b54ba272108ba0503057683f2a688a2"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -1955,8 +1956,8 @@ dependencies = [
  "num-integer",
  "num-traits",
  "sha2 0.10.6",
- "soroban-env-common 0.0.9 (git+https://github.com/stellar/rs-soroban-env?rev=eda2ab70)",
- "soroban-native-sdk-macros 0.0.9 (git+https://github.com/stellar/rs-soroban-env?rev=eda2ab70)",
+ "soroban-env-common 0.0.10 (git+https://github.com/stellar/rs-soroban-env?rev=c1480516)",
+ "soroban-native-sdk-macros 0.0.10 (git+https://github.com/stellar/rs-soroban-env?rev=c1480516)",
  "soroban-wasmi",
  "static_assertions",
  "tinyvec",
@@ -1964,8 +1965,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=eda2ab7#eda2ab70fbc2a9f78a12f54a211e308d1b6ac1b7"
+version = "0.0.10"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=c148051#c14805161b54ba272108ba0503057683f2a688a2"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1976,8 +1977,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=eda2ab70#eda2ab70fbc2a9f78a12f54a211e308d1b6ac1b7"
+version = "0.0.10"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=c1480516#c14805161b54ba272108ba0503057683f2a688a2"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1987,9 +1988,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "soroban-ledger-snapshot"
+version = "0.3.0"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=501379d#501379da86286918f4953fe7323038ea5d264ada"
+dependencies = [
+ "serde",
+ "serde_json",
+ "soroban-env-host 0.0.10 (git+https://github.com/stellar/rs-soroban-env?rev=c1480516)",
+]
+
+[[package]]
 name = "soroban-native-sdk-macros"
-version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=eda2ab7#eda2ab70fbc2a9f78a12f54a211e308d1b6ac1b7"
+version = "0.0.10"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=c148051#c14805161b54ba272108ba0503057683f2a688a2"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1999,8 +2010,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-native-sdk-macros"
-version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=eda2ab70#eda2ab70fbc2a9f78a12f54a211e308d1b6ac1b7"
+version = "0.0.10"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=c1480516#c14805161b54ba272108ba0503057683f2a688a2"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -2010,29 +2021,30 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "0.2.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=27a24b8#27a24b81c411eb5dfea32f14809d0def6d9adeb1"
+version = "0.3.0"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=501379d#501379da86286918f4953fe7323038ea5d264ada"
 dependencies = [
  "bytes-lit",
  "ed25519-dalek",
  "rand 0.8.5",
  "soroban-env-guest",
- "soroban-env-host 0.0.9 (git+https://github.com/stellar/rs-soroban-env?rev=eda2ab70)",
+ "soroban-env-host 0.0.10 (git+https://github.com/stellar/rs-soroban-env?rev=c1480516)",
+ "soroban-ledger-snapshot",
  "soroban-sdk-macros",
  "stellar-strkey 0.0.6 (git+https://github.com/stellar/rs-stellar-strkey?rev=5e582a8b)",
 ]
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "0.2.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=27a24b8#27a24b81c411eb5dfea32f14809d0def6d9adeb1"
+version = "0.3.0"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=501379d#501379da86286918f4953fe7323038ea5d264ada"
 dependencies = [
  "darling",
  "itertools",
  "proc-macro2",
  "quote",
  "sha2 0.10.6",
- "soroban-env-common 0.0.9 (git+https://github.com/stellar/rs-soroban-env?rev=eda2ab70)",
+ "soroban-env-common 0.0.10 (git+https://github.com/stellar/rs-soroban-env?rev=c1480516)",
  "soroban-spec",
  "stellar-xdr",
  "syn",
@@ -2040,8 +2052,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "0.2.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=27a24b8#27a24b81c411eb5dfea32f14809d0def6d9adeb1"
+version = "0.3.0"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=501379d#501379da86286918f4953fe7323038ea5d264ada"
 dependencies = [
  "base64",
  "darling",
@@ -2061,8 +2073,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-token-spec"
-version = "0.2.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=27a24b8#27a24b81c411eb5dfea32f14809d0def6d9adeb1"
+version = "0.3.0"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=501379d#501379da86286918f4953fe7323038ea5d264ada"
 dependencies = [
  "soroban-auth",
  "soroban-sdk",
@@ -2089,7 +2101,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.6",
- "soroban-env-host 0.0.9 (git+https://github.com/stellar/rs-soroban-env?rev=eda2ab7)",
+ "soroban-env-host 0.0.10 (git+https://github.com/stellar/rs-soroban-env?rev=c148051)",
  "soroban-spec",
  "soroban-token-spec",
  "stellar-strkey 0.0.6 (git+https://github.com/stellar/rs-stellar-strkey?rev=5e582a8)",
@@ -2160,8 +2172,8 @@ dependencies = [
 
 [[package]]
 name = "stellar-xdr"
-version = "0.0.7"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=2775f4b6#2775f4b6f6ce2c9fcc22af42b0709d1047fabf8f"
+version = "0.0.9"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=1309e3de#1309e3de46fcb01743f818831de3a9ac4a5b1ab6"
 dependencies = [
  "base64",
  "crate-git-revision 0.0.3",
@@ -2203,9 +2215,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.104"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae548ec36cf198c0ef7710d3c230987c2d6d7bd98ad6edc0274462724c585ce"
+checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2949,9 +2961,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
+checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2083,7 +2083,6 @@ dependencies = [
  "hex",
  "jsonrpsee-core",
  "jsonrpsee-http-client",
- "num-bigint",
  "rand 0.8.5",
  "regex",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
@@ -43,11 +43,11 @@ checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.4"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ae1ddd39efd67689deb1979d80bad3bf7f2b09c6e6117c8d1f2443b5e2f83e"
+checksum = "ba45b8163c49ab5f972e59a8a5a03b6d2972619d486e19ec9fe744f7c2753d3c"
 dependencies = [
- "bstr",
+ "bstr 1.0.1",
  "doc-comment",
  "predicates",
  "predicates-core",
@@ -57,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "assert_fs"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf09bb72e00da477c2596865e8873227e2196d263cca35414048875dbbeea1be"
+checksum = "1429b32ede0cb31afd9f6cb1e8f06f1e32a4c75ed9290f9f4d3cda0c5981e061"
 dependencies = [
  "doc-comment",
  "globwalk",
@@ -71,9 +71,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.57"
+version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
+checksum = "31e6e93155431f3931513b243d371981bb2770112b370c82745a1d19d2f99364"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -120,9 +120,9 @@ checksum = "23ce669cd6c8588f79e15cf450314f9638f967fc5770ff1c7c1deb0925ea7cfa"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "beef"
@@ -179,6 +179,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fca0852af221f458706eb0725c03e4ed6c46af9ac98e6a689d5e634215d594dd"
+dependencies = [
+ "memchr",
+ "once_cell",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "buf_redux"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,9 +202,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.11.0"
+version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
 name = "byteorder"
@@ -202,9 +214,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "bytes-lit"
@@ -220,9 +232,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
 dependencies = [
  "jobserver",
 ]
@@ -235,9 +247,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
  "num-integer",
@@ -248,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.22"
+version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
  "bitflags",
@@ -341,10 +353,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.8.12"
+name = "crate-git-revision"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
+checksum = "78cea8a8c6f40508aa6292231db40fe5b4968f6959fefcad608e528b50657564"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if",
 ]
@@ -365,7 +388,7 @@ version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
 dependencies = [
- "bstr",
+ "bstr 0.2.17",
  "csv-core",
  "itoa 0.4.8",
  "ryu",
@@ -396,9 +419,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.79"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f83d0ebf42c6eafb8d7c52f7e5f2d3003b89c7aa4fd2b79229209459a849af8"
+checksum = "d4a41a86530d0fe7f5d9ea779916b7cadd2d4f9add748b99c2c029cbbdfaf453"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -408,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.79"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d050484b55975889284352b0ffc2ecbda25c0c55978017c132b29ba0818a86"
+checksum = "06416d667ff3e3ad2df1cd8cd8afae5da26cf9cec4d0825040f88b5ca659a2f0"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -423,15 +446,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.79"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d2199b00553eda8012dfec8d3b1c75fce747cf27c169a270b3b99e3448ab78"
+checksum = "820a9a2af1669deeef27cb271f476ffd196a2c4b6731336011e0ba63e2c7cf71"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.79"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb67a6de1f602736dd7eaead0080cf3435df806c61b24b13328db128c58868f"
+checksum = "a08a6e2fcc370a089ad3b4aaf54db3b1b4cee38ddabce5896b33eb693275f470"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -440,9 +463,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
+checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -450,9 +473,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
+checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
 dependencies = [
  "fnv",
  "ident_case",
@@ -464,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
+checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
 dependencies = [
  "darling_core",
  "quote",
@@ -490,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.3",
  "crypto-common",
@@ -571,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
+checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -581,27 +604,27 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
+checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
+checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
 
 [[package]]
 name = "futures-task"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
+checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
 
 [[package]]
 name = "futures-util"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
+checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -634,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
@@ -656,7 +679,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a1e17342619edbc21a964c2afbeb6c820c6a2560032872f397bb97ea127bd0a"
 dependencies = [
  "aho-corasick",
- "bstr",
+ "bstr 0.2.17",
  "fnv",
  "log",
  "regex",
@@ -675,9 +698,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
+checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
 dependencies = [
  "bytes",
  "fnv",
@@ -755,7 +778,7 @@ checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.3",
+ "itoa 1.0.4",
 ]
 
 [[package]]
@@ -783,9 +806,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.20"
+version = "0.14.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -796,7 +819,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.3",
+ "itoa 1.0.4",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -807,9 +830,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
+checksum = "59df7c4e19c950e6e0e868dcc0a300b09a9b88e9ec55bd879ca819087a77355d"
 dependencies = [
  "http",
  "hyper",
@@ -823,9 +846,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.51"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a6ef98976b22b3b7f2f3a806f858cb862044cfa66805aa3ad84cb3d3b785ed"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -895,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -936,9 +959,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "jobserver"
@@ -1019,15 +1042,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.133"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "libm"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "292a948cd991e376cf75541fe5b97a1081d713c618b4f1b9500f8844e49eb565"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "link-cplusplus"
@@ -1096,14 +1119,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1179,20 +1202,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
  "hermit-abi",
- "libc",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
  "libc",
 ]
 
@@ -1207,9 +1221,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "opaque-debug"
@@ -1225,9 +1239,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.3.0"
+version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "parking_lot"
@@ -1241,15 +1255,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1292,15 +1306,15 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "predicates"
-version = "2.1.1"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
+checksum = "ed6bd09a7f7e68f3f0bf710fb7ab9c4615a488b58b5f653382a687701e458c92"
 dependencies = [
  "difflib",
  "itertools",
@@ -1309,15 +1323,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da1c2388b1513e1b605fcec39a95e0a9e8ef088f71443ef37099fa9ae6673fcb"
+checksum = "72f883590242d3c6fc5bf50299011695fa6590c2c70eac95ee1bdb9a733ad1a2"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d86de6de25020a36c6d3643a86d9a6a9f552107c0559c60ea03551b5e16c032"
+checksum = "54ff541861505aabf6ea722d2131ee980b8276e10a1297b94e896dd8b621850d"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -1325,9 +1339,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.1.19"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a49e86d2c26a24059894a3afa13fd17d063419b05dfb83f06d9c3566060c3f5a"
+checksum = "c142c0e46b57171fe0c528bee8c5b7569e80f0c17e377cd0e30ea57dbc11bb51"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -1359,9 +1373,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
@@ -1440,7 +1454,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.7",
+ "getrandom 0.2.8",
 ]
 
 [[package]]
@@ -1472,9 +1486,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1489,9 +1503,9 @@ checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.27"
+version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "remove_dir_all"
@@ -1531,9 +1545,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustls"
-version = "0.20.6"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033"
+checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
 dependencies = [
  "log",
  "ring",
@@ -1605,14 +1619,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
 dependencies = [
  "lazy_static",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
 name = "scoped-tls"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -1661,18 +1675,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.145"
+version = "1.0.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+checksum = "e53f64bb4ba0191d6d0676e1b141ca55047d83b74f5607e6d8eb88126c52c2dc"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.145"
+version = "1.0.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+checksum = "a55492425aa53521babf6137309e7d34c20bbfbbfcfe2c7f3a047fd1f6b92c0c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1681,11 +1695,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.85"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
 dependencies = [
- "itoa 1.0.3",
+ "itoa 1.0.4",
  "ryu",
  "serde",
 ]
@@ -1697,16 +1711,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.3",
+ "itoa 1.0.4",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_with"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f2d60d049ea019a84dcd6687b0d1e0030fe663ae105039bdf967ed5e6a9a7"
+checksum = "25bf4a5a814902cd1014dbccfa4d4560fb8432c779471e96e035602519f82eef"
 dependencies = [
  "base64",
  "chrono",
@@ -1720,9 +1734,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ccadfacf6cf10faad22bbadf55986bdd0856edfb5d9210aa1dcf1f516e84e93"
+checksum = "e3452b4c0f6c1e357f73fdb87cd1efabaa12acf328c7a528e252893baeb3f4aa"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1732,13 +1746,13 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.5",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -1749,7 +1763,7 @@ checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.5",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -1773,7 +1787,7 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.5",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -1787,9 +1801,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.3"
+version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb766570a2825fa972bceff0d195727876a9cdf2460ab2e52d455dc2de47fd9"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
 name = "sized-chunks"
@@ -1812,9 +1826,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "socket2"
@@ -1829,7 +1843,7 @@ dependencies = [
 [[package]]
 name = "soroban-auth"
 version = "0.2.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=63bef69c#63bef69c72f897b1d28beeaf6923afb5293f26f1"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=27a24b8#27a24b81c411eb5dfea32f14809d0def6d9adeb1"
 dependencies = [
  "soroban-sdk",
 ]
@@ -1843,7 +1857,7 @@ dependencies = [
  "base64",
  "clap",
  "clap_complete",
- "crate-git-revision",
+ "crate-git-revision 0.0.2",
  "csv",
  "ed25519-dalek",
  "hex",
@@ -1856,11 +1870,11 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.6",
- "soroban-env-host",
+ "soroban-env-host 0.0.9 (git+https://github.com/stellar/rs-soroban-env?rev=eda2ab7)",
  "soroban-sdk",
  "soroban-spec",
  "soroban-token-spec",
- "stellar-strkey 0.0.6 (git+https://github.com/stellar/rs-stellar-strkey?rev=d1b68fd1)",
+ "stellar-strkey 0.0.6 (git+https://github.com/stellar/rs-stellar-strkey?rev=5e582a8)",
  "thiserror",
  "tokio",
  "warp",
@@ -1871,9 +1885,23 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=99de1bf0#99de1bf0d2026d1fdb2854a13c195c5902f088a4"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=eda2ab7#eda2ab70fbc2a9f78a12f54a211e308d1b6ac1b7"
 dependencies = [
- "soroban-env-macros",
+ "crate-git-revision 0.0.3",
+ "serde",
+ "soroban-env-macros 0.0.9 (git+https://github.com/stellar/rs-soroban-env?rev=eda2ab7)",
+ "soroban-wasmi",
+ "static_assertions",
+ "stellar-xdr",
+]
+
+[[package]]
+name = "soroban-env-common"
+version = "0.0.9"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=eda2ab70#eda2ab70fbc2a9f78a12f54a211e308d1b6ac1b7"
+dependencies = [
+ "crate-git-revision 0.0.3",
+ "soroban-env-macros 0.0.9 (git+https://github.com/stellar/rs-soroban-env?rev=eda2ab70)",
  "soroban-wasmi",
  "static_assertions",
  "stellar-xdr",
@@ -1882,30 +1910,53 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=99de1bf0#99de1bf0d2026d1fdb2854a13c195c5902f088a4"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=eda2ab70#eda2ab70fbc2a9f78a12f54a211e308d1b6ac1b7"
 dependencies = [
- "soroban-env-common",
+ "soroban-env-common 0.0.9 (git+https://github.com/stellar/rs-soroban-env?rev=eda2ab70)",
  "static_assertions",
 ]
 
 [[package]]
 name = "soroban-env-host"
 version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=99de1bf0#99de1bf0d2026d1fdb2854a13c195c5902f088a4"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=eda2ab7#eda2ab70fbc2a9f78a12f54a211e308d1b6ac1b7"
 dependencies = [
  "backtrace",
+ "curve25519-dalek",
  "dyn-fmt",
  "ed25519-dalek",
  "hex",
  "im-rc",
  "log",
- "num-bigint",
  "num-derive",
  "num-integer",
  "num-traits",
  "sha2 0.10.6",
- "soroban-env-common",
- "soroban-native-sdk-macros",
+ "soroban-env-common 0.0.9 (git+https://github.com/stellar/rs-soroban-env?rev=eda2ab7)",
+ "soroban-native-sdk-macros 0.0.9 (git+https://github.com/stellar/rs-soroban-env?rev=eda2ab7)",
+ "soroban-wasmi",
+ "static_assertions",
+ "tinyvec",
+]
+
+[[package]]
+name = "soroban-env-host"
+version = "0.0.9"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=eda2ab70#eda2ab70fbc2a9f78a12f54a211e308d1b6ac1b7"
+dependencies = [
+ "backtrace",
+ "curve25519-dalek",
+ "dyn-fmt",
+ "ed25519-dalek",
+ "hex",
+ "im-rc",
+ "log",
+ "num-derive",
+ "num-integer",
+ "num-traits",
+ "sha2 0.10.6",
+ "soroban-env-common 0.0.9 (git+https://github.com/stellar/rs-soroban-env?rev=eda2ab70)",
+ "soroban-native-sdk-macros 0.0.9 (git+https://github.com/stellar/rs-soroban-env?rev=eda2ab70)",
  "soroban-wasmi",
  "static_assertions",
  "tinyvec",
@@ -1914,7 +1965,19 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=99de1bf0#99de1bf0d2026d1fdb2854a13c195c5902f088a4"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=eda2ab7#eda2ab70fbc2a9f78a12f54a211e308d1b6ac1b7"
+dependencies = [
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "stellar-xdr",
+ "syn",
+]
+
+[[package]]
+name = "soroban-env-macros"
+version = "0.0.9"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=eda2ab70#eda2ab70fbc2a9f78a12f54a211e308d1b6ac1b7"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1926,7 +1989,18 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=99de1bf0#99de1bf0d2026d1fdb2854a13c195c5902f088a4"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=eda2ab7#eda2ab70fbc2a9f78a12f54a211e308d1b6ac1b7"
+dependencies = [
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "soroban-native-sdk-macros"
+version = "0.0.9"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=eda2ab70#eda2ab70fbc2a9f78a12f54a211e308d1b6ac1b7"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1937,13 +2011,13 @@ dependencies = [
 [[package]]
 name = "soroban-sdk"
 version = "0.2.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=63bef69c#63bef69c72f897b1d28beeaf6923afb5293f26f1"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=27a24b8#27a24b81c411eb5dfea32f14809d0def6d9adeb1"
 dependencies = [
  "bytes-lit",
  "ed25519-dalek",
  "rand 0.8.5",
  "soroban-env-guest",
- "soroban-env-host",
+ "soroban-env-host 0.0.9 (git+https://github.com/stellar/rs-soroban-env?rev=eda2ab70)",
  "soroban-sdk-macros",
  "stellar-strkey 0.0.6 (git+https://github.com/stellar/rs-stellar-strkey?rev=5e582a8b)",
 ]
@@ -1951,14 +2025,14 @@ dependencies = [
 [[package]]
 name = "soroban-sdk-macros"
 version = "0.2.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=63bef69c#63bef69c72f897b1d28beeaf6923afb5293f26f1"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=27a24b8#27a24b81c411eb5dfea32f14809d0def6d9adeb1"
 dependencies = [
  "darling",
  "itertools",
  "proc-macro2",
  "quote",
  "sha2 0.10.6",
- "soroban-env-common",
+ "soroban-env-common 0.0.9 (git+https://github.com/stellar/rs-soroban-env?rev=eda2ab70)",
  "soroban-spec",
  "stellar-xdr",
  "syn",
@@ -1967,7 +2041,7 @@ dependencies = [
 [[package]]
 name = "soroban-spec"
 version = "0.2.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=63bef69c#63bef69c72f897b1d28beeaf6923afb5293f26f1"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=27a24b8#27a24b81c411eb5dfea32f14809d0def6d9adeb1"
 dependencies = [
  "base64",
  "darling",
@@ -1979,7 +2053,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.6",
- "soroban-env-host",
  "stellar-xdr",
  "syn",
  "thiserror",
@@ -1989,7 +2062,7 @@ dependencies = [
 [[package]]
 name = "soroban-token-spec"
 version = "0.2.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=63bef69c#63bef69c72f897b1d28beeaf6923afb5293f26f1"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=27a24b8#27a24b81c411eb5dfea32f14809d0def6d9adeb1"
 dependencies = [
  "soroban-auth",
  "soroban-sdk",
@@ -2004,7 +2077,7 @@ dependencies = [
  "base64",
  "clap",
  "clap_complete",
- "crate-git-revision",
+ "crate-git-revision 0.0.2",
  "csv",
  "ed25519-dalek",
  "hex",
@@ -2017,10 +2090,10 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.6",
- "soroban-env-host",
+ "soroban-env-host 0.0.9 (git+https://github.com/stellar/rs-soroban-env?rev=eda2ab7)",
  "soroban-spec",
  "soroban-token-spec",
- "stellar-strkey 0.0.6 (git+https://github.com/stellar/rs-stellar-strkey?rev=d1b68fd1)",
+ "stellar-strkey 0.0.6 (git+https://github.com/stellar/rs-stellar-strkey?rev=5e582a8)",
  "thiserror",
  "tokio",
  "warp",
@@ -2030,8 +2103,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-wasmi"
-version = "0.16.0-soroban1"
-source = "git+https://github.com/stellar/wasmi?rev=d1ec0036#d1ec0036a002a14227b0b09117f0dc6182ae19e4"
+version = "0.16.0-soroban2"
+source = "git+https://github.com/stellar/wasmi?rev=862b32f5#862b32f53f9c6223911e79e0b0fc8592fb3bb04c"
 dependencies = [
  "soroban-wasmi_core",
  "spin 0.9.4",
@@ -2040,8 +2113,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-wasmi_core"
-version = "0.16.0-soroban1"
-source = "git+https://github.com/stellar/wasmi?rev=d1ec0036#d1ec0036a002a14227b0b09117f0dc6182ae19e4"
+version = "0.16.0-soroban2"
+source = "git+https://github.com/stellar/wasmi?rev=862b32f5#862b32f53f9c6223911e79e0b0fc8592fb3bb04c"
 dependencies = [
  "downcast-rs",
  "libm",
@@ -2071,7 +2144,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stellar-strkey"
 version = "0.0.6"
-source = "git+https://github.com/stellar/rs-stellar-strkey?rev=5e582a8b#5e582a8b48f85443df60dc78e2e98959862400d6"
+source = "git+https://github.com/stellar/rs-stellar-strkey?rev=5e582a8#5e582a8b48f85443df60dc78e2e98959862400d6"
 dependencies = [
  "base32",
  "thiserror",
@@ -2080,7 +2153,7 @@ dependencies = [
 [[package]]
 name = "stellar-strkey"
 version = "0.0.6"
-source = "git+https://github.com/stellar/rs-stellar-strkey?rev=d1b68fd1#d1b68fd17cd4b04f370dcb1a1785d2eddca0a3c4"
+source = "git+https://github.com/stellar/rs-stellar-strkey?rev=5e582a8b#5e582a8b48f85443df60dc78e2e98959862400d6"
 dependencies = [
  "base32",
  "thiserror",
@@ -2089,9 +2162,10 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "0.0.7"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=e88f9fa7#e88f9fa7ab3d0f54efb5cee8499ef9080f4d41f4"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=2775f4b6#2775f4b6f6ce2c9fcc22af42b0709d1047fabf8f"
 dependencies = [
  "base64",
+ "crate-git-revision 0.0.3",
  "hex",
  "serde",
  "serde_with",
@@ -2130,9 +2204,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.101"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
+checksum = "4ae548ec36cf198c0ef7710d3c230987c2d6d7bd98ad6edc0274462724c585ce"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2176,9 +2250,9 @@ dependencies = [
 
 [[package]]
 name = "termtree"
-version = "0.2.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
+checksum = "95059e91184749cb66be6dc994f67f182b6d897cb3df74a5bf66b5e709295fd8"
 
 [[package]]
 name = "test_hello_world"
@@ -2196,9 +2270,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
@@ -2231,14 +2305,29 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d634a985c4d4238ec39cacaed2e7ae552fbd3c476b552c1deac3021b7d7eaf0c"
+checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
- "itoa 1.0.3",
- "libc",
- "num_threads",
+ "itoa 1.0.4",
  "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+dependencies = [
+ "time-core",
 ]
 
 [[package]]
@@ -2258,9 +2347,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.2"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
+checksum = "d76ce4a75fb488c605c54bf610f221cea8b0dafb53333c1a67e8ee199dcd2ae3"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2278,9 +2367,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2300,9 +2389,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6edf2d6bc038a43d31353570e27270603f4648d18f5ed10c0e179abe43255af"
+checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2343,9 +2432,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "log",
@@ -2356,9 +2445,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2367,9 +2456,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
 ]
@@ -2441,9 +2530,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "unicode-normalization"
@@ -2756,12 +2845,33 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.0",
+ "windows_i686_gnu 0.42.0",
+ "windows_i686_msvc 0.42.0",
+ "windows_x86_64_gnu 0.42.0",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.0",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2770,10 +2880,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2782,16 +2904,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,24 +57,24 @@ members = [
 default-members = ["cmd/soroban-cli"]
 
 [workspace.dependencies.soroban-env-host]
-version = "0.0.9"
+version = "0.0.10"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "eda2ab7"
+rev = "c148051"
 
 [workspace.dependencies.soroban-spec]
-version = "0.2.1"
+version = "0.3.0"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "27a24b8"
+rev = "501379d"
 
 [workspace.dependencies.soroban-token-spec]
-version = "0.2.1"
+version = "0.3.0"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "27a24b8"
+rev = "501379d"
 
 [workspace.dependencies.soroban-sdk]
-version = "0.2.1"
+version = "0.3.0"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "27a24b8"
+rev = "501379d"
 
 [workspace.dependencies.stellar-strkey]
 version = "0.0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,27 +60,27 @@ default-members = ["cmd/soroban-cli"]
 [workspace.dependencies.soroban-env-host]
 version = "0.0.9"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "99de1bf0"
+rev = "eda2ab7"
 
 [workspace.dependencies.soroban-spec]
 version = "0.2.1"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "63bef69c"
+rev = "27a24b8"
 
 [workspace.dependencies.soroban-token-spec]
 version = "0.2.1"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "63bef69c"
+rev = "27a24b8"
 
 [workspace.dependencies.soroban-sdk]
 version = "0.2.1"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "63bef69c"
+rev = "27a24b8"
 
 [workspace.dependencies.stellar-strkey]
 version = "0.0.6"
 git = "https://github.com/stellar/rs-stellar-strkey"
-rev = "d1b68fd1"
+rev = "5e582a8"
 
 # [patch."https://github.com/stellar/rs-soroban-env"]
 # soroban-env-host = { path = "../rs-soroban-env/soroban-env-host/" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ serde = "1.0.82"
 serde_derive = "1.0.82"
 serde_json = "1.0.82"
 hex = "0.4.3"
-num-bigint = "0.4"
 tokio = { version = "1", features = ["full"] }
 warp = "0.3"
 clap_complete = "3.2.3"

--- a/cmd/soroban-cli/src/deploy.rs
+++ b/cmd/soroban-cli/src/deploy.rs
@@ -213,7 +213,7 @@ fn build_install_contract_code_tx(
     salt: [u8; 32],
     key: &ed25519_dalek::Keypair,
 ) -> Result<(TransactionEnvelope, Hash), Error> {
-    let hash = contract_hash(&contract)?;
+    let hash = utils::contract_hash(&contract)?;
 
     let op = Operation {
         source_account: None,
@@ -293,15 +293,6 @@ fn build_create_contract_tx(
     let envelope = utils::sign_transaction(key, &tx, network_passphrase)?;
 
     Ok((envelope, Hash(contract_id.into())))
-}
-
-fn contract_hash(contract: &[u8]) -> Result<Hash, Error> {
-    let install_contract_code_args = InstallContractCodeArgs {
-        code: contract.try_into()?,
-    };
-    let mut buf: Vec<u8> = vec![];
-    install_contract_code_args.write_xdr(&mut buf)?;
-    Ok(Hash(Sha256::digest(buf.try_into()?).try_into()?))
 }
 
 #[cfg(test)]

--- a/cmd/soroban-cli/src/deploy.rs
+++ b/cmd/soroban-cli/src/deploy.rs
@@ -8,10 +8,12 @@ use rand::Rng;
 use sha2::{Digest, Sha256};
 use soroban_env_host::xdr::HashIdPreimageSourceAccountContractId;
 use soroban_env_host::xdr::{
-    AccountId, Error as XdrError, Hash, HashIdPreimage, HostFunction, InvokeHostFunctionOp,
-    LedgerFootprint, LedgerKey::ContractData, LedgerKeyContractData, Memo, MuxedAccount, Operation,
-    OperationBody, Preconditions, PublicKey, ScObject, ScStatic::LedgerKeyContractCode, ScVal,
-    SequenceNumber, Transaction, TransactionEnvelope, TransactionExt, Uint256, VecM, WriteXdr,
+    AccountId, ContractId, CreateContractArgs, Error as XdrError, Hash, HashIdPreimage,
+    HostFunction, InstallContractCodeArgs, InvokeHostFunctionOp, LedgerFootprint,
+    LedgerKey::ContractCode, LedgerKey::ContractData, LedgerKeyContractCode, LedgerKeyContractData,
+    Memo, MuxedAccount, Operation, OperationBody, Preconditions, PublicKey, ScContractCode,
+    ScStatic, ScVal, SequenceNumber, Transaction, TransactionEnvelope, TransactionExt, Uint256,
+    VecM, WriteXdr,
 };
 use soroban_env_host::HostError;
 
@@ -178,7 +180,8 @@ impl Cmd {
         // TODO: create a cmdline parameter for the fee instead of simply using the minimum fee
         let fee: u32 = 100;
         let sequence = account_details.sequence.parse::<i64>()?;
-        let (tx, contract_id) = build_create_contract_tx(
+
+        let (tx, hash) = build_install_contract_code_tx(
             contract,
             sequence + 1,
             fee,
@@ -186,14 +189,23 @@ impl Cmd {
             salt,
             &key,
         )?;
+        client.send_transaction(&tx).await?;
 
+        let (tx, contract_id) = build_create_contract_tx(
+            hash,
+            sequence + 2,
+            fee,
+            self.network_passphrase.as_ref().unwrap(),
+            salt,
+            &key,
+        )?;
         client.send_transaction(&tx).await?;
 
         Ok(hex::encode(contract_id.0))
     }
 }
 
-fn build_create_contract_tx(
+fn build_install_contract_code_tx(
     contract: Vec<u8>,
     sequence: i64,
     fee: u32,
@@ -201,8 +213,48 @@ fn build_create_contract_tx(
     salt: [u8; 32],
     key: &ed25519_dalek::Keypair,
 ) -> Result<(TransactionEnvelope, Hash), Error> {
+    let hash = contract_hash(&contract)?;
+
+    let op = Operation {
+        source_account: None,
+        body: OperationBody::InvokeHostFunction(InvokeHostFunctionOp {
+            function: HostFunction::InstallContractCode(InstallContractCodeArgs {
+                code: contract.try_into()?,
+            }),
+            footprint: LedgerFootprint {
+                read_only: VecM::default(),
+                read_write: vec![ContractCode(LedgerKeyContractCode { hash })].try_into()?,
+            },
+        }),
+    };
+
+    let tx = Transaction {
+        source_account: MuxedAccount::Ed25519(Uint256(key.public.to_bytes())),
+        fee,
+        seq_num: SequenceNumber(sequence),
+        cond: Preconditions::None,
+        memo: Memo::None,
+        operations: vec![op].try_into()?,
+        ext: TransactionExt::V0,
+    };
+
+    let envelope = utils::sign_transaction(key, &tx, network_passphrase)?;
+
+    Ok((envelope, hash))
+}
+
+fn build_create_contract_tx(
+    hash: Hash,
+    sequence: i64,
+    fee: u32,
+    network_passphrase: &str,
+    salt: [u8; 32],
+    key: &ed25519_dalek::Keypair,
+) -> Result<(TransactionEnvelope, Hash), Error> {
+    let network_id = Hash(Sha256::digest(network_passphrase.as_bytes()).into());
     let preimage =
         HashIdPreimage::ContractIdFromSourceAccount(HashIdPreimageSourceAccountContractId {
+            network_id,
             source_account: AccountId(PublicKey::PublicKeyTypeEd25519(
                 key.public.to_bytes().into(),
             )),
@@ -211,24 +263,20 @@ fn build_create_contract_tx(
     let preimage_xdr = preimage.to_xdr()?;
     let contract_id = Sha256::digest(preimage_xdr);
 
-    let contract_parameter = ScVal::Object(Some(ScObject::Bytes(contract.try_into()?)));
-    let salt_parameter = ScVal::Object(Some(ScObject::Bytes(salt.try_into()?)));
-
-    let lk = ContractData(LedgerKeyContractData {
-        contract_id: Hash(contract_id.into()),
-        key: ScVal::Static(LedgerKeyContractCode),
-    });
-
-    let parameters: VecM<ScVal, 256_000> = vec![contract_parameter, salt_parameter].try_into()?;
-
     let op = Operation {
         source_account: None,
         body: OperationBody::InvokeHostFunction(InvokeHostFunctionOp {
-            function: HostFunction::CreateContractWithSourceAccount,
-            parameters: parameters.into(),
+            function: HostFunction::CreateContract(CreateContractArgs {
+                contract_id: ContractId::SourceAccount(Uint256(salt)),
+                source: ScContractCode::WasmRef(hash),
+            }),
             footprint: LedgerFootprint {
-                read_only: VecM::default(),
-                read_write: vec![lk].try_into()?,
+                read_only: vec![ContractCode(LedgerKeyContractCode { hash })].try_into()?,
+                read_write: vec![ContractData(LedgerKeyContractData {
+                    contract_id: Hash(contract_id.into()),
+                    key: ScVal::Static(ScStatic::LedgerKeyContractCode),
+                })]
+                .try_into()?,
             },
         }),
     };
@@ -247,14 +295,42 @@ fn build_create_contract_tx(
     Ok((envelope, Hash(contract_id.into())))
 }
 
+fn contract_hash(contract: &[u8]) -> Result<Hash, Error> {
+    let install_contract_code_args = InstallContractCodeArgs {
+        code: contract.try_into()?,
+    };
+    let mut buf: Vec<u8> = vec![];
+    install_contract_code_args.write_xdr(&mut buf)?;
+    Ok(Hash(Sha256::digest(buf.try_into()?).try_into()?))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn test_build_create_contract() {
-        let result = build_create_contract_tx(
+    fn test_build_install_contract_code() {
+        let result = build_install_contract_code_tx(
             b"foo".to_vec(),
+            300,
+            1,
+            "Public Global Stellar Network ; September 2015",
+            [0u8; 32],
+            &utils::parse_secret_key("SBFGFF27Y64ZUGFAIG5AMJGQODZZKV2YQKAVUUN4HNE24XZXD2OEUVUP")
+                .unwrap(),
+        );
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_build_create_contract() {
+        let hash = hex::decode("0000000000000000000000000000000000000000000000000000000000000000")
+            .unwrap()
+            .try_into()
+            .unwrap();
+        let result = build_create_contract_tx(
+            Hash(hash),
             300,
             1,
             "Public Global Stellar Network ; September 2015",

--- a/cmd/soroban-cli/src/deploy.rs
+++ b/cmd/soroban-cli/src/deploy.rs
@@ -186,7 +186,6 @@ impl Cmd {
             sequence + 1,
             fee,
             self.network_passphrase.as_ref().unwrap(),
-            salt,
             &key,
         )?;
         client.send_transaction(&tx).await?;
@@ -210,7 +209,6 @@ fn build_install_contract_code_tx(
     sequence: i64,
     fee: u32,
     network_passphrase: &str,
-    salt: [u8; 32],
     key: &ed25519_dalek::Keypair,
 ) -> Result<(TransactionEnvelope, Hash), Error> {
     let hash = utils::contract_hash(&contract)?;
@@ -223,7 +221,8 @@ fn build_install_contract_code_tx(
             }),
             footprint: LedgerFootprint {
                 read_only: VecM::default(),
-                read_write: vec![ContractCode(LedgerKeyContractCode { hash })].try_into()?,
+                read_write: vec![ContractCode(LedgerKeyContractCode { hash: hash.clone() })]
+                    .try_into()?,
             },
         }),
     };
@@ -268,7 +267,7 @@ fn build_create_contract_tx(
         body: OperationBody::InvokeHostFunction(InvokeHostFunctionOp {
             function: HostFunction::CreateContract(CreateContractArgs {
                 contract_id: ContractId::SourceAccount(Uint256(salt)),
-                source: ScContractCode::WasmRef(hash),
+                source: ScContractCode::WasmRef(hash.clone()),
             }),
             footprint: LedgerFootprint {
                 read_only: vec![ContractCode(LedgerKeyContractCode { hash })].try_into()?,
@@ -306,7 +305,6 @@ mod tests {
             300,
             1,
             "Public Global Stellar Network ; September 2015",
-            [0u8; 32],
             &utils::parse_secret_key("SBFGFF27Y64ZUGFAIG5AMJGQODZZKV2YQKAVUUN4HNE24XZXD2OEUVUP")
                 .unwrap(),
         );

--- a/cmd/soroban-cli/src/invoke.rs
+++ b/cmd/soroban-cli/src/invoke.rs
@@ -23,9 +23,7 @@ use soroban_spec::read::FromWasmError;
 use stellar_strkey::StrkeyPublicKeyEd25519;
 
 use crate::rpc::Client;
-use crate::utils::{
-    contract_code_to_spec_entries, create_ledger_footprint, default_account_ledger_entry,
-};
+use crate::utils::{create_ledger_footprint, default_account_ledger_entry};
 use crate::{
     rpc, snapshot,
     strval::{self, StrValError},

--- a/cmd/soroban-cli/src/invoke.rs
+++ b/cmd/soroban-cli/src/invoke.rs
@@ -406,7 +406,7 @@ impl Cmd {
         let host_function_params =
             self.build_host_function_parameters(contract_id, &spec_entries, matches)?;
 
-        let res = h.invoke_function(HostFunction::InvokeContract, host_function_params)?;
+        let res = h.invoke_function(HostFunction::InvokeContract(host_function_params))?;
         let res_str = strval::to_string(&res).map_err(|e| Error::CannotPrintResult {
             result: res,
             error: e,
@@ -471,8 +471,7 @@ fn build_invoke_contract_tx(
     let op = Operation {
         source_account: None,
         body: OperationBody::InvokeHostFunction(InvokeHostFunctionOp {
-            function: HostFunction::InvokeContract,
-            parameters,
+            function: HostFunction::InvokeContract(parameters),
             footprint: final_footprint,
         }),
     };

--- a/cmd/soroban-cli/src/invoke.rs
+++ b/cmd/soroban-cli/src/invoke.rs
@@ -482,7 +482,7 @@ async fn get_remote_contract_spec_entries(
     // Get the contract from the network
     let contract_ref = client
         .get_ledger_entry(LedgerKey::ContractData(LedgerKeyContractData {
-            contract_id: xdr::Hash(contract_id.clone()),
+            contract_id: xdr::Hash(*contract_id),
             key: ScVal::Static(ScStatic::LedgerKeyContractCode),
         }))
         .await?;

--- a/cmd/soroban-cli/src/rpc/mod.rs
+++ b/cmd/soroban-cli/src/rpc/mod.rs
@@ -61,6 +61,13 @@ pub struct GetContractDataResponse {
 
 // TODO: this should also be used by serve
 #[derive(serde::Deserialize, serde::Serialize, Debug)]
+pub struct GetLedgerEntryResponse {
+    pub xdr: String,
+    // TODO: add lastModifiedLedgerSeq and latestLedger
+}
+
+// TODO: this should also be used by serve
+#[derive(serde::Deserialize, serde::Serialize, Debug)]
 pub struct Cost {
     #[serde(rename = "cpuInsns")]
     pub cpu_insns: String,

--- a/cmd/soroban-cli/src/rpc/mod.rs
+++ b/cmd/soroban-cli/src/rpc/mod.rs
@@ -1,6 +1,6 @@
 use jsonrpsee_core::{client::ClientT, rpc_params};
 use jsonrpsee_http_client::{HeaderMap, HttpClient, HttpClientBuilder};
-use soroban_env_host::xdr::{Error as XdrError, LedgerKey, ScVal, TransactionEnvelope, WriteXdr};
+use soroban_env_host::xdr::{Error as XdrError, LedgerKey, TransactionEnvelope, WriteXdr};
 use std::time::{Duration, Instant};
 use tokio::time::sleep;
 
@@ -178,18 +178,6 @@ impl Client {
         Ok(self
             .client()?
             .request("getTransactionStatus", rpc_params![tx_id])
-            .await?)
-    }
-
-    pub async fn get_contract_data(
-        &self,
-        contract_id: &str,
-        key: ScVal,
-    ) -> Result<GetContractDataResponse, Error> {
-        let base64_key = key.to_xdr_base64()?;
-        Ok(self
-            .client()?
-            .request("getContractData", rpc_params![contract_id, base64_key])
             .await?)
     }
 

--- a/cmd/soroban-cli/src/rpc/mod.rs
+++ b/cmd/soroban-cli/src/rpc/mod.rs
@@ -1,6 +1,6 @@
 use jsonrpsee_core::{client::ClientT, rpc_params};
 use jsonrpsee_http_client::{HeaderMap, HttpClient, HttpClientBuilder};
-use soroban_env_host::xdr::{Error as XdrError, ScVal, TransactionEnvelope, WriteXdr};
+use soroban_env_host::xdr::{Error as XdrError, LedgerKey, ScVal, TransactionEnvelope, WriteXdr};
 use std::time::{Duration, Instant};
 use tokio::time::sleep;
 
@@ -183,6 +183,14 @@ impl Client {
         Ok(self
             .client()?
             .request("getContractData", rpc_params![contract_id, base64_key])
+            .await?)
+    }
+
+    pub async fn get_ledger_entry(&self, key: LedgerKey) -> Result<GetLedgerEntryResponse, Error> {
+        let base64_key = key.to_xdr_base64()?;
+        Ok(self
+            .client()?
+            .request("getLedgerEntry", rpc_params![base64_key])
             .await?)
     }
 }

--- a/cmd/soroban-cli/src/serve.rs
+++ b/cmd/soroban-cli/src/serve.rs
@@ -288,7 +288,7 @@ fn parse_transaction(
     };
 
     // TODO: Support creating contracts and token wrappers here as well.
-    let parameters: ScVec = if let HostFunction::InvokeContract(p) = body {
+    let parameters = if let HostFunction::InvokeContract(p) = body.function {
         p
     } else {
         return Err(Error::UnsupportedTransaction {

--- a/cmd/soroban-cli/src/serve.rs
+++ b/cmd/soroban-cli/src/serve.rs
@@ -146,6 +146,7 @@ async fn handler(
         ("getContractData", Some(Requests::GetContractData((contract_id, key)))) => {
             get_contract_data(&contract_id, key, &ledger_file)
         }
+        ("getLedgerEntry", Some(Requests::StringArg(key))) => get_ledger_entry(key, &ledger_file),
         ("getTransactionStatus", Some(Requests::StringArg(b))) => {
             get_transaction_status(&transaction_status_map, b).await
         }
@@ -227,6 +228,25 @@ fn get_contract_data(
 
     Ok(json!({
         "xdr": value.to_xdr_base64()?,
+        "lastModifiedLedgerSeq": ledger_entry.last_modified_ledger_seq,
+        // TODO: Find "real" ledger seq number here
+        "latestLedger": 1,
+    }))
+}
+
+fn get_ledger_entry(key_xdr: String, ledger_file: &PathBuf) -> Result<Value, Error> {
+    // Initialize storage and host
+    let state = snapshot::read(ledger_file)?;
+    let key = LedgerKey::from_xdr_base64(key_xdr)?;
+
+    let snap = Rc::new(snapshot::Snap {
+        ledger_entries: state.1,
+    });
+    let mut storage = Storage::with_recording_footprint(snap);
+    let ledger_entry = storage.get(&key)?;
+
+    Ok(json!({
+        "xdr": ledger_entry.data.to_xdr_base64()?,
         "lastModifiedLedgerSeq": ledger_entry.last_modified_ledger_seq,
         // TODO: Find "real" ledger seq number here
         "latestLedger": 1,

--- a/cmd/soroban-cli/src/serve.rs
+++ b/cmd/soroban-cli/src/serve.rs
@@ -288,7 +288,7 @@ fn parse_transaction(
     };
 
     // TODO: Support creating contracts and token wrappers here as well.
-    let parameters = if let HostFunction::InvokeContract(p) = body.function {
+    let parameters = if let HostFunction::InvokeContract(p) = &body.function {
         p
     } else {
         return Err(Error::UnsupportedTransaction {

--- a/cmd/soroban-cli/src/strval.rs
+++ b/cmd/soroban-cli/src/strval.rs
@@ -2,9 +2,9 @@ use serde_json::Value;
 use std::{error::Error, fmt::Display, str::FromStr};
 
 use soroban_env_host::xdr::{
-    AccountId, BytesM, Error as XdrError, Int128Parts, PublicKey, ScMap, ScMapEntry, ScObject,
-    ScSpecTypeDef, ScSpecTypeMap, ScSpecTypeOption, ScSpecTypeTuple, ScSpecTypeVec, ScStatic,
-    ScVal, ScVec, Uint256,
+    AccountId, BytesM, Error as XdrError, PublicKey, ScMap, ScMapEntry, ScObject, ScSpecTypeDef,
+    ScSpecTypeMap, ScSpecTypeOption, ScSpecTypeTuple, ScSpecTypeVec, ScStatic, ScVal, ScVec,
+    Uint256,
 };
 
 use stellar_strkey::StrkeyPublicKeyEd25519;

--- a/cmd/soroban-cli/src/token/create.rs
+++ b/cmd/soroban-cli/src/token/create.rs
@@ -7,12 +7,12 @@ use soroban_env_host::{
     budget::Budget,
     storage::Storage,
     xdr::{
-        AccountId, Error as XdrError, Hash, HashIdPreimage, HashIdPreimageSourceAccountContractId,
-        HostFunction, InvokeHostFunctionOp, LedgerFootprint, LedgerKey::ContractData,
-        LedgerKeyContractData, Memo, MuxedAccount, Operation, OperationBody, Preconditions,
-        PublicKey, ScHostStorageErrorCode, ScMap, ScMapEntry, ScObject,
-        ScStatic::LedgerKeyContractCode, ScStatus, ScVal, ScVec, SequenceNumber, Transaction,
-        TransactionEnvelope, TransactionExt, Uint256, VecM, WriteXdr,
+        AccountId, ContractId, CreateContractArgs, Error as XdrError, Hash, HashIdPreimage,
+        HashIdPreimageSourceAccountContractId, HostFunction, InvokeHostFunctionOp, LedgerFootprint,
+        LedgerKey::ContractData, LedgerKeyContractData, Memo, MuxedAccount, Operation,
+        OperationBody, Preconditions, PublicKey, ScContractCode, ScHostStorageErrorCode, ScMap,
+        ScMapEntry, ScObject, ScStatic::LedgerKeyContractCode, ScStatus, ScVal, ScVec,
+        SequenceNumber, Transaction, TransactionEnvelope, TransactionExt, Uint256, VecM, WriteXdr,
     },
     Host, HostError,
 };
@@ -185,17 +185,22 @@ impl Cmd {
         ledger_info.timestamp += 5;
         h.set_ledger_info(ledger_info.clone());
 
-        let res = h.invoke_function(
-            HostFunction::CreateTokenContractWithSourceAccount,
-            vec![ScVal::Object(Some(ScObject::Bytes(salt.try_into()?)))].try_into()?,
-        )?;
+        let network_passphrase = self.network_passphrase.as_ref().unwrap();
+        let contract_id = get_contract_id(salt, admin.clone(), &network_passphrase)?;
+
+        let res = h.invoke_function(HostFunction::CreateContract(CreateContractArgs {
+            contract_id: ContractId::SourceAccount(Uint256(salt)),
+            source: ScContractCode::Token,
+        }))?;
         let res_str = utils::vec_to_hash(&res)?;
 
-        let contract_id = get_contract_id(salt, admin.clone())?;
-        h.invoke_function(
-            HostFunction::InvokeContract,
-            init_parameters(contract_id, &admin, name, symbol, decimal),
-        )?;
+        h.invoke_function(HostFunction::InvokeContract(init_parameters(
+            contract_id,
+            &admin,
+            name,
+            symbol,
+            decimal,
+        )))?;
 
         let (storage, _, _) = h.try_finish().map_err(|_h| {
             HostError::from(ScStatus::HostStorageError(
@@ -241,14 +246,15 @@ impl Cmd {
         // TODO: create a cmdline parameter for the fee instead of simply using the minimum fee
         let fee: u32 = 100;
         let sequence = account_details.sequence.parse::<i64>()?;
-        let contract_id = get_contract_id(salt_val, admin_key.clone())?;
+        let network_passphrase = self.network_passphrase.as_ref().unwrap();
+        let contract_id = get_contract_id(salt_val, admin_key.clone(), &network_passphrase)?;
 
         client
             .send_transaction(&build_tx(
                 build_create_token_op(&Hash(contract_id), salt_val)?,
                 sequence + 1,
                 fee,
-                self.network_passphrase.as_ref().unwrap(),
+                &network_passphrase,
                 &key,
             )?)
             .await?;
@@ -261,7 +267,7 @@ impl Cmd {
                 )?,
                 sequence + 2,
                 fee,
-                self.network_passphrase.as_ref().unwrap(),
+                &network_passphrase,
                 &key,
             )?)
             .await?;
@@ -270,9 +276,19 @@ impl Cmd {
     }
 }
 
-fn get_contract_id(salt: [u8; 32], source_account: AccountId) -> Result<[u8; 32], Error> {
+fn get_contract_id(
+    salt: [u8; 32],
+    source_account: AccountId,
+    network_passphrase: &str,
+) -> Result<[u8; 32], Error> {
+    let network_id = Hash(
+        Sha256::digest(network_passphrase.as_bytes())
+            .try_into()
+            .unwrap(),
+    );
     let preimage =
         HashIdPreimage::ContractIdFromSourceAccount(HashIdPreimageSourceAccountContractId {
+            network_id,
             source_account,
             salt: Uint256(salt),
         });
@@ -306,14 +322,13 @@ fn build_create_token_op(contract_id: &Hash, salt: [u8; 32]) -> Result<Operation
         key: ScVal::Static(LedgerKeyContractCode),
     });
 
-    let parameters: VecM<ScVal, 256_000> =
-        vec![ScVal::Object(Some(ScObject::Bytes(salt.try_into()?)))].try_into()?;
-
     Ok(Operation {
         source_account: None,
         body: OperationBody::InvokeHostFunction(InvokeHostFunctionOp {
-            function: HostFunction::CreateTokenContractWithSourceAccount,
-            parameters: parameters.into(),
+            function: HostFunction::CreateContract(CreateContractArgs {
+                contract_id: ContractId::SourceAccount(Uint256(salt)),
+                source: ScContractCode::Token,
+            }),
             footprint: LedgerFootprint {
                 read_only: VecM::default(),
                 read_write: vec![lk].try_into()?,
@@ -370,8 +385,7 @@ fn build_init_op(contract_id: &Hash, parameters: ScVec) -> Result<Operation, Err
     Ok(Operation {
         source_account: None,
         body: OperationBody::InvokeHostFunction(InvokeHostFunctionOp {
-            function: HostFunction::InvokeContract,
-            parameters,
+            function: HostFunction::InvokeContract(parameters),
             footprint: LedgerFootprint {
                 read_only: vec![ContractData(LedgerKeyContractData {
                     contract_id: contract_id.clone(),

--- a/cmd/soroban-cli/src/token/create.rs
+++ b/cmd/soroban-cli/src/token/create.rs
@@ -19,6 +19,7 @@ use soroban_env_host::{
 use stellar_strkey::StrkeyPublicKeyEd25519;
 
 use crate::{
+    network,
     rpc::{Client, Error as SorobanRpcError},
     snapshot, utils, HEADING_RPC, HEADING_SANDBOX,
 };
@@ -185,8 +186,8 @@ impl Cmd {
         ledger_info.timestamp += 5;
         h.set_ledger_info(ledger_info.clone());
 
-        let network_passphrase = self.network_passphrase.as_ref().unwrap();
-        let contract_id = get_contract_id(salt, admin.clone(), &network_passphrase)?;
+        let contract_id =
+            get_contract_id(salt, admin.clone(), network::SANDBOX_NETWORK_PASSPHRASE)?;
 
         let res = h.invoke_function(HostFunction::CreateContract(CreateContractArgs {
             contract_id: ContractId::SourceAccount(Uint256(salt)),
@@ -247,14 +248,14 @@ impl Cmd {
         let fee: u32 = 100;
         let sequence = account_details.sequence.parse::<i64>()?;
         let network_passphrase = self.network_passphrase.as_ref().unwrap();
-        let contract_id = get_contract_id(salt_val, admin_key.clone(), &network_passphrase)?;
+        let contract_id = get_contract_id(salt_val, admin_key.clone(), network_passphrase)?;
 
         client
             .send_transaction(&build_tx(
                 build_create_token_op(&Hash(contract_id), salt_val)?,
                 sequence + 1,
                 fee,
-                &network_passphrase,
+                network_passphrase,
                 &key,
             )?)
             .await?;
@@ -267,7 +268,7 @@ impl Cmd {
                 )?,
                 sequence + 2,
                 fee,
-                &network_passphrase,
+                network_passphrase,
                 &key,
             )?)
             .await?;

--- a/cmd/soroban-cli/src/token/wrap.rs
+++ b/cmd/soroban-cli/src/token/wrap.rs
@@ -5,12 +5,13 @@ use soroban_env_host::{
     budget::Budget,
     storage::Storage,
     xdr::{
-        AccountId, AlphaNum12, AlphaNum4, Asset, AssetCode12, AssetCode4, Error as XdrError, Hash,
-        HashIdPreimage, HostFunction, InvokeHostFunctionOp, LedgerFootprint,
-        LedgerKey::ContractData, LedgerKeyContractData, Memo, MuxedAccount, Operation,
-        OperationBody, Preconditions, PublicKey, ScHostStorageErrorCode, ScObject,
-        ScStatic::LedgerKeyContractCode, ScStatus, ScVal, SequenceNumber, Transaction,
-        TransactionEnvelope, TransactionExt, Uint256, VecM, WriteXdr,
+        AccountId, AlphaNum12, AlphaNum4, Asset, AssetCode12, AssetCode4, ContractId,
+        CreateContractArgs, Error as XdrError, Hash, HashIdPreimage, HashIdPreimageFromAsset,
+        HostFunction, InvokeHostFunctionOp, LedgerFootprint, LedgerKey::ContractData,
+        LedgerKeyContractData, Memo, MuxedAccount, Operation, OperationBody, Preconditions,
+        PublicKey, ScContractCode, ScHostStorageErrorCode, ScStatic::LedgerKeyContractCode,
+        ScStatus, ScVal, SequenceNumber, Transaction, TransactionEnvelope, TransactionExt, Uint256,
+        VecM, WriteXdr,
     },
     Host, HostError,
 };
@@ -134,15 +135,10 @@ impl Cmd {
         ledger_info.timestamp += 5;
         h.set_ledger_info(ledger_info.clone());
 
-        let mut buf: Vec<u8> = vec![];
-        asset.write_xdr(&mut buf)?;
-        let parameters: VecM<ScVal, 256_000> =
-            vec![ScVal::Object(Some(ScObject::Bytes(buf.try_into()?)))].try_into()?;
-
-        let res = h.invoke_function(
-            HostFunction::CreateTokenContractWithAsset,
-            parameters.into(),
-        )?;
+        let res = h.invoke_function(HostFunction::CreateContract(CreateContractArgs {
+            contract_id: ContractId::Asset(asset.clone()),
+            source: ScContractCode::Token,
+        }))?;
         let res_str = utils::vec_to_hash(&res)?;
 
         let (storage, _, _) = h.try_finish().map_err(|_h| {
@@ -173,13 +169,14 @@ impl Cmd {
         // TODO: create a cmdline parameter for the fee instead of simply using the minimum fee
         let fee: u32 = 100;
         let sequence = account_details.sequence.parse::<i64>()?;
-        let contract_id = get_contract_id(&asset)?;
+        let network_passphrase = self.network_passphrase.as_ref().unwrap();
+        let contract_id = get_contract_id(&asset, &network_passphrase)?;
         let tx = build_wrap_token_tx(
             &asset,
             &contract_id,
             sequence + 1,
             fee,
-            self.network_passphrase.as_ref().unwrap(),
+            network_passphrase,
             &key,
         )?;
 
@@ -189,8 +186,16 @@ impl Cmd {
     }
 }
 
-fn get_contract_id(asset: &Asset) -> Result<Hash, Error> {
-    let preimage = HashIdPreimage::ContractIdFromAsset(asset.clone());
+fn get_contract_id(asset: &Asset, network_passphrase: &str) -> Result<Hash, Error> {
+    let network_id = Hash(
+        Sha256::digest(network_passphrase.as_bytes())
+            .try_into()
+            .unwrap(),
+    );
+    let preimage = HashIdPreimage::ContractIdFromAsset(HashIdPreimageFromAsset {
+        network_id,
+        asset: asset.clone(),
+    });
     let preimage_xdr = preimage.to_xdr()?;
     Ok(Hash(Sha256::digest(preimage_xdr).into()))
 }
@@ -220,16 +225,13 @@ fn build_wrap_token_tx(
         }));
     }
 
-    let mut buf: Vec<u8> = vec![];
-    asset.write_xdr(&mut buf)?;
-    let parameters: VecM<ScVal, 256_000> =
-        vec![ScVal::Object(Some(ScObject::Bytes(buf.try_into()?)))].try_into()?;
-
     let op = Operation {
         source_account: None,
         body: OperationBody::InvokeHostFunction(InvokeHostFunctionOp {
-            function: HostFunction::CreateTokenContractWithAsset,
-            parameters: parameters.into(),
+            function: HostFunction::CreateContract(CreateContractArgs {
+                contract_id: ContractId::Asset(asset.clone()),
+                source: ScContractCode::Token,
+            }),
             footprint: LedgerFootprint {
                 read_only: VecM::default(),
                 read_write: read_write.try_into()?,

--- a/cmd/soroban-cli/src/token/wrap.rs
+++ b/cmd/soroban-cli/src/token/wrap.rs
@@ -170,7 +170,7 @@ impl Cmd {
         let fee: u32 = 100;
         let sequence = account_details.sequence.parse::<i64>()?;
         let network_passphrase = self.network_passphrase.as_ref().unwrap();
-        let contract_id = get_contract_id(&asset, &network_passphrase)?;
+        let contract_id = get_contract_id(&asset, network_passphrase)?;
         let tx = build_wrap_token_tx(
             &asset,
             &contract_id,

--- a/cmd/soroban-cli/src/utils.rs
+++ b/cmd/soroban-cli/src/utils.rs
@@ -1,49 +1,68 @@
 use ed25519_dalek::Signer;
 use hex::FromHexError;
 use sha2::{Digest, Sha256};
-use soroban_env_host::storage::{AccessType, Footprint};
-use soroban_env_host::xdr::{
-    AccountEntry, AccountEntryExt, AccountId, DecoratedSignature, LedgerFootprint, ScSpecEntry,
-    SequenceNumber, Signature, SignatureHint, StringM, Thresholds, TransactionEnvelope,
-    TransactionV1Envelope, VecM,
-};
 use soroban_env_host::{
     im_rc::OrdMap,
-    storage::Storage,
+    storage::{AccessType, Footprint, Storage},
     xdr::{
-        ContractDataEntry, Error as XdrError, Hash, LedgerEntry, LedgerEntryData, LedgerEntryExt,
-        LedgerKey, LedgerKeyContractData, ScContractCode, ScObject, ScStatic, ScVal, Transaction,
-        TransactionSignaturePayload, TransactionSignaturePayloadTaggedTransaction, WriteXdr,
+        AccountEntry, AccountEntryExt, AccountId, ContractCodeEntry, ContractDataEntry,
+        DecoratedSignature, Error as XdrError, ExtensionPoint, Hash, InstallContractCodeArgs,
+        LedgerEntry, LedgerEntryData, LedgerEntryExt, LedgerFootprint, LedgerKey,
+        LedgerKeyContractCode, LedgerKeyContractData, ScContractCode, ScObject, ScSpecEntry,
+        ScStatic, ScVal, SequenceNumber, Signature, SignatureHint, StringM, Thresholds,
+        Transaction, TransactionEnvelope, TransactionSignaturePayload,
+        TransactionSignaturePayloadTaggedTransaction, TransactionV1Envelope, VecM, WriteXdr,
     },
 };
 use soroban_spec::read::FromWasmError;
 use stellar_strkey::StrkeyPrivateKeyEd25519;
+
+fn contract_hash(contract: &[u8]) -> Result<Hash, XdrError> {
+    let args_xdr = InstallContractCodeArgs {
+        code: contract.try_into()?,
+    }
+    .to_xdr()?;
+    Ok(Hash(Sha256::digest(args_xdr).into()))
+}
 
 pub fn add_contract_to_ledger_entries(
     entries: &mut OrdMap<LedgerKey, LedgerEntry>,
     contract_id: [u8; 32],
     contract: Vec<u8>,
 ) -> Result<(), XdrError> {
-    let key = LedgerKey::ContractData(LedgerKeyContractData {
-        contract_id: contract_id.into(),
-        key: ScVal::Static(ScStatic::LedgerKeyContractCode),
-    });
-
-    let data = LedgerEntryData::ContractData(ContractDataEntry {
-        contract_id: contract_id.into(),
-        key: ScVal::Static(ScStatic::LedgerKeyContractCode),
-        val: ScVal::Object(Some(ScObject::ContractCode(ScContractCode::Wasm(
-            contract.try_into()?,
-        )))),
-    });
-
-    let entry = LedgerEntry {
+    // Install the code
+    let hash = contract_hash(&contract.as_slice())?;
+    let code_key = LedgerKey::ContractCode(LedgerKeyContractCode { hash });
+    let code_entry = LedgerEntry {
         last_modified_ledger_seq: 0,
-        data,
+        data: LedgerEntryData::ContractCode(ContractCodeEntry {
+            code: contract.try_into()?,
+            ext: ExtensionPoint::V0,
+            hash,
+        }),
         ext: LedgerEntryExt::V0,
     };
+    entries.insert(code_key, code_entry);
 
-    entries.insert(key, entry);
+    // Create the contract
+    let contract_key = LedgerKey::ContractData(LedgerKeyContractData {
+        contract_id: contract_id.into(),
+        key: ScVal::Static(ScStatic::LedgerKeyContractCode),
+    });
+
+    let contract_entry = LedgerEntry {
+        last_modified_ledger_seq: 0,
+        data: LedgerEntryData::ContractData(ContractDataEntry {
+            contract_id: contract_id.into(),
+            key: ScVal::Static(ScStatic::LedgerKeyContractCode),
+            val: ScVal::Object(Some(ScObject::ContractCode(ScContractCode::WasmRef(
+                contract.try_into()?,
+            )))),
+        }),
+        ext: LedgerEntryExt::V0,
+    };
+    entries.insert(contract_key, contract_entry);
+
     Ok(())
 }
 
@@ -104,17 +123,23 @@ pub fn get_contract_spec_from_storage(
         ..
     }) = storage.get(&key)
     {
-        contract_code_to_spec_entries(c)
+        match c {
+            ScContractCode::Token => soroban_spec::read::parse_raw(&soroban_token_spec::spec_xdr())
+                .map_err(FromWasmError::Parse),
+            ScContractCode::WasmRef(hash) => {
+                if let Ok(LedgerEntry {
+                    data: LedgerEntryData::ContractCode(ContractCodeEntry { code, .. }),
+                    ..
+                }) = storage.get(&LedgerKey::ContractCode(LedgerKeyContractCode { hash }))
+                {
+                    soroban_spec::read::from_wasm(&code)
+                } else {
+                    Err(FromWasmError::NotFound)
+                }
+            }
+        }
     } else {
         Err(FromWasmError::NotFound)
-    }
-}
-
-pub fn contract_code_to_spec_entries(c: ScContractCode) -> Result<Vec<ScSpecEntry>, FromWasmError> {
-    match c {
-        ScContractCode::Wasm(wasm) => soroban_spec::read::from_wasm(&wasm),
-        ScContractCode::Token => soroban_spec::read::parse_raw(&soroban_token_spec::spec_xdr())
-            .map_err(FromWasmError::Parse),
     }
 }
 

--- a/cmd/soroban-cli/src/utils.rs
+++ b/cmd/soroban-cli/src/utils.rs
@@ -31,14 +31,14 @@ pub fn add_contract_to_ledger_entries(
     contract: Vec<u8>,
 ) -> Result<(), XdrError> {
     // Install the code
-    let hash = contract_hash(&contract.as_slice())?;
-    let code_key = LedgerKey::ContractCode(LedgerKeyContractCode { hash });
+    let hash = contract_hash(contract.as_slice())?;
+    let code_key = LedgerKey::ContractCode(LedgerKeyContractCode { hash: hash.clone() });
     let code_entry = LedgerEntry {
         last_modified_ledger_seq: 0,
         data: LedgerEntryData::ContractCode(ContractCodeEntry {
             code: contract.try_into()?,
             ext: ExtensionPoint::V0,
-            hash,
+            hash: hash.clone(),
         }),
         ext: LedgerEntryExt::V0,
     };
@@ -55,9 +55,7 @@ pub fn add_contract_to_ledger_entries(
         data: LedgerEntryData::ContractData(ContractDataEntry {
             contract_id: contract_id.into(),
             key: ScVal::Static(ScStatic::LedgerKeyContractCode),
-            val: ScVal::Object(Some(ScObject::ContractCode(ScContractCode::WasmRef(
-                contract.try_into()?,
-            )))),
+            val: ScVal::Object(Some(ScObject::ContractCode(ScContractCode::WasmRef(hash)))),
         }),
         ext: LedgerEntryExt::V0,
     };

--- a/cmd/soroban-cli/src/utils.rs
+++ b/cmd/soroban-cli/src/utils.rs
@@ -17,7 +17,7 @@ use soroban_env_host::{
 use soroban_spec::read::FromWasmError;
 use stellar_strkey::StrkeyPrivateKeyEd25519;
 
-fn contract_hash(contract: &[u8]) -> Result<Hash, XdrError> {
+pub fn contract_hash(contract: &[u8]) -> Result<Hash, XdrError> {
     let args_xdr = InstallContractCodeArgs {
         code: contract.try_into()?,
     }

--- a/cmd/soroban-rpc/internal/jsonrpc.go
+++ b/cmd/soroban-rpc/internal/jsonrpc.go
@@ -47,6 +47,7 @@ func NewJSONRPCHandler(params HandlerParams) (Handler, error) {
 	bridge := jhttp.NewBridge(handler.Map{
 		"getHealth":            methods.NewHealthCheck(),
 		"getAccount":           methods.NewAccountHandler(params.AccountStore),
+		"getLedgerEntry":       methods.NewGetLedgerEntryHandler(params.Logger, params.CoreClient),
 		"getTransactionStatus": methods.NewGetTransactionStatusHandler(params.TransactionProxy),
 		"sendTransaction":      methods.NewSendTransactionHandler(params.TransactionProxy),
 		"simulateTransaction":  methods.NewSimulateTransactionHandler(params.Logger, params.CoreClient),

--- a/cmd/soroban-rpc/internal/methods/get_ledger_entry.go
+++ b/cmd/soroban-rpc/internal/methods/get_ledger_entry.go
@@ -23,7 +23,7 @@ type GetLedgerEntryResponse struct {
 	LatestLedger       int64  `json:"latestLedger,string"`
 }
 
-// NewGetLedgerEntryHandler returns a json rpc handler to retrieve a contract data ledger entry from stellar cre
+// NewGetLedgerEntryHandler returns a json rpc handler to retrieve the specified ledger entry from stellar core
 func NewGetLedgerEntryHandler(logger *log.Entry, coreClient *stellarcore.Client) jrpc2.Handler {
 	return handler.New(func(ctx context.Context, request GetLedgerEntryRequest) (GetLedgerEntryResponse, error) {
 		var key xdr.LedgerKey

--- a/cmd/soroban-rpc/internal/methods/get_ledger_entry.go
+++ b/cmd/soroban-rpc/internal/methods/get_ledger_entry.go
@@ -1,0 +1,83 @@
+package methods
+
+import (
+	"context"
+
+	"github.com/creachadair/jrpc2"
+	"github.com/creachadair/jrpc2/code"
+	"github.com/creachadair/jrpc2/handler"
+
+	"github.com/stellar/go/clients/stellarcore"
+	proto "github.com/stellar/go/protocols/stellarcore"
+	"github.com/stellar/go/support/log"
+	"github.com/stellar/go/xdr"
+)
+
+type GetLedgerEntryRequest struct {
+	Key string `json:"key"`
+}
+
+type GetLedgerEntryResponse struct {
+	XDR                string `json:"xdr"`
+	LastModifiedLedger int64  `json:"lastModifiedLedgerSeq,string"`
+	LatestLedger       int64  `json:"latestLedger,string"`
+}
+
+// NewGetLedgerEntryHandler returns a json rpc handler to retrieve a contract data ledger entry from stellar cre
+func NewGetLedgerEntryHandler(logger *log.Entry, coreClient *stellarcore.Client) jrpc2.Handler {
+	return handler.New(func(ctx context.Context, request GetLedgerEntryRequest) (GetLedgerEntryResponse, error) {
+		var key xdr.LedgerKey
+		if err := xdr.SafeUnmarshalBase64(request.Key, &key); err != nil {
+			logger.WithError(err).WithField("request", request).
+				Info("could not unmarshal ledgerKey from getLedgerEntry request")
+			return GetLedgerEntryResponse{}, &jrpc2.Error{
+				Code:    code.InvalidParams,
+				Message: "cannot unmarshal key value",
+			}
+		}
+
+		coreResponse, err := coreClient.GetLedgerEntry(ctx, key)
+		if err != nil {
+			logger.WithError(err).WithField("request", request).
+				Info("could not submit getLedgerEntry request to core")
+			return GetLedgerEntryResponse{}, &jrpc2.Error{
+				Code:    code.InternalError,
+				Message: "could not submit request to core",
+			}
+		}
+
+		if coreResponse.State == proto.DeadState {
+			return GetLedgerEntryResponse{}, &jrpc2.Error{
+				Code:    code.InvalidRequest,
+				Message: "not found",
+			}
+		}
+
+		var ledgerEntry xdr.LedgerEntry
+		if err = xdr.SafeUnmarshalBase64(coreResponse.Entry, &ledgerEntry); err != nil {
+			logger.WithError(err).WithField("request", request).
+				WithField("response", coreResponse).
+				Info("could not parse ledger entry")
+			return GetLedgerEntryResponse{}, &jrpc2.Error{
+				Code:    code.InternalError,
+				Message: "could not parse core response",
+			}
+		}
+
+		response := GetLedgerEntryResponse{
+			LastModifiedLedger: int64(ledgerEntry.LastModifiedLedgerSeq),
+			LatestLedger:       coreResponse.Ledger,
+		}
+		if response.XDR, err = xdr.MarshalBase64(ledgerEntry.Data); err != nil {
+			logger.WithError(err).WithField("request", request).
+				WithField("response", coreResponse).
+				Info("could not serialize ledger entry data")
+			return GetLedgerEntryResponse{}, &jrpc2.Error{
+				Code:    code.InternalError,
+				Message: "could not serialize ledger entry data",
+			}
+		}
+
+		return response, nil
+	})
+}

--- a/cmd/soroban-rpc/internal/test/docker-compose.yml
+++ b/cmd/soroban-rpc/internal/test/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     # Note: Please keep the image pinned to an immutable tag matching the Captive Core version.
     #       This avoid implicit updates which break compatibility between
     #       the Core container and captive core.
-    image: ${CORE_IMAGE:-sreuland/stellar-core:19.4.1-1097.4e813f20e.focal-soroban}
+    image: ${CORE_IMAGE:-2opremio/stellar-core:19.5.1-1131.f55f88376.focal-soroban}
     depends_on:
       - core-postgres
     restart: on-failure

--- a/cmd/soroban-rpc/internal/test/docker-compose.yml
+++ b/cmd/soroban-rpc/internal/test/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     # Note: Please keep the image pinned to an immutable tag matching the Captive Core version.
     #       This avoid implicit updates which break compatibility between
     #       the Core container and captive core.
-    image: ${CORE_IMAGE:-2opremio/stellar-core:19.5.1-1131.f55f88376.focal-soroban}
+    image: ${CORE_IMAGE:-sreuland/stellar-core:19.5.1-1137.b3a6bc281.focal-soroban}
     depends_on:
       - core-postgres
     restart: on-failure

--- a/cmd/soroban-rpc/internal/test/get_ledger_entry_test.go
+++ b/cmd/soroban-rpc/internal/test/get_ledger_entry_test.go
@@ -1,0 +1,139 @@
+package test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/creachadair/jrpc2"
+	"github.com/creachadair/jrpc2/code"
+	"github.com/creachadair/jrpc2/jhttp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/txnbuild"
+	"github.com/stellar/go/xdr"
+	"github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/methods"
+)
+
+func TestGetLedgerEntryNotFound(t *testing.T) {
+	test := NewTest(t)
+
+	ch := jhttp.NewChannel(test.server.URL, nil)
+	client := jrpc2.NewClient(ch, nil)
+
+	sourceAccount := keypair.Root(StandaloneNetworkPassphrase).Address()
+	contractID := getContractID(t, sourceAccount, testSalt, StandaloneNetworkPassphrase)
+	keyB64, err := xdr.MarshalBase64(xdr.LedgerKey{
+		Type: xdr.LedgerEntryTypeContractData,
+		ContractData: &xdr.LedgerKeyContractData{
+			ContractId: contractID,
+			Key:        getContractCodeLedgerKey(),
+		},
+	})
+	require.NoError(t, err)
+	request := methods.GetLedgerEntryRequest{
+		Key: keyB64,
+	}
+
+	var result methods.GetLedgerEntryResponse
+	jsonRPCErr := client.CallResult(context.Background(), "getLedgerEntry", request, &result).(*jrpc2.Error)
+	assert.Equal(t, "not found", jsonRPCErr.Message)
+	assert.Equal(t, code.InvalidRequest, jsonRPCErr.Code)
+}
+
+func TestGetLedgerEntryInvalidParams(t *testing.T) {
+	test := NewTest(t)
+
+	ch := jhttp.NewChannel(test.server.URL, nil)
+	client := jrpc2.NewClient(ch, nil)
+
+	request := methods.GetLedgerEntryRequest{
+		Key: "<>@@#$",
+	}
+
+	var result methods.GetLedgerEntryResponse
+	jsonRPCErr := client.CallResult(context.Background(), "getLedgerEntry", request, &result).(*jrpc2.Error)
+	assert.Equal(t, "cannot unmarshal key value", jsonRPCErr.Message)
+	assert.Equal(t, code.InvalidParams, jsonRPCErr.Code)
+}
+
+func TestGetLedgerEntryDeadlineError(t *testing.T) {
+	test := NewTest(t)
+	test.coreClient.HTTP = &http.Client{
+		Timeout: time.Microsecond,
+	}
+
+	ch := jhttp.NewChannel(test.server.URL, nil)
+	client := jrpc2.NewClient(ch, nil)
+
+	sourceAccount := keypair.Root(StandaloneNetworkPassphrase).Address()
+	contractID := getContractID(t, sourceAccount, testSalt, StandaloneNetworkPassphrase)
+	keyB64, err := xdr.MarshalBase64(xdr.LedgerKey{
+		Type: xdr.LedgerEntryTypeContractData,
+		ContractData: &xdr.LedgerKeyContractData{
+			ContractId: contractID,
+			Key:        getContractCodeLedgerKey(),
+		},
+	})
+	require.NoError(t, err)
+	request := methods.GetLedgerEntryRequest{
+		Key: keyB64,
+	}
+
+	var result methods.GetLedgerEntryResponse
+	jsonRPCErr := client.CallResult(context.Background(), "getLedgerEntry", request, &result).(*jrpc2.Error)
+	assert.Equal(t, "could not submit request to core", jsonRPCErr.Message)
+	assert.Equal(t, code.InternalError, jsonRPCErr.Code)
+}
+
+func TestGetLedgerEntrySucceeds(t *testing.T) {
+	test := NewTest(t)
+
+	ch := jhttp.NewChannel(test.server.URL, nil)
+	client := jrpc2.NewClient(ch, nil)
+
+	kp := keypair.Root(StandaloneNetworkPassphrase)
+	account := txnbuild.NewSimpleAccount(kp.Address(), 0)
+
+	// Install and create the contract first
+	for _, op := range []txnbuild.Operation{
+		createInstallContractCodeOperation(t, account.AccountID, testContract, true),
+		createCreateContractOperation(t, account.AccountID, testContract, StandaloneNetworkPassphrase, true),
+	} {
+		assertSendTransaction(t, client, kp, txnbuild.TransactionParams{
+			SourceAccount:        &account,
+			IncrementSequenceNum: true,
+			Operations:           []txnbuild.Operation{op},
+			BaseFee:              txnbuild.MinBaseFee,
+			Preconditions: txnbuild.Preconditions{
+				TimeBounds: txnbuild.NewInfiniteTimeout(),
+			},
+		})
+	}
+
+	sourceAccount := keypair.Root(StandaloneNetworkPassphrase).Address()
+	contractID := getContractID(t, sourceAccount, testSalt, StandaloneNetworkPassphrase)
+	keyB64, err := xdr.MarshalBase64(xdr.LedgerKey{
+		Type: xdr.LedgerEntryTypeContractData,
+		ContractData: &xdr.LedgerKeyContractData{
+			ContractId: contractID,
+			Key:        getContractCodeLedgerKey(),
+		},
+	})
+	require.NoError(t, err)
+	request := methods.GetLedgerEntryRequest{
+		Key: keyB64,
+	}
+
+	var result methods.GetLedgerEntryResponse
+	err = client.CallResult(context.Background(), "getLedgerEntry", request, &result)
+	assert.NoError(t, err)
+	assert.Greater(t, result.LatestLedger, int64(0))
+	assert.GreaterOrEqual(t, result.LatestLedger, result.LastModifiedLedger)
+	var scVal xdr.ScVal
+	assert.NoError(t, xdr.SafeUnmarshalBase64(result.XDR, &scVal))
+	assert.Equal(t, testContract, scVal.MustObj().MustContractCode().MustWasmId())
+}

--- a/cmd/soroban-rpc/internal/test/get_ledger_entry_test.go
+++ b/cmd/soroban-rpc/internal/test/get_ledger_entry_test.go
@@ -25,7 +25,7 @@ func TestGetLedgerEntryNotFound(t *testing.T) {
 	client := jrpc2.NewClient(ch, nil)
 
 	sourceAccount := keypair.Root(StandaloneNetworkPassphrase).Address()
-	contractID := getContractID(t, sourceAccount, testSalt, StandaloneNetworkPassphrase)
+	contractID := getContractID(t, sourceAccount, testSalt)
 	keyB64, err := xdr.MarshalBase64(xdr.LedgerKey{
 		Type: xdr.LedgerEntryTypeContractData,
 		ContractData: &xdr.LedgerKeyContractData{
@@ -70,7 +70,7 @@ func TestGetLedgerEntryDeadlineError(t *testing.T) {
 	client := jrpc2.NewClient(ch, nil)
 
 	sourceAccount := keypair.Root(StandaloneNetworkPassphrase).Address()
-	contractID := getContractID(t, sourceAccount, testSalt, StandaloneNetworkPassphrase)
+	contractID := getContractID(t, sourceAccount, testSalt)
 	keyB64, err := xdr.MarshalBase64(xdr.LedgerKey{
 		Type: xdr.LedgerEntryTypeContractData,
 		ContractData: &xdr.LedgerKeyContractData{
@@ -115,7 +115,7 @@ func TestGetLedgerEntrySucceeds(t *testing.T) {
 	}
 
 	sourceAccount := keypair.Root(StandaloneNetworkPassphrase).Address()
-	contractID := getContractID(t, sourceAccount, testSalt, StandaloneNetworkPassphrase)
+	contractID := getContractID(t, sourceAccount, testSalt)
 	keyB64, err := xdr.MarshalBase64(xdr.LedgerKey{
 		Type: xdr.LedgerEntryTypeContractData,
 		ContractData: &xdr.LedgerKeyContractData{

--- a/cmd/soroban-rpc/internal/test/integration.go
+++ b/cmd/soroban-rpc/internal/test/integration.go
@@ -144,8 +144,12 @@ func (i *Test) runComposeCommand(args ...string) {
 func (i *Test) prepareShutdownHandlers() {
 	i.shutdownCalls = append(i.shutdownCalls,
 		func() {
-			i.handler.Close()
-			i.server.Close()
+			if i.handler.Handler != nil {
+				i.handler.Close()
+			}
+			if i.server != nil {
+				i.server.Close()
+			}
 			i.runComposeCommand("down", "-v")
 		},
 	)

--- a/cmd/soroban-rpc/internal/test/transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/transaction_test.go
@@ -83,7 +83,7 @@ func TestSendTransactionSucceedsWithResults(t *testing.T) {
 		SourceAccount:        &account,
 		IncrementSequenceNum: true,
 		Operations: []txnbuild.Operation{
-			createInvokeHostOperation(t, account.AccountID, true),
+			createInstallContractCodeOperation(t, account.AccountID, testContract, true),
 		},
 		BaseFee: txnbuild.MinBaseFee,
 		Preconditions: txnbuild.Preconditions{
@@ -115,7 +115,7 @@ func TestSendTransactionSucceedsWithResults(t *testing.T) {
 	assert.Nil(t, response.Error)
 	assert.Equal(t,
 		[]methods.SCVal{
-			{XDR: "AAAABAAAAAEAAAAEAAAAIJL0uHwiQNNaPB0brHQ1Wg+WexdpZMjN1H4UDoxE5pQz"},
+			{XDR: "AAAABAAAAAEAAAAGAAAAIOqfy4GuVKKfazvyk4R9P9fpo2n9HICsr+xqvVcTF+DC"},
 		},
 		response.Results,
 	)
@@ -220,7 +220,7 @@ func TestSendTransactionFailedInLedger(t *testing.T) {
 		IncrementSequenceNum: true,
 		Operations: []txnbuild.Operation{
 			// without the footprint the tx will fail
-			createInvokeHostOperation(t, account.AccountID, false),
+			createInstallContractCodeOperation(t, account.AccountID, testContract, false),
 		},
 		BaseFee: txnbuild.MinBaseFee,
 		Preconditions: txnbuild.Preconditions{

--- a/cmd/soroban-rpc/main.go
+++ b/cmd/soroban-rpc/main.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stellar/go/network"
 	"github.com/stellar/go/support/config"
 	supportlog "github.com/stellar/go/support/log"
-	goxdr "github.com/stellar/go/xdr"
 	localConfig "github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/config"
 	"github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/daemon"
 )
@@ -124,7 +123,8 @@ func main() {
 					branch = ""
 				}
 				fmt.Printf("soroban-rpc %s (%s) %s\n", localConfig.Version, localConfig.CommitHash, branch)
-				fmt.Printf("stellar-xdr %s\n", goxdr.CommitHash)
+				// TODO: Should we include this??
+				// fmt.Printf("stellar-xdr %s\n", goxdr.CommitHash)
 			}
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/sirupsen/logrus v1.4.1
 	github.com/spf13/cobra v0.0.0-20160830174925-9c28e4bbd74e
 	github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189
+	github.com/stellar/go v0.0.0-20221201205727-49dc8a987555
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/mod v0.6.0
 )
@@ -52,7 +53,6 @@ require (
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/spf13/cast v0.0.0-20150508191742-4d07383ffe94 // indirect
 	github.com/spf13/jwalterweatherman v0.0.0-20141219030609-3d60171a6431 // indirect
-	github.com/stellar/go v0.0.0-20221130151413-77a05889334f
 	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.0 // indirect
 	golang.org/x/crypto v0.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/sirupsen/logrus v1.4.1
 	github.com/spf13/cobra v0.0.0-20160830174925-9c28e4bbd74e
 	github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189
-	github.com/stellar/go v0.0.0-20221201205727-49dc8a987555
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/mod v0.6.0
 )
@@ -53,6 +52,7 @@ require (
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/spf13/cast v0.0.0-20150508191742-4d07383ffe94 // indirect
 	github.com/spf13/jwalterweatherman v0.0.0-20141219030609-3d60171a6431 // indirect
+	github.com/stellar/go v0.0.0-20221201205727-49dc8a987555
 	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.0 // indirect
 	golang.org/x/crypto v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -112,8 +112,8 @@ github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475 h1:RtZIgreTwcayPTOw7G5
 github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189 h1:fvB1AFbBd6SfI9Rd0ooAJp8uLkZDbZaLFHi7ZnNP6uI=
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
-github.com/stellar/go v0.0.0-20221130151413-77a05889334f h1:ZKf9XwvizoE0F4VQ49Qs8aXn8zhyuw6vX0ng/VVh2Sc=
-github.com/stellar/go v0.0.0-20221130151413-77a05889334f/go.mod h1:AbsNBrmclUvQcs0EeN+LDhubhX7tyo18r5fw0SCz/oM=
+github.com/stellar/go v0.0.0-20221201205727-49dc8a987555 h1:ZnZHZKe3xiBkUkAyMr6kTGQkDZ6lVo1E03CfTdl9DE0=
+github.com/stellar/go v0.0.0-20221201205727-49dc8a987555/go.mod h1:AbsNBrmclUvQcs0EeN+LDhubhX7tyo18r5fw0SCz/oM=
 github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee h1:fbVs0xmXpBvVS4GBeiRmAE3Le70ofAqFMch1GTiq/e8=
 github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/tests/it/e2e_rpc_server.rs
+++ b/tests/it/e2e_rpc_server.rs
@@ -12,13 +12,13 @@ fn e2e_deploy_and_invoke_contract_against_rpc_server() {
         .arg(test_wasm("test_hello_world"))
         .arg("--salt=0")
         .assert()
-        .stdout("1f3eb7b8dc051d6aa46db5454588a142c671a0cdcdb36a2f754d9675a64bf613\n")
-        .stderr("success\n")
+        .stdout("b392cd0044315873f32307bfd535a9cbbb0402a57133ff7283afcae66be8174b\n")
+        .stderr("success\nsuccess\n")
         .success();
 
     Standalone::new_cmd()
         .arg("invoke")
-        .arg("--id=1f3eb7b8dc051d6aa46db5454588a142c671a0cdcdb36a2f754d9675a64bf613")
+        .arg("--id=b392cd0044315873f32307bfd535a9cbbb0402a57133ff7283afcae66be8174b")
         .arg("--fn=hello")
         .arg("--arg=world")
         .assert()
@@ -41,14 +41,14 @@ fn create_and_invoke_token_contract_against_rpc_server() {
             "--salt=1",
         ])
         .assert()
-        .stdout("8af3f0c5c2c4b5a3c6ac67b390f84d9db843b48827376f42e5bad215c42588f7\n")
+        .stdout("1bd2a2473623e73904d35a334476d1fe3cd192811bd823b7815fd9ce57c82232\n")
         .stderr("success\nsuccess\n")
         .success();
 
     Standalone::new_cmd()
         .args([
             "invoke",
-            "--id=8af3f0c5c2c4b5a3c6ac67b390f84d9db843b48827376f42e5bad215c42588f7",
+            "--id=1bd2a2473623e73904d35a334476d1fe3cd192811bd823b7815fd9ce57c82232",
             "--fn=symbol",
         ])
         .assert()

--- a/tests/it/invoke_sandbox.rs
+++ b/tests/it/invoke_sandbox.rs
@@ -12,13 +12,13 @@ fn invoke_token() {
         .arg("--symbol=tok")
         .assert()
         .success()
-        .stdout("d55b5a3a5793539545f957f7da783f7b19159369ccdb19c53dbd117ebfc08842\n");
+        .stdout("7794c4a02357bd9063499148e709bde44aa9e643d3fa20fde202f6e84a671e1b\n");
 
     Sandbox::new_cmd()
         .arg("invoke")
         .arg("--ledger-file")
         .arg(ledger)
-        .arg("--id=d55b5a3a5793539545f957f7da783f7b19159369ccdb19c53dbd117ebfc08842")
+        .arg("--id=7794c4a02357bd9063499148e709bde44aa9e643d3fa20fde202f6e84a671e1b")
         .arg("--fn=decimals")
         .assert()
         .success()


### PR DESCRIPTION
### What

Add a new rpc `getLedgerEntry` method to supersede `getContractData`.

### Why

Because the contract storage has changed with the new xdr, `getContractData` can no longer be used by soroban-cli to fetch the contract code. We could have added the `getContractCode` endpoint from the original spec. But, it's come up several times that actually `getLedgerEntry` is both lower-level and more useful.

The plan will be to deprecate `getContractData`, and remove it in favour of `getLedgerEntry` in the next release.

### Todo

- [x] Rebase this onto main
- [ ] test this
- [x] use the new method from soroban-cli to fetch the contract code
  - Will need two requests, one to get the code address, and a second to get the actual code.
- [x] update the rust dependencies to include the new xdr and conversions
- [x] update the go dependency to include the new xdr
- [ ] Once merged: Update the [api doc](https://docs.google.com/document/d/1TZUDgo_3zPz7TiPMMHVW_mtogjLyPL0plvzGMsxSz6A/edit)
