### PR TITLE
Add index of the parsed argument in the error message

### DIFF
--- a/cmd/soroban-cli/src/invoke.rs
+++ b/cmd/soroban-cli/src/invoke.rs
@@ -105,8 +105,8 @@ pub struct Cmd {
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[error("parsing argument {arg}: {error}")]
-    CannotParseArg { arg: String, error: StrValError },
+    #[error("parsing argument '{arg}' at index {index}: {error}")]
+    CannotParseArg { arg: String, error: StrValError, index: usize },
     #[error("parsing XDR arg {arg}: {error}")]
     CannotParseXdrArg { arg: String, error: XdrError },
     #[error("cannot add contract to ledger entries: {0}")]
@@ -229,6 +229,7 @@ impl Cmd {
                     strval::from_string(s, &input.type_).map_err(|e| Error::CannotParseArg {
                         arg: s.clone(),
                         error: e,
+                        index: arg.0,
                     })
                 }
             })


### PR DESCRIPTION
### What

Add index of the parsed argument in the error message

### Why

When invoking a contract with multiple arguments, especially if the types accept the same kind of values.

### Known limitations

The index is not only '--arg' index but the index of all the invoke command options
