### PR TITLE
Additional CLI support for the contract deployment changes.

### DIFF
--- a/cmd/soroban-cli/src/deploy.rs
+++ b/cmd/soroban-cli/src/deploy.rs
@@ -141,17 +141,15 @@ impl Cmd {
                 filepath: wasm.clone(),
                 error: e,
             })?)
+        } else if let Some(wasm_hash) = &self.wasm_hash {
+            ContractSource::WasmHash(utils::id_from_str(wasm_hash).map_err(|e| {
+                Error::CannotParseWasmHash {
+                    wasm_hash: wasm_hash.clone(),
+                    error: e,
+                }
+            })?)
         } else {
-            if let Some(wasm_hash) = &self.wasm_hash {
-                ContractSource::WasmHash(utils::id_from_str(wasm_hash).map_err(|e| {
-                    Error::CannotParseWasmHash {
-                        wasm_hash: wasm_hash.clone(),
-                        error: e,
-                    }
-                })?)
-            } else {
-                return Err(Error::ContractSourceNotProvided);
-            }
+            return Err(Error::ContractSourceNotProvided);
         };
 
         let res_str = if self.rpc_url.is_some() {

--- a/cmd/soroban-cli/src/deploy.rs
+++ b/cmd/soroban-cli/src/deploy.rs
@@ -9,14 +9,14 @@ use sha2::{Digest, Sha256};
 use soroban_env_host::xdr::HashIdPreimageSourceAccountContractId;
 use soroban_env_host::xdr::{
     AccountId, ContractId, CreateContractArgs, Error as XdrError, Hash, HashIdPreimage,
-    HostFunction, InstallContractCodeArgs, InvokeHostFunctionOp, LedgerFootprint,
-    LedgerKey::ContractCode, LedgerKey::ContractData, LedgerKeyContractCode, LedgerKeyContractData,
-    Memo, MuxedAccount, Operation, OperationBody, Preconditions, PublicKey, ScContractCode,
-    ScStatic, ScVal, SequenceNumber, Transaction, TransactionEnvelope, TransactionExt, Uint256,
-    VecM, WriteXdr,
+    HostFunction, InvokeHostFunctionOp, LedgerFootprint, LedgerKey::ContractCode,
+    LedgerKey::ContractData, LedgerKeyContractCode, LedgerKeyContractData, Memo, MuxedAccount,
+    Operation, OperationBody, Preconditions, PublicKey, ScContractCode, ScStatic, ScVal,
+    SequenceNumber, Transaction, TransactionEnvelope, TransactionExt, Uint256, WriteXdr,
 };
 use soroban_env_host::HostError;
 
+use crate::install::build_install_contract_code_tx;
 use crate::rpc::{self, Client};
 use crate::snapshot::{self, get_default_ledger_info};
 use crate::{utils, HEADING_RPC, HEADING_SANDBOX};
@@ -25,7 +25,11 @@ use crate::{utils, HEADING_RPC, HEADING_SANDBOX};
 pub struct Cmd {
     /// WASM file to deploy
     #[clap(long, parse(from_os_str))]
-    wasm: std::path::PathBuf,
+    wasm: Option<std::path::PathBuf>,
+
+    /// Hash of the already installed/deployed WASM file
+    #[clap(long = "wasm-hash", conflicts_with = "wasm")]
+    wasm_hash: Option<String>,
 
     /// Contract ID to deploy to
     #[clap(
@@ -112,36 +116,59 @@ pub enum Error {
         contract_id: String,
         error: FromHexError,
     },
+    #[error("cannot parse WASM hash {wasm_hash}: {error}")]
+    CannotParseWasmHash {
+        wasm_hash: String,
+        error: FromHexError,
+    },
     #[error("cannot parse secret key")]
     CannotParseSecretKey,
     #[error(transparent)]
     Rpc(#[from] rpc::Error),
+    #[error("either --wasm or --wasm-hash has to be provided")]
+    ContractSourceNotProvided,
+}
+
+enum ContractSource {
+    Wasm(Vec<u8>),
+    WasmHash([u8; 32]),
 }
 
 impl Cmd {
     pub async fn run(&self) -> Result<(), Error> {
-        let contract = fs::read(&self.wasm).map_err(|e| Error::CannotReadContractFile {
-            filepath: self.wasm.clone(),
-            error: e,
-        })?;
+        let source = if let Some(wasm) = &self.wasm {
+            ContractSource::Wasm(fs::read(wasm).map_err(|e| Error::CannotReadContractFile {
+                filepath: wasm.clone(),
+                error: e,
+            })?)
+        } else {
+            if let Some(wasm_hash) = &self.wasm_hash {
+                ContractSource::WasmHash(utils::id_from_str(wasm_hash).map_err(|e| {
+                    Error::CannotParseWasmHash {
+                        wasm_hash: wasm_hash.clone(),
+                        error: e,
+                    }
+                })?)
+            } else {
+                return Err(Error::ContractSourceNotProvided);
+            }
+        };
 
         let res_str = if self.rpc_url.is_some() {
-            self.run_against_rpc_server(contract).await?
+            self.run_against_rpc_server(source).await?
         } else {
-            self.run_in_sandbox(contract)?
+            self.run_in_sandbox(source)?
         };
         println!("{res_str}");
         Ok(())
     }
 
-    fn run_in_sandbox(&self, contract: Vec<u8>) -> Result<String, Error> {
+    fn run_in_sandbox(&self, contract_src: ContractSource) -> Result<String, Error> {
         let contract_id: [u8; 32] = match &self.contract_id {
-            Some(id) => {
-                utils::contract_id_from_str(id).map_err(|e| Error::CannotParseContractId {
-                    contract_id: self.contract_id.as_ref().unwrap().clone(),
-                    error: e,
-                })?
-            }
+            Some(id) => utils::id_from_str(id).map_err(|e| Error::CannotParseContractId {
+                contract_id: self.contract_id.as_ref().unwrap().clone(),
+                error: e,
+            })?,
             None => rand::thread_rng().gen::<[u8; 32]>(),
         };
 
@@ -150,7 +177,13 @@ impl Cmd {
                 filepath: self.ledger_file.clone(),
                 error: e,
             })?;
-        utils::add_contract_to_ledger_entries(&mut state.1, contract_id, contract)?;
+        let wasm_hash = match contract_src {
+            ContractSource::Wasm(wasm) => {
+                utils::add_contract_code_to_ledger_entries(&mut state.1, wasm)?.0
+            }
+            ContractSource::WasmHash(wasm_hash) => wasm_hash,
+        };
+        utils::add_contract_to_ledger_entries(&mut state.1, contract_id, wasm_hash);
 
         snapshot::commit(state.1, get_default_ledger_info(), [], &self.ledger_file).map_err(
             |e| Error::CannotCommitLedgerFile {
@@ -161,11 +194,12 @@ impl Cmd {
         Ok(hex::encode(contract_id))
     }
 
-    async fn run_against_rpc_server(&self, contract: Vec<u8>) -> Result<String, Error> {
+    async fn run_against_rpc_server(&self, contract_src: ContractSource) -> Result<String, Error> {
         let salt: [u8; 32] = match &self.salt {
             // Hack: re-use contract_id_from_str to parse the 32-byte salt hex.
-            Some(h) => utils::contract_id_from_str(h)
-                .map_err(|_| Error::CannotParseSalt { salt: h.clone() })?,
+            Some(h) => {
+                utils::id_from_str(h).map_err(|_| Error::CannotParseSalt { salt: h.clone() })?
+            }
             None => rand::thread_rng().gen::<[u8; 32]>(),
         };
 
@@ -181,17 +215,23 @@ impl Cmd {
         let fee: u32 = 100;
         let sequence = account_details.sequence.parse::<i64>()?;
 
-        let (tx, hash) = build_install_contract_code_tx(
-            contract,
-            sequence + 1,
-            fee,
-            self.network_passphrase.as_ref().unwrap(),
-            &key,
-        )?;
-        client.send_transaction(&tx).await?;
+        let wasm_hash = match contract_src {
+            ContractSource::Wasm(wasm) => {
+                let (tx, hash) = build_install_contract_code_tx(
+                    wasm,
+                    sequence + 1,
+                    fee,
+                    self.network_passphrase.as_ref().unwrap(),
+                    &key,
+                )?;
+                client.send_transaction(&tx).await?;
+                hash
+            }
+            ContractSource::WasmHash(wasm_hash) => Hash(wasm_hash),
+        };
 
         let (tx, contract_id) = build_create_contract_tx(
-            hash,
+            wasm_hash,
             sequence + 2,
             fee,
             self.network_passphrase.as_ref().unwrap(),
@@ -202,44 +242,6 @@ impl Cmd {
 
         Ok(hex::encode(contract_id.0))
     }
-}
-
-fn build_install_contract_code_tx(
-    contract: Vec<u8>,
-    sequence: i64,
-    fee: u32,
-    network_passphrase: &str,
-    key: &ed25519_dalek::Keypair,
-) -> Result<(TransactionEnvelope, Hash), Error> {
-    let hash = utils::contract_hash(&contract)?;
-
-    let op = Operation {
-        source_account: None,
-        body: OperationBody::InvokeHostFunction(InvokeHostFunctionOp {
-            function: HostFunction::InstallContractCode(InstallContractCodeArgs {
-                code: contract.try_into()?,
-            }),
-            footprint: LedgerFootprint {
-                read_only: VecM::default(),
-                read_write: vec![ContractCode(LedgerKeyContractCode { hash: hash.clone() })]
-                    .try_into()?,
-            },
-        }),
-    };
-
-    let tx = Transaction {
-        source_account: MuxedAccount::Ed25519(Uint256(key.public.to_bytes())),
-        fee,
-        seq_num: SequenceNumber(sequence),
-        cond: Preconditions::None,
-        memo: Memo::None,
-        operations: vec![op].try_into()?,
-        ext: TransactionExt::V0,
-    };
-
-    let envelope = utils::sign_transaction(key, &tx, network_passphrase)?;
-
-    Ok((envelope, hash))
 }
 
 fn build_create_contract_tx(
@@ -297,20 +299,6 @@ fn build_create_contract_tx(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_build_install_contract_code() {
-        let result = build_install_contract_code_tx(
-            b"foo".to_vec(),
-            300,
-            1,
-            "Public Global Stellar Network ; September 2015",
-            &utils::parse_secret_key("SBFGFF27Y64ZUGFAIG5AMJGQODZZKV2YQKAVUUN4HNE24XZXD2OEUVUP")
-                .unwrap(),
-        );
-
-        assert!(result.is_ok());
-    }
 
     #[test]
     fn test_build_create_contract() {

--- a/cmd/soroban-cli/src/install.rs
+++ b/cmd/soroban-cli/src/install.rs
@@ -1,0 +1,206 @@
+use std::array::TryFromSliceError;
+use std::num::ParseIntError;
+use std::{fmt::Debug, fs, io};
+
+use clap::Parser;
+use soroban_env_host::xdr::{
+    Error as XdrError, Hash, HostFunction, InstallContractCodeArgs, InvokeHostFunctionOp,
+    LedgerFootprint, LedgerKey::ContractCode, LedgerKeyContractCode, Memo, MuxedAccount, Operation,
+    OperationBody, Preconditions, SequenceNumber, Transaction, TransactionEnvelope, TransactionExt,
+    Uint256, VecM,
+};
+use soroban_env_host::HostError;
+
+use crate::rpc::{self, Client};
+use crate::snapshot::{self, get_default_ledger_info};
+use crate::{utils, HEADING_RPC, HEADING_SANDBOX};
+
+#[derive(Parser, Debug)]
+pub struct Cmd {
+    /// WASM file to install
+    #[clap(long, parse(from_os_str))]
+    wasm: std::path::PathBuf,
+    /// File to persist ledger state
+    #[clap(
+        long,
+        parse(from_os_str),
+        default_value = ".soroban/ledger.json",
+        conflicts_with = "rpc-url",
+        env = "SOROBAN_LEDGER_FILE",
+        help_heading = HEADING_SANDBOX,
+    )]
+    ledger_file: std::path::PathBuf,
+
+    /// Secret 'S' key used to sign the transaction sent to the rpc server
+    #[clap(
+        long = "secret-key",
+        env = "SOROBAN_SECRET_KEY",
+        help_heading = HEADING_RPC,
+    )]
+    secret_key: Option<String>,
+    /// RPC server endpoint
+    #[clap(
+        long,
+        requires = "secret-key",
+        requires = "network-passphrase",
+        env = "SOROBAN_RPC_URL",
+        help_heading = HEADING_RPC,
+    )]
+    rpc_url: Option<String>,
+    /// Network passphrase to sign the transaction sent to the rpc server
+    #[clap(
+        long = "network-passphrase",
+        env = "SOROBAN_NETWORK_PASSPHRASE",
+        help_heading = HEADING_RPC,
+    )]
+    network_passphrase: Option<String>,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Host(#[from] HostError),
+    #[error("error parsing int: {0}")]
+    ParseIntError(#[from] ParseIntError),
+    #[error("internal conversion error: {0}")]
+    TryFromSliceError(#[from] TryFromSliceError),
+    #[error("xdr processing error: {0}")]
+    Xdr(#[from] XdrError),
+    #[error("jsonrpc error: {0}")]
+    JsonRpc(#[from] jsonrpsee_core::Error),
+    #[error("reading file {filepath}: {error}")]
+    CannotReadLedgerFile {
+        filepath: std::path::PathBuf,
+        error: snapshot::Error,
+    },
+    #[error("reading file {filepath}: {error}")]
+    CannotReadContractFile {
+        filepath: std::path::PathBuf,
+        error: io::Error,
+    },
+    #[error("committing file {filepath}: {error}")]
+    CannotCommitLedgerFile {
+        filepath: std::path::PathBuf,
+        error: snapshot::Error,
+    },
+    #[error("cannot parse secret key")]
+    CannotParseSecretKey,
+    #[error(transparent)]
+    Rpc(#[from] rpc::Error),
+}
+
+impl Cmd {
+    pub async fn run(&self) -> Result<(), Error> {
+        let contract = fs::read(&self.wasm).map_err(|e| Error::CannotReadContractFile {
+            filepath: self.wasm.clone(),
+            error: e,
+        })?;
+
+        let res_str = if self.rpc_url.is_some() {
+            self.run_against_rpc_server(contract).await?
+        } else {
+            self.run_in_sandbox(contract)?
+        };
+        println!("{res_str}");
+        Ok(())
+    }
+
+    fn run_in_sandbox(&self, contract: Vec<u8>) -> Result<String, Error> {
+        let mut state =
+            snapshot::read(&self.ledger_file).map_err(|e| Error::CannotReadLedgerFile {
+                filepath: self.ledger_file.clone(),
+                error: e,
+            })?;
+        let wasm_hash = utils::add_contract_code_to_ledger_entries(&mut state.1, contract)?;
+
+        snapshot::commit(state.1, get_default_ledger_info(), [], &self.ledger_file).map_err(
+            |e| Error::CannotCommitLedgerFile {
+                filepath: self.ledger_file.clone(),
+                error: e,
+            },
+        )?;
+        Ok(hex::encode(wasm_hash))
+    }
+
+    async fn run_against_rpc_server(&self, contract: Vec<u8>) -> Result<String, Error> {
+        let client = Client::new(self.rpc_url.as_ref().unwrap());
+        let key = utils::parse_secret_key(self.secret_key.as_ref().unwrap())
+            .map_err(|_| Error::CannotParseSecretKey)?;
+
+        // Get the account sequence number
+        let public_strkey =
+            stellar_strkey::StrkeyPublicKeyEd25519(key.public.to_bytes()).to_string();
+        let account_details = client.get_account(&public_strkey).await?;
+        // TODO: create a cmdline parameter for the fee instead of simply using the minimum fee
+        let fee: u32 = 100;
+        let sequence = account_details.sequence.parse::<i64>()?;
+
+        let (tx, hash) = build_install_contract_code_tx(
+            contract,
+            sequence + 1,
+            fee,
+            self.network_passphrase.as_ref().unwrap(),
+            &key,
+        )?;
+        client.send_transaction(&tx).await?;
+
+        Ok(hex::encode(hash.0))
+    }
+}
+
+pub(crate) fn build_install_contract_code_tx(
+    contract: Vec<u8>,
+    sequence: i64,
+    fee: u32,
+    network_passphrase: &str,
+    key: &ed25519_dalek::Keypair,
+) -> Result<(TransactionEnvelope, Hash), XdrError> {
+    let hash = utils::contract_hash(&contract)?;
+
+    let op = Operation {
+        source_account: None,
+        body: OperationBody::InvokeHostFunction(InvokeHostFunctionOp {
+            function: HostFunction::InstallContractCode(InstallContractCodeArgs {
+                code: contract.try_into()?,
+            }),
+            footprint: LedgerFootprint {
+                read_only: VecM::default(),
+                read_write: vec![ContractCode(LedgerKeyContractCode { hash: hash.clone() })]
+                    .try_into()?,
+            },
+        }),
+    };
+
+    let tx = Transaction {
+        source_account: MuxedAccount::Ed25519(Uint256(key.public.to_bytes())),
+        fee,
+        seq_num: SequenceNumber(sequence),
+        cond: Preconditions::None,
+        memo: Memo::None,
+        operations: vec![op].try_into()?,
+        ext: TransactionExt::V0,
+    };
+
+    let envelope = utils::sign_transaction(key, &tx, network_passphrase)?;
+
+    Ok((envelope, hash))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_install_contract_code() {
+        let result = build_install_contract_code_tx(
+            b"foo".to_vec(),
+            300,
+            1,
+            "Public Global Stellar Network ; September 2015",
+            &utils::parse_secret_key("SBFGFF27Y64ZUGFAIG5AMJGQODZZKV2YQKAVUUN4HNE24XZXD2OEUVUP")
+                .unwrap(),
+        );
+
+        assert!(result.is_ok());
+    }
+}

--- a/cmd/soroban-cli/src/invoke.rs
+++ b/cmd/soroban-cli/src/invoke.rs
@@ -255,11 +255,9 @@ impl Cmd {
 
     pub async fn run(&self, matches: &clap::ArgMatches) -> Result<(), Error> {
         let contract_id: [u8; 32] =
-            utils::contract_id_from_str(&self.contract_id).map_err(|e| {
-                Error::CannotParseContractId {
-                    contract_id: self.contract_id.clone(),
-                    error: e,
-                }
+            utils::id_from_str(&self.contract_id).map_err(|e| Error::CannotParseContractId {
+                contract_id: self.contract_id.clone(),
+                error: e,
             })?;
 
         if self.rpc_url.is_some() {
@@ -360,8 +358,10 @@ impl Cmd {
                 filepath: f.clone(),
                 error: e,
             })?;
-            utils::add_contract_to_ledger_entries(&mut state.1, contract_id, contract)
-                .map_err(Error::CannotAddContractToLedgerEntries)?;
+            let wasm_hash = utils::add_contract_code_to_ledger_entries(&mut state.1, contract)
+                .map_err(Error::CannotAddContractToLedgerEntries)?
+                .0;
+            utils::add_contract_to_ledger_entries(&mut state.1, contract_id, wasm_hash);
         }
 
         // Create source account, adding it to the ledger if not already present.

--- a/cmd/soroban-cli/src/main.rs
+++ b/cmd/soroban-cli/src/main.rs
@@ -4,6 +4,7 @@ mod completion;
 mod deploy;
 mod gen;
 mod inspect;
+mod install;
 mod invoke;
 mod jsonrpc;
 mod network;
@@ -51,6 +52,8 @@ enum Cmd {
     Token(token::Root),
     /// Deploy a WASM file as a contract
     Deploy(deploy::Cmd),
+    /// Install a WASM file to the ledger without creating a contract instance
+    Install(install::Cmd),
     /// Generate code client bindings for a contract
     Gen(gen::Cmd),
 
@@ -84,6 +87,8 @@ enum CmdError {
     #[error(transparent)]
     Deploy(#[from] deploy::Error),
     #[error(transparent)]
+    Install(#[from] install::Error),
+    #[error(transparent)]
     Xdr(#[from] xdr::Error),
 }
 
@@ -100,6 +105,7 @@ async fn run(cmd: Cmd, matches: &mut clap::ArgMatches) -> Result<(), CmdError> {
         Cmd::Token(token) => token.run().await?,
         Cmd::Gen(gen) => gen.run()?,
         Cmd::Deploy(deploy) => deploy.run().await?,
+        Cmd::Install(install) => install.run().await?,
         Cmd::Xdr(xdr) => xdr.run()?,
         Cmd::Version(version) => version.run(),
         Cmd::Completion(completion) => completion.run(&mut Root::command()),

--- a/cmd/soroban-cli/src/read.rs
+++ b/cmd/soroban-cli/src/read.rs
@@ -94,11 +94,9 @@ impl Cmd {
     #[allow(clippy::too_many_lines)]
     pub fn run(&self) -> Result<(), Error> {
         let contract_id: [u8; 32] =
-            utils::contract_id_from_str(&self.contract_id).map_err(|e| {
-                Error::CannotParseContractId {
-                    contract_id: self.contract_id.clone(),
-                    error: e,
-                }
+            utils::id_from_str(&self.contract_id).map_err(|e| Error::CannotParseContractId {
+                contract_id: self.contract_id.clone(),
+                error: e,
             })?;
         let key = if let Some(key) = &self.key {
             Some(

--- a/cmd/soroban-cli/src/serve.rs
+++ b/cmd/soroban-cli/src/serve.rs
@@ -208,7 +208,7 @@ fn get_contract_data(
 ) -> Result<Value, Error> {
     // Initialize storage and host
     let state = snapshot::read(ledger_file)?;
-    let contract_id: [u8; 32] = utils::contract_id_from_str(&contract_id_hex.to_string())?;
+    let contract_id: [u8; 32] = utils::id_from_str(&contract_id_hex.to_string())?;
     let key = ScVal::from_xdr_base64(key_xdr)?;
 
     let snap = Rc::new(snapshot::Snap {

--- a/cmd/soroban-cli/src/token/create.rs
+++ b/cmd/soroban-cli/src/token/create.rs
@@ -118,7 +118,7 @@ impl Cmd {
     pub async fn run(&self) -> Result<(), Error> {
         // Hack: re-use contract_id_from_str to parse the 32-byte salt hex.
         let salt: [u8; 32] =
-            utils::contract_id_from_str(&self.salt).map_err(|_| Error::CannotParseSalt {
+            utils::id_from_str(&self.salt).map_err(|_| Error::CannotParseSalt {
                 salt: self.salt.clone(),
             })?;
 

--- a/tests/it/e2e_rpc_server.rs
+++ b/tests/it/e2e_rpc_server.rs
@@ -27,6 +27,40 @@ fn e2e_deploy_and_invoke_contract_against_rpc_server() {
         .success();
 }
 
+// e2e tests are ignore by default
+#[test]
+#[ignore]
+fn e2e_install_deploy_and_invoke_contract_against_rpc_server() {
+    // This test assumes a fresh standalone network rpc server on port 8000
+    Standalone::new_cmd()
+        .arg("install")
+        .arg("--wasm")
+        .arg(test_wasm("test_hello_world"))
+        .assert()
+        .stdout("86270dcca8dd4e7131c89dcc61223f096d7a1fa4a1d90c39dd6542b562369ecc\n")
+        .stderr("success\n")
+        .success();
+
+    Standalone::new_cmd()
+        .arg("deploy")
+        .arg("--wasm-hash=86270dcca8dd4e7131c89dcc61223f096d7a1fa4a1d90c39dd6542b562369ecc")
+        .arg("--salt=0")
+        .assert()
+        .stdout("b392cd0044315873f32307bfd535a9cbbb0402a57133ff7283afcae66be8174b\n")
+        .stderr("success\n")
+        .success();
+
+    Standalone::new_cmd()
+        .arg("invoke")
+        .arg("--id=b392cd0044315873f32307bfd535a9cbbb0402a57133ff7283afcae66be8174b")
+        .arg("--fn=hello")
+        .arg("--arg=world")
+        .assert()
+        .stdout("[\"Hello\",\"world\"]\n")
+        .stderr("success\n")
+        .success();
+}
+
 #[test]
 #[ignore]
 fn create_and_invoke_token_contract_against_rpc_server() {

--- a/tests/it/invoke_sandbox.rs
+++ b/tests/it/invoke_sandbox.rs
@@ -39,3 +39,34 @@ fn source_account_exists() {
         .success()
         .stdout("true\n");
 }
+
+#[test]
+fn install_wasm_then_deploy_contract() {
+    Sandbox::new_cmd()
+        .arg("install")
+        .arg("--wasm")
+        .arg(test_wasm("test_hello_world"))
+        .assert()
+        .success()
+        .stdout("86270dcca8dd4e7131c89dcc61223f096d7a1fa4a1d90c39dd6542b562369ecc\n");
+
+    Sandbox::new_cmd()
+        .arg("deploy")
+        .arg("--wasm-hash=86270dcca8dd4e7131c89dcc61223f096d7a1fa4a1d90c39dd6542b562369ecc")
+        .arg("--id=1")
+        .assert()
+        .success()
+        .stdout("0000000000000000000000000000000000000000000000000000000000000001\n");
+}
+
+#[test]
+fn deploy_contract_with_wasm_file() {
+    Sandbox::new_cmd()
+        .arg("deploy")
+        .arg("--wasm")
+        .arg(test_wasm("test_hello_world"))
+        .arg("--id=1")
+        .assert()
+        .success()
+        .stdout("0000000000000000000000000000000000000000000000000000000000000001\n");
+}

--- a/tests/it/invoke_sandbox.rs
+++ b/tests/it/invoke_sandbox.rs
@@ -42,8 +42,11 @@ fn source_account_exists() {
 
 #[test]
 fn install_wasm_then_deploy_contract() {
+    let ledger = temp_ledger_file();
     Sandbox::new_cmd()
         .arg("install")
+        .arg("--ledger-file")
+        .arg(&ledger)
         .arg("--wasm")
         .arg(test_wasm("test_hello_world"))
         .assert()
@@ -52,6 +55,8 @@ fn install_wasm_then_deploy_contract() {
 
     Sandbox::new_cmd()
         .arg("deploy")
+        .arg("--ledger-file")
+        .arg(&ledger)
         .arg("--wasm-hash=86270dcca8dd4e7131c89dcc61223f096d7a1fa4a1d90c39dd6542b562369ecc")
         .arg("--id=1")
         .assert()
@@ -63,6 +68,8 @@ fn install_wasm_then_deploy_contract() {
 fn deploy_contract_with_wasm_file() {
     Sandbox::new_cmd()
         .arg("deploy")
+        .arg("--ledger-file")
+        .arg(temp_ledger_file())
         .arg("--wasm")
         .arg(test_wasm("test_hello_world"))
         .arg("--id=1")


### PR DESCRIPTION
### What

- Added `install` command to install the WASM without creating a contract instance
- Added `--wasm-hash` option to `deploy` command (not `invoke` for now) to use the installed WASM

### Why

This supports the contract factory use case that requires to install the contract code separately and also showcases the new API capabilities.

### Known limitations

This is still imperfect - e.g. a WASM hash should probably be returned when the contract is deployed, but I'm not sure what would be the right way to display it.
