### PR TITLE
soroban-rpc: fix docker-compose error in integration tests

### DIFF
--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -42,6 +42,11 @@ jobs:
           sudo bash -c 'echo "deb https://apt.stellar.org focal unstable" > /etc/apt/sources.list.d/SDF-unstable.list'
           sudo apt-get update && sudo apt-get install -y stellar-core="$PROTOCOL_20_CORE_DEBIAN_PKG_VERSION"
           echo "Using stellar core version $(stellar-core version)"
+      
+      # Docker-compose's remote contexts on Ubuntu 20 started failing with an OpenSSL versioning error.
+      # See https://stackoverflow.com/questions/66579446/error-executing-docker-compose-building-webserver-unable-to-prepare-context-un
+      - name: Work around Docker Compose problem
+        run: sudo pip3 install docker-compose
 
       - name: Build Soroban RPC reproducible build
         run: |


### PR DESCRIPTION
The soroban-rpc integration tests started to fail with errors like: 

```
unable to prepare context: unable to 'git clone' to temporary context directory: error fetching: /usr/lib/git-core/git-remote-https: /tmp/_MEIRQrBNt/libcrypto.so.1.1: version `OPENSSL_1_1_1' not found (required by /lib/x86_64-linux-gnu/libssh.so.4)
```

See https://github.com/stellar/soroban-tools/actions/runs/3932760675/jobs/6725700781