### PR TITLE
include captive-core-use-db command option

### DIFF
--- a/cmd/soroban-rpc/internal/config/config.go
+++ b/cmd/soroban-rpc/internal/config/config.go
@@ -13,6 +13,7 @@ type LocalConfig struct {
 	CaptiveCoreConfigPath     string
 	CaptiveCoreStoragePath    string
 	CaptiveCoreHTTPPort       uint16
+	CaptiveCoreUseDB          bool
 	NetworkPassphrase         string
 	HistoryArchiveURLs        []string
 	LogLevel                  logrus.Level

--- a/cmd/soroban-rpc/internal/daemon/daemon.go
+++ b/cmd/soroban-rpc/internal/daemon/daemon.go
@@ -56,6 +56,7 @@ func MustNew(cfg config.LocalConfig) *Daemon {
 	captiveCoreTomlParams.HistoryArchiveURLs = cfg.HistoryArchiveURLs
 	captiveCoreTomlParams.NetworkPassphrase = cfg.NetworkPassphrase
 	captiveCoreTomlParams.Strict = true
+	captiveCoreTomlParams.UseDB = cfg.CaptiveCoreUseDB
 	captiveCoreToml, err := ledgerbackend.NewCaptiveCoreTomlFromFile(cfg.CaptiveCoreConfigPath, captiveCoreTomlParams)
 	if err != nil {
 		logger.WithError(err).Fatal("Invalid captive core toml")
@@ -70,6 +71,7 @@ func MustNew(cfg config.LocalConfig) *Daemon {
 		Log:                 logger.WithField("subservice", "stellar-core"),
 		Toml:                captiveCoreToml,
 		UserAgent:           "captivecore",
+		UseDB:               cfg.CaptiveCoreUseDB,
 	}
 	core, err := ledgerbackend.NewCaptive(captiveConfig)
 	if err != nil {

--- a/cmd/soroban-rpc/main.go
+++ b/cmd/soroban-rpc/main.go
@@ -23,6 +23,7 @@ func main() {
 	var endpoint, horizonURL, stellarCoreURL, binaryPath, configPath, networkPassphrase, dbPath, captivecoreStoragePath string
 	var captiveCoreHTTPPort, ledgerEntryStorageTimeoutMinutes uint
 	var checkpointFrequency uint32
+	var useDb bool
 	var historyArchiveURLs []string
 	var txConcurrency, txQueueSize int
 	var logLevel logrus.Level
@@ -111,6 +112,14 @@ func main() {
 			ConfigKey: &captivecoreStoragePath,
 		},
 		{
+			Name:        "captive-core-use-db",
+			OptType:     types.Bool,
+			FlagDefault: false,
+			Required:    false,
+			Usage:       "informs captive core to use on disk mode. the db will by default be created in current runtime directory of soroban-rpc, unless DATABASE=<path> setting is present in captive core config file.",
+			ConfigKey:   &useDb,
+		},
+		&config.ConfigOption{
 			Name:        "history-archive-urls",
 			ConfigKey:   &historyArchiveURLs,
 			OptType:     types.String,
@@ -189,6 +198,7 @@ func main() {
 				StellarCoreURL:            stellarCoreURL,
 				StellarCoreBinaryPath:     binaryPath,
 				CaptiveCoreConfigPath:     configPath,
+				CaptiveCoreUseDB:          useDb,
 				CaptiveCoreHTTPPort:       uint16(captiveCoreHTTPPort),
 				CaptiveCoreStoragePath:    captivecoreStoragePath,
 				NetworkPassphrase:         networkPassphrase,

--- a/cmd/soroban-rpc/main.go
+++ b/cmd/soroban-rpc/main.go
@@ -23,7 +23,7 @@ func main() {
 	var endpoint, horizonURL, stellarCoreURL, binaryPath, configPath, networkPassphrase, dbPath, captivecoreStoragePath string
 	var captiveCoreHTTPPort, ledgerEntryStorageTimeoutMinutes uint
 	var checkpointFrequency uint32
-	var useDb bool
+	var useDB bool
 	var historyArchiveURLs []string
 	var txConcurrency, txQueueSize int
 	var logLevel logrus.Level
@@ -117,7 +117,7 @@ func main() {
 			FlagDefault: false,
 			Required:    false,
 			Usage:       "informs captive core to use on disk mode. the db will by default be created in current runtime directory of soroban-rpc, unless DATABASE=<path> setting is present in captive core config file.",
-			ConfigKey:   &useDb,
+			ConfigKey:   &useDB,
 		},
 		&config.ConfigOption{
 			Name:        "history-archive-urls",
@@ -198,7 +198,7 @@ func main() {
 				StellarCoreURL:            stellarCoreURL,
 				StellarCoreBinaryPath:     binaryPath,
 				CaptiveCoreConfigPath:     configPath,
-				CaptiveCoreUseDB:          useDb,
+				CaptiveCoreUseDB:          useDB,
 				CaptiveCoreHTTPPort:       uint16(captiveCoreHTTPPort),
 				CaptiveCoreStoragePath:    captivecoreStoragePath,
 				NetworkPassphrase:         networkPassphrase,


### PR DESCRIPTION
### What

include a `captive-core-use-db` command option to be passed to captive core config 

### Why

have more control of ram vs disk usage at deployment/runtime

### Known limitations


