### PR TITLE
Disable optional features in wasm-opt

### DIFF
--- a/cmd/soroban-cli/src/optimize.rs
+++ b/cmd/soroban-cli/src/optimize.rs
@@ -42,6 +42,11 @@ impl Cmd {
         let mut options = OptimizationOptions::new_optimize_for_size_aggressively();
         options.converge = true;
 
+        // Don't let wasm-opt use any optional features,
+        // including the default signext, and mutable globals.
+        // Soroban disables all optional wasm features in wasmi.
+        options.mvp_features_only();
+
         options
             .run(&self.wasm, &wasm_out)
             .map_err(Error::OptimizationError)?;


### PR DESCRIPTION
### What

Disable optional features when calling wasm-opt.

### Why

In https://github.com/stellar/soroban-tools/pull/331 I mentioned that the new wasm-opt enables signext and mutable globals by default.

After a closer look, soroban disables these features explicitly when setting up the wasmi vm, so it seems to me they should be disabled in wasm-opt too.

### Known limitations

na