### PR TITLE
integration testing: fix "unable to find commit hash" during tests

### DIFF
--- a/cmd/soroban-rpc/internal/test/integration.go
+++ b/cmd/soroban-rpc/internal/test/integration.go
@@ -399,7 +399,8 @@ func findCommitHash(shortCommitHash string) (string, error) {
 			if reviewedHashes[pHash] {
 				continue
 			}
-			pCommit, err := repo.CommitObject(pHash)
+			var pCommit *object.Commit
+			pCommit, err = repo.CommitObject(pHash)
 			if err != nil {
 				fmt.Printf("unable to get commit hash %s", pHash.String())
 				return err
@@ -430,6 +431,7 @@ func findGoMonorepoCommit(composePath string) string {
 	panicIf(err)
 	commitHash, err := findCommitHash(shortCommitHash)
 	panicIf(err)
+
 	return commitHash
 }
 

--- a/cmd/soroban-rpc/internal/test/integration.go
+++ b/cmd/soroban-rpc/internal/test/integration.go
@@ -402,7 +402,7 @@ func findCommitHash(shortCommitHash string) (string, error) {
 		return revCommit, nil
 	}
 	// otherwise, this commit might be in one of the branches.
-	return "", errors.New("unable to find full hash")
+	return "", fmt.Errorf("unable to find full hash for commit hash '%s'", shortCommitHash)
 }
 
 func findGoMonorepoCommit(composePath string) string {

--- a/cmd/soroban-rpc/internal/test/integration.go
+++ b/cmd/soroban-rpc/internal/test/integration.go
@@ -19,6 +19,7 @@ import (
 
 	git "github.com/go-git/go-git/v5"
 
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/plumbing/storer"
 	"github.com/go-git/go-git/v5/storage/memory"
@@ -382,27 +383,45 @@ func findCommitHash(shortCommitHash string) (string, error) {
 		fmt.Printf("unable to get log entries at %s for %s: %v\n", path, shortCommitHash, err)
 		return "", err
 	}
+	reviewedHashes := make(map[plumbing.Hash]bool, 0)
 	// ... just iterates over the commits, looking for a commit with a specific hash.
 	var revCommit string
-	err = cIter.ForEach(func(c *object.Commit) error {
+	var lookupRecursive func(c *object.Commit) error
+	lookupRecursive = func(c *object.Commit) error {
 		revString := strings.ToLower(c.Hash.String())
 		if strings.HasPrefix(revString, lookoutCommit) {
 			// found !
 			revCommit = revString
 			return storer.ErrStop
 		}
+		reviewedHashes[c.Hash] = true
+		for _, pHash := range c.ParentHashes {
+			if reviewedHashes[pHash] {
+				continue
+			}
+			pCommit, err := repo.CommitObject(pHash)
+			if err != nil {
+				fmt.Printf("unable to get commit hash %s", pHash.String())
+				return err
+			}
+			err = lookupRecursive(pCommit)
+			if err != nil {
+				return err
+			}
+		}
 		return nil
-	})
-
+	}
+	err = cIter.ForEach(lookupRecursive)
 	if err != nil && err != storer.ErrStop {
-		fmt.Printf("unable to iterate on lof entries for %s : %v\n", path, err)
+		fmt.Printf("unable to iterate on log entries for %s : %v\n", path, err)
 		return "", err
 	}
+
 	if revCommit != "" {
 		return revCommit, nil
 	}
 	// otherwise, this commit might be in one of the branches.
-	return "", fmt.Errorf("unable to find full hash for commit hash '%s'", shortCommitHash)
+	return "", fmt.Errorf("unable to find full hash for commit hash '%s' for '%s'", lookoutCommit, path)
 }
 
 func findGoMonorepoCommit(composePath string) string {
@@ -411,7 +430,6 @@ func findGoMonorepoCommit(composePath string) string {
 	panicIf(err)
 	commitHash, err := findCommitHash(shortCommitHash)
 	panicIf(err)
-
 	return commitHash
 }
 


### PR DESCRIPTION
### What

The current code was producing the message `unable to find commit hash` without specifying what commit hash was being looked for. 

### Why

The code for scanning the commits was incorrect. It should have evaluated parents of commits in order to properly find the full hash based on the short hash.

### Known limitations

N/A
