### PR TITLE
Use an older version of glibc for published binaries on Linux

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,9 +19,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-20.04 # Use 20.04 to get an older version of glibc for increased compat
             target: x86_64-unknown-linux-gnu
-          - os: ubuntu-20.04
+          - os: ubuntu-20.04 # Use 20.04 to get an older version of glibc for increased compat
             target: aarch64-unknown-linux-gnu
           - os: macos-latest
             target: x86_64-apple-darwin

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,9 +19,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             target: aarch64-unknown-linux-gnu
           - os: macos-latest
             target: x86_64-apple-darwin


### PR DESCRIPTION
### What
Build Linux binaries on Ubuntu 20 instead of Ubuntu 22.

### Why
To get an older version of glibc, so that the Linux binaries are compatible with a wider variety of Linux distributions in use right now.