### PR TITLE
Bugfixes for e2e tests in release/v0.3.0 branch

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -81,7 +81,7 @@ jobs:
       - run: rustup target add wasm32-unknown-unknown
       # TODO: we should probably manage the container in the test itself
       - run: make build-test-wasms
-      - run: docker run -d -p 8000:8000 stellar/quickstart:pr-389-soroban-dev --standalone --enable-soroban-rpc --enable-core-artificially-accelerate-time-for-testing --protocol-version 20
+      - run: docker run -d -p 8000:8000 stellar/quickstart:soroban-dev --standalone --enable-soroban-rpc --enable-core-artificially-accelerate-time-for-testing --protocol-version 20
       - run: while ! [ "$(curl -s --fail localhost:8000 | jq '.history_latest_ledger')" -gt 0 ]; do echo waiting; sleep 1; done
       # Run e2e tests sequentially to avoid	sequence number	mismatches
       # TODO: use different accounts in different tests to avoid the data race

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -81,7 +81,7 @@ jobs:
       - run: rustup target add wasm32-unknown-unknown
       # TODO: we should probably manage the container in the test itself
       - run: make build-test-wasms
-      - run: docker run -d -p 8000:8000 stellar/quickstart:soroban-dev --standalone --enable-soroban-rpc --enable-core-artificially-accelerate-time-for-testing --protocol-version 20
+      - run: docker run -d -p 8000:8000 stellar/quickstart:pr-389-soroban-dev --standalone --enable-soroban-rpc --enable-core-artificially-accelerate-time-for-testing --protocol-version 20
       - run: while ! [ "$(curl -s --fail localhost:8000 | jq '.history_latest_ledger')" -gt 0 ]; do echo waiting; sleep 1; done
       # Run e2e tests sequentially to avoid	sequence number	mismatches
       # TODO: use different accounts in different tests to avoid the data race

--- a/cmd/soroban-cli/src/deploy.rs
+++ b/cmd/soroban-cli/src/deploy.rs
@@ -211,13 +211,13 @@ impl Cmd {
         // Get the account sequence number
         let public_strkey =
             stellar_strkey::StrkeyPublicKeyEd25519(key.public.to_bytes()).to_string();
-        let account_details = client.get_account(&public_strkey).await?;
         // TODO: create a cmdline parameter for the fee instead of simply using the minimum fee
         let fee: u32 = 100;
-        let sequence = account_details.sequence.parse::<i64>()?;
 
         let wasm_hash = match contract_src {
             ContractSource::Wasm(wasm) => {
+                let account_details = client.get_account(&public_strkey).await?;
+                let sequence = account_details.sequence.parse::<i64>()?;
                 let (tx, hash) = build_install_contract_code_tx(
                     wasm,
                     sequence + 1,
@@ -231,9 +231,11 @@ impl Cmd {
             ContractSource::WasmHash(wasm_hash) => Hash(wasm_hash),
         };
 
+        let account_details = client.get_account(&public_strkey).await?;
+        let sequence = account_details.sequence.parse::<i64>()?;
         let (tx, contract_id) = build_create_contract_tx(
             wasm_hash,
-            sequence + 2,
+            sequence + 1,
             fee,
             self.network_passphrase.as_ref().unwrap(),
             salt,

--- a/cmd/soroban-cli/tests/it/e2e_rpc_server.rs
+++ b/cmd/soroban-cli/tests/it/e2e_rpc_server.rs
@@ -44,15 +44,15 @@ fn e2e_install_deploy_and_invoke_contract_against_rpc_server() {
     Standalone::new_cmd()
         .arg("deploy")
         .arg("--wasm-hash=86270dcca8dd4e7131c89dcc61223f096d7a1fa4a1d90c39dd6542b562369ecc")
-        .arg("--salt=0")
+        .arg("--salt=2")
         .assert()
-        .stdout("b392cd0044315873f32307bfd535a9cbbb0402a57133ff7283afcae66be8174b\n")
+        .stdout("d437d1a67f0ae578b36dd863e60995bfc8850528b9a85c3e643e1c28eb51c141\n")
         .stderr("success\n")
         .success();
 
     Standalone::new_cmd()
         .arg("invoke")
-        .arg("--id=b392cd0044315873f32307bfd535a9cbbb0402a57133ff7283afcae66be8174b")
+        .arg("--id=d437d1a67f0ae578b36dd863e60995bfc8850528b9a85c3e643e1c28eb51c141")
         .arg("--fn=hello")
         .arg("--arg=world")
         .assert()


### PR DESCRIPTION
### What

- Fix bug in `soroban deploy --wasm-hash` sequence calculation introduced in https://github.com/stellar/soroban-tools/commit/eadacececc2b1071232db7ab045738d461908481
  - Incidentally fixes https://github.com/stellar/soroban-tools/issues/290
- Fix conflicting contract ids in e2e tests
  - The token contract and the newly installed one were using the same salt, resulting in a conflict between the tests.
- Use the temporary `stellar/quickstart:pr-389-soroban-dev` to run e2e tests so they work for now.
- Remove hardcoded `--salt` params from e2e tests altogether.
  - This means the cli will autogenerate a random salt for each one.
  - The e2e tests are then independent from each other and are less likely to conflict.
  - The e2e do not need a clean network to run anymore.

### Why

To fix the e2e tests for https://github.com/stellar/soroban-tools/pull/291

### Known limitations

[TODO or N/A]
