### PR TITLE
re-incorporate xdr commit into version command

### DIFF
--- a/cmd/soroban-rpc/main.go
+++ b/cmd/soroban-rpc/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stellar/go/network"
 	"github.com/stellar/go/support/config"
 	supportlog "github.com/stellar/go/support/log"
+	goxdr "github.com/stellar/go/xdr"
 	localConfig "github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/config"
 	"github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/daemon"
 )
@@ -123,8 +124,7 @@ func main() {
 					branch = ""
 				}
 				fmt.Printf("soroban-rpc %s (%s) %s\n", localConfig.Version, localConfig.CommitHash, branch)
-				// TODO: Should we include this??
-				// fmt.Printf("stellar-xdr %s\n", goxdr.CommitHash)
+				fmt.Printf("stellar-xdr %s\n", goxdr.CommitHash)
 			}
 		},
 	}


### PR DESCRIPTION
### What

Bring back the xdr commit hash in the version output.

### Why

It was accidentally removed in #274 

### Known limitations

[TODO or N/A]
