### PR TITLE
soroban-cli, soroban-rpc: Simplify topic matching code.

### DIFF
--- a/cmd/soroban-cli/src/events.rs
+++ b/cmd/soroban-cli/src/events.rs
@@ -351,26 +351,11 @@ impl Cmd {
 // [Code
 // Reference](https://github.com/stellar/soroban-tools/blob/bac1be79e8c2590c9c35ad8a0168aab0ae2b4171/cmd/soroban-rpc/internal/methods/get_events.go#L182-L203)
 pub fn does_topic_match(topic: &[String], filter: &[String]) -> bool {
-    let mut idx = 0;
-
-    for segment in filter {
-        if idx >= topic.len() {
-            // Nothing to match, need at least one segment.
-            return false;
-        }
-
-        if *segment == "*" {
-            // One-segment wildcard: ignore this token
-        } else if *segment != topic[idx] {
-            // Exact match the ScVal (decodability is assumed)
-            return false;
-        }
-
-        idx += 1;
-    }
-
-    // Check we had no leftovers
-    idx >= topic.len()
+    filter.len() == topic.len()
+        && filter
+            .iter()
+            .enumerate()
+            .all(|(i, s)| *s == "*" || topic[i] == *s)
 }
 
 pub fn print_event(event: &rpc::Event) -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
### What
The topic matching code was a little convoluted given the simplified invariants it needs to maintain:
 - the topic filter needs to match the **number** of segments exactly (e.g. `transfer/GABC/10` should not match `transfer/GABC`)
 - a filter segment should match the topic segment **exactly** or be a wildcard (`*`)

### Why
Simpler code = easier to read/maintain/debug.

### Known limitations
Both of these have unit tests, so N/A.