### PR TITLE
Bump to new env and SDK versions, fix clippy issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1791,8 +1791,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-auth"
-version = "0.4.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=980778ec#980778ecc78e57178fd0226fed25b341a17c1eac"
+version = "0.4.3"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=e1c3de33942f0e997680645941787102ebf61e85#e1c3de33942f0e997680645941787102ebf61e85"
 dependencies = [
  "soroban-sdk",
 ]
@@ -1838,7 +1838,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.12"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=65498c8#65498c84ccc30df302c99b50af31752f7aa087e8"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=993c527abce72748405d71467498bffd63e061c1#993c527abce72748405d71467498bffd63e061c1"
 dependencies = [
  "crate-git-revision",
  "serde",
@@ -1851,7 +1851,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.12"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=65498c8#65498c84ccc30df302c99b50af31752f7aa087e8"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=993c527abce72748405d71467498bffd63e061c1#993c527abce72748405d71467498bffd63e061c1"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1860,7 +1860,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.12"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=65498c8#65498c84ccc30df302c99b50af31752f7aa087e8"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=993c527abce72748405d71467498bffd63e061c1#993c527abce72748405d71467498bffd63e061c1"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -1882,7 +1882,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.12"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=65498c8#65498c84ccc30df302c99b50af31752f7aa087e8"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=993c527abce72748405d71467498bffd63e061c1#993c527abce72748405d71467498bffd63e061c1"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1896,8 +1896,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "0.4.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=980778ec#980778ecc78e57178fd0226fed25b341a17c1eac"
+version = "0.4.3"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=e1c3de33942f0e997680645941787102ebf61e85#e1c3de33942f0e997680645941787102ebf61e85"
 dependencies = [
  "serde",
  "serde_json",
@@ -1908,7 +1908,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.12"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=65498c8#65498c84ccc30df302c99b50af31752f7aa087e8"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=993c527abce72748405d71467498bffd63e061c1#993c527abce72748405d71467498bffd63e061c1"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1918,8 +1918,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "0.4.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=980778ec#980778ecc78e57178fd0226fed25b341a17c1eac"
+version = "0.4.3"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=e1c3de33942f0e997680645941787102ebf61e85#e1c3de33942f0e997680645941787102ebf61e85"
 dependencies = [
  "bytes-lit",
  "ed25519-dalek",
@@ -1933,8 +1933,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "0.4.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=980778ec#980778ecc78e57178fd0226fed25b341a17c1eac"
+version = "0.4.3"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=e1c3de33942f0e997680645941787102ebf61e85#e1c3de33942f0e997680645941787102ebf61e85"
 dependencies = [
  "darling",
  "itertools",
@@ -1949,8 +1949,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "0.4.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=980778ec#980778ecc78e57178fd0226fed25b341a17c1eac"
+version = "0.4.3"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=e1c3de33942f0e997680645941787102ebf61e85#e1c3de33942f0e997680645941787102ebf61e85"
 dependencies = [
  "base64",
  "darling",
@@ -1970,8 +1970,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-token-spec"
-version = "0.4.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=980778ec#980778ecc78e57178fd0226fed25b341a17c1eac"
+version = "0.4.3"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=e1c3de33942f0e997680645941787102ebf61e85#e1c3de33942f0e997680645941787102ebf61e85"
 dependencies = [
  "soroban-auth",
  "soroban-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,27 +10,27 @@ default-members = ["cmd/soroban-cli"]
 [workspace.dependencies.soroban-env-host]
 version = "0.0.12"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "65498c8"
+rev = "993c527abce72748405d71467498bffd63e061c1"
 
 [workspace.dependencies.soroban-spec]
 version = "0.4.1"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "980778ec"
+rev = "e1c3de33942f0e997680645941787102ebf61e85"
 
 [workspace.dependencies.soroban-token-spec]
 version = "0.4.1"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "980778ec"
+rev = "e1c3de33942f0e997680645941787102ebf61e85"
 
 [workspace.dependencies.soroban-sdk]
 version = "0.4.1"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "980778ec"
+rev = "e1c3de33942f0e997680645941787102ebf61e85"
 
 [workspace.dependencies.soroban-ledger-snapshot]
 version = "0.4.1"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "980778ec"
+rev = "e1c3de33942f0e997680645941787102ebf61e85"
 
 [workspace.dependencies.stellar-strkey]
 version = "0.0.7"

--- a/cmd/soroban-cli/src/serve.rs
+++ b/cmd/soroban-cli/src/serve.rs
@@ -276,18 +276,14 @@ fn parse_transaction(
     }
     let op = ops.first().ok_or(Error::Xdr(XdrError::Invalid))?;
     let source_account = parse_op_source_account(&transaction, op);
-    let body = if let OperationBody::InvokeHostFunction(b) = &op.body {
-        b
-    } else {
+    let OperationBody::InvokeHostFunction(body) = &op.body else {
         return Err(Error::UnsupportedTransaction {
             message: "Operation must be invokeHostFunction".to_string(),
         });
     };
 
     // TODO: Support creating contracts and token wrappers here as well.
-    let parameters = if let HostFunction::InvokeContract(p) = &body.function {
-        p
-    } else {
+    let HostFunction::InvokeContract(parameters) = &body.function else {
         return Err(Error::UnsupportedTransaction {
             message: "Function must be invokeContract".to_string(),
         });


### PR DESCRIPTION
The "adapts" the CLI to changes to the SDK APIs that arrived in https://github.com/stellar/rs-soroban-sdk/pull/824 though apparently there is no adaptation required, just a version bump. Also includes a small fix to a clippy issue.