### PR TITLE
soroban-rpc: Fix integration tests again

### DIFF
--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -46,7 +46,10 @@ jobs:
       # Docker-compose's remote contexts on Ubuntu 20 started failing with an OpenSSL versioning error.
       # See https://stackoverflow.com/questions/66579446/error-executing-docker-compose-building-webserver-unable-to-prepare-context-un
       - name: Work around Docker Compose problem
-        run: sudo pip3 install docker-compose
+        run: |
+          sudo pip3 install pip --upgrade
+          sudo pip3 install pyopenssl --upgrade
+          sudo pip3 install docker-compose
 
       - name: Build Soroban RPC reproducible build
         run: |


### PR DESCRIPTION
After fixing the integration tests a few days ago (https://github.com/stellar/soroban-tools/pull/340) they started failing again with a different error: ` AttributeError: module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK'`

see, for instance https://github.com/stellar/soroban-tools/actions/runs/3974532238/jobs/6813853311
