### PR TITLE
Use LedgerSnapshot::update to update snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1790,7 +1790,7 @@ dependencies = [
 [[package]]
 name = "soroban-auth"
 version = "0.3.2"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=309e63c#309e63c4d1f6d5d567580dedfe2d7dc06023022e"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=7799198f#7799198f6fa0051a6ced6a28f04fc6c841b57bf5"
 dependencies = [
  "soroban-sdk",
 ]
@@ -1833,7 +1833,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.11"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=995386a#995386a39bce05133c26361aa18fb98afbcb2fdd"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=94a347c#94a347cd18b59a1123dcb6a82faa8ca46fcc5d42"
 dependencies = [
  "crate-git-revision",
  "serde",
@@ -1846,7 +1846,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.11"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=995386a#995386a39bce05133c26361aa18fb98afbcb2fdd"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=94a347c#94a347cd18b59a1123dcb6a82faa8ca46fcc5d42"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1855,7 +1855,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.11"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=995386a#995386a39bce05133c26361aa18fb98afbcb2fdd"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=94a347c#94a347cd18b59a1123dcb6a82faa8ca46fcc5d42"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -1877,7 +1877,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.11"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=995386a#995386a39bce05133c26361aa18fb98afbcb2fdd"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=94a347c#94a347cd18b59a1123dcb6a82faa8ca46fcc5d42"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1889,7 +1889,7 @@ dependencies = [
 [[package]]
 name = "soroban-ledger-snapshot"
 version = "0.3.2"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=309e63c#309e63c4d1f6d5d567580dedfe2d7dc06023022e"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=7799198f#7799198f6fa0051a6ced6a28f04fc6c841b57bf5"
 dependencies = [
  "serde",
  "serde_json",
@@ -1900,7 +1900,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.11"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=995386a#995386a39bce05133c26361aa18fb98afbcb2fdd"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=94a347c#94a347cd18b59a1123dcb6a82faa8ca46fcc5d42"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1911,7 +1911,7 @@ dependencies = [
 [[package]]
 name = "soroban-sdk"
 version = "0.3.2"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=309e63c#309e63c4d1f6d5d567580dedfe2d7dc06023022e"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=7799198f#7799198f6fa0051a6ced6a28f04fc6c841b57bf5"
 dependencies = [
  "bytes-lit",
  "ed25519-dalek",
@@ -1926,7 +1926,7 @@ dependencies = [
 [[package]]
 name = "soroban-sdk-macros"
 version = "0.3.2"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=309e63c#309e63c4d1f6d5d567580dedfe2d7dc06023022e"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=7799198f#7799198f6fa0051a6ced6a28f04fc6c841b57bf5"
 dependencies = [
  "darling",
  "itertools",
@@ -1942,7 +1942,7 @@ dependencies = [
 [[package]]
 name = "soroban-spec"
 version = "0.3.2"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=309e63c#309e63c4d1f6d5d567580dedfe2d7dc06023022e"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=7799198f#7799198f6fa0051a6ced6a28f04fc6c841b57bf5"
 dependencies = [
  "base64",
  "darling",
@@ -1963,7 +1963,7 @@ dependencies = [
 [[package]]
 name = "soroban-token-spec"
 version = "0.3.2"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=309e63c#309e63c4d1f6d5d567580dedfe2d7dc06023022e"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=7799198f#7799198f6fa0051a6ced6a28f04fc6c841b57bf5"
 dependencies = [
  "soroban-auth",
  "soroban-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,27 +10,27 @@ default-members = ["cmd/soroban-cli"]
 [workspace.dependencies.soroban-env-host]
 version = "0.0.11"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "995386a"
+rev = "94a347c"
 
 [workspace.dependencies.soroban-spec]
 version = "0.3.1"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "309e63c"
+rev = "7799198f"
 
 [workspace.dependencies.soroban-token-spec]
 version = "0.3.1"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "309e63c"
+rev = "7799198f"
 
 [workspace.dependencies.soroban-sdk]
 version = "0.3.1"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "309e63c"
+rev = "7799198f"
 
 [workspace.dependencies.soroban-ledger-snapshot]
 version = "0.3.1"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "309e63c"
+rev = "7799198f"
 
 [workspace.dependencies.stellar-strkey]
 version = "0.0.6"

--- a/cmd/soroban-cli/src/invoke.rs
+++ b/cmd/soroban-cli/src/invoke.rs
@@ -392,7 +392,7 @@ impl Cmd {
         let mut ledger_info = state.ledger_info();
         ledger_info.sequence_number += 1;
         ledger_info.timestamp += 5;
-        h.set_ledger_info(ledger_info.clone());
+        h.set_ledger_info(ledger_info);
 
         let host_function_params =
             self.build_host_function_parameters(contract_id, &spec_entries, matches)?;
@@ -404,6 +404,8 @@ impl Cmd {
         })?;
 
         println!("{res_str}");
+
+        state.update(&h);
 
         let (storage, budget, events) = h.try_finish().map_err(|_h| {
             HostError::from(ScStatus::HostStorageError(
@@ -436,8 +438,6 @@ impl Cmd {
             }
         }
 
-        state.set_ledger_info(ledger_info);
-        state.update_entries(&storage.map);
         state
             .write_file(&self.ledger_file)
             .map_err(|e| Error::CannotCommitLedgerFile {

--- a/cmd/soroban-cli/src/token/create.rs
+++ b/cmd/soroban-cli/src/token/create.rs
@@ -10,9 +10,9 @@ use soroban_env_host::{
         AccountId, ContractId, CreateContractArgs, Error as XdrError, Hash, HashIdPreimage,
         HashIdPreimageSourceAccountContractId, HostFunction, InvokeHostFunctionOp, LedgerFootprint,
         LedgerKey::ContractData, LedgerKeyContractData, Memo, MuxedAccount, Operation,
-        OperationBody, Preconditions, PublicKey, ScContractCode, ScHostStorageErrorCode, ScMap,
-        ScMapEntry, ScObject, ScStatic::LedgerKeyContractCode, ScStatus, ScVal, ScVec,
-        SequenceNumber, Transaction, TransactionEnvelope, TransactionExt, Uint256, VecM, WriteXdr,
+        OperationBody, Preconditions, PublicKey, ScContractCode, ScMap, ScMapEntry, ScObject,
+        ScStatic::LedgerKeyContractCode, ScVal, ScVec, SequenceNumber, Transaction,
+        TransactionEnvelope, TransactionExt, Uint256, VecM, WriteXdr,
     },
     Host, HostError,
 };
@@ -184,7 +184,7 @@ impl Cmd {
         let mut ledger_info = state.ledger_info();
         ledger_info.sequence_number += 1;
         ledger_info.timestamp += 5;
-        h.set_ledger_info(ledger_info.clone());
+        h.set_ledger_info(ledger_info);
 
         let contract_id =
             get_contract_id(salt, admin.clone(), network::SANDBOX_NETWORK_PASSPHRASE)?;
@@ -203,14 +203,7 @@ impl Cmd {
             decimal,
         )))?;
 
-        let (storage, _, _) = h.try_finish().map_err(|_h| {
-            HostError::from(ScStatus::HostStorageError(
-                ScHostStorageErrorCode::UnknownError,
-            ))
-        })?;
-
-        state.set_ledger_info(ledger_info);
-        state.update_entries(&storage.map);
+        state.update(&h);
         state
             .write_file(&self.ledger_file)
             .map_err(|e| Error::CannotCommitLedgerFile {


### PR DESCRIPTION
### What
Use LedgerSnapshot::update to update snapshot instead of unpacking the host and updating ledger info and entries separately.

### Why
The update function that takes a host and updates a snapshot was added in https://github.com/stellar/rs-soroban-sdk/pull/802 to reduce the amount of code applications like the CLI needed to write to update the snapshot. It also moves responsibility and knowledge about what it means to update a snapshot into the snapshot library, where that knowledge is specialized.