### PR TITLE
chore: StrValError --> and implemented using thiserror

### DIFF
--- a/cmd/soroban-cli/src/invoke.rs
+++ b/cmd/soroban-cli/src/invoke.rs
@@ -24,11 +24,7 @@ use stellar_strkey::StrkeyPublicKeyEd25519;
 
 use crate::rpc::Client;
 use crate::utils::{create_ledger_footprint, default_account_ledger_entry};
-use crate::{
-    rpc, snapshot,
-    strval::{self, StrValError},
-    utils,
-};
+use crate::{rpc, snapshot, strval, utils};
 use crate::{HEADING_RPC, HEADING_SANDBOX};
 
 #[derive(Parser, Debug)]
@@ -105,7 +101,7 @@ pub struct Cmd {
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("parsing argument {arg}: {error}")]
-    CannotParseArg { arg: String, error: StrValError },
+    CannotParseArg { arg: String, error: strval::Error },
     #[error("parsing XDR arg {arg}: {error}")]
     CannotParseXdrArg { arg: String, error: XdrError },
     #[error("cannot add contract to ledger entries: {0}")]
@@ -149,7 +145,7 @@ pub enum Error {
     #[error("argument count ({current}) surpasses maximum allowed count ({maximum})")]
     MaxNumberOfArgumentsReached { current: usize, maximum: usize },
     #[error("cannot print result {result:?}: {error}")]
-    CannotPrintResult { result: ScVal, error: StrValError },
+    CannotPrintResult { result: ScVal, error: strval::Error },
     #[error("xdr processing error: {0}")]
     Xdr(#[from] XdrError),
     #[error("error parsing int: {0}")]

--- a/cmd/soroban-cli/src/read.rs
+++ b/cmd/soroban-cli/src/read.rs
@@ -13,11 +13,7 @@ use soroban_env_host::{
     HostError,
 };
 
-use crate::{
-    snapshot,
-    strval::{self, StrValError},
-    utils, HEADING_SANDBOX,
-};
+use crate::{snapshot, strval, utils, HEADING_SANDBOX};
 
 #[derive(Parser, Debug)]
 pub struct Cmd {
@@ -58,7 +54,7 @@ pub enum Output {
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("parsing key {key}: {error}")]
-    CannotParseKey { key: String, error: StrValError },
+    CannotParseKey { key: String, error: strval::Error },
     #[error("parsing XDR key {key}: {error}")]
     CannotParseXdrKey { key: String, error: XdrError },
     #[error("reading file {filepath}: {error}")]
@@ -72,7 +68,7 @@ pub enum Error {
         error: FromHexError,
     },
     #[error("cannot print result {result:?}: {error}")]
-    CannotPrintResult { result: ScVal, error: StrValError },
+    CannotPrintResult { result: ScVal, error: strval::Error },
     #[error("cannot print result {result:?}: {error}")]
     CannotPrintJsonResult {
         result: ScVal,

--- a/cmd/soroban-cli/src/serve.rs
+++ b/cmd/soroban-cli/src/serve.rs
@@ -22,7 +22,7 @@ use warp::{http::Response, Filter};
 
 use crate::network::SANDBOX_NETWORK_PASSPHRASE;
 use crate::snapshot;
-use crate::strval::StrValError;
+use crate::strval;
 use crate::utils::{self, create_ledger_footprint};
 use crate::{jsonrpc, HEADING_SANDBOX};
 
@@ -48,7 +48,7 @@ pub enum Error {
     #[error("io")]
     Io(#[from] io::Error),
     #[error("strval")]
-    StrVal(#[from] StrValError),
+    StrVal(#[from] strval::Error),
     #[error("xdr")]
     Xdr(#[from] XdrError),
     #[error("host")]

--- a/cmd/soroban-cli/src/strval.rs
+++ b/cmd/soroban-cli/src/strval.rs
@@ -1,5 +1,5 @@
 use serde_json::Value;
-use std::{error::Error, fmt::Display, str::FromStr};
+use std::str::FromStr;
 
 use soroban_env_host::xdr::{
     AccountId, BytesM, Error as XdrError, PublicKey, ScMap, ScMapEntry, ScObject, ScSpecTypeDef,
@@ -11,32 +11,16 @@ use stellar_strkey::StrkeyPublicKeyEd25519;
 
 use crate::utils;
 
-#[derive(Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum StrValError {
+    #[error("an unknown error occurred")]
     UnknownError,
+    #[error("value is not parseable to {0:#?}")]
     InvalidValue(Option<ScSpecTypeDef>),
+    #[error(transparent)]
     Xdr(XdrError),
+    #[error(transparent)]
     Serde(serde_json::Error),
-}
-
-impl Error for StrValError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        None
-    }
-}
-
-impl Display for StrValError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "parse error: ")?;
-        match self {
-            Self::UnknownError => write!(f, "an unknown error occurred")?,
-            Self::InvalidValue(Some(s)) => write!(f, "value is not parseable to {:?}", s)?,
-            Self::InvalidValue(None) => write!(f, "value is not parseable to type")?,
-            Self::Serde(e) => write!(f, "{e}")?,
-            Self::Xdr(e) => write!(f, "{e}")?,
-        };
-        Ok(())
-    }
 }
 
 impl From<()> for StrValError {


### PR DESCRIPTION
### What

Rename StrValError to Error and implement it with thiserror. Also remove Error suffix for `UnknownError` since `Error::Unknown` is clearly an error.

### Why

Make it more idiomatic and follow the same convention for errors used across the crate.

### Known limitations

[TODO or N/A]
