### PR TITLE
Run soroban-rpc tests on ubuntu focal so stellar-core can install

### DIFF
--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -11,7 +11,7 @@ jobs:
     name: Integration tests
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         go: [1.19.1]
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
### What

Run the tests on ubuntu focal.

### Why

Because stellar-core doesn't currently install on ubuntu jammy.

### Known limitations

[TODO or N/A]
