### PR TITLE
update docker build for latest make target

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+target/
+.soroban/

--- a/cmd/soroban-rpc/docker/Dockerfile
+++ b/cmd/soroban-rpc/docker/Dockerfile
@@ -1,23 +1,23 @@
 FROM golang:1.19.1 as build
+ARG RUST_TOOLCHAIN_VERSION=stable
 
-ADD . /src/soroban-rpc
-WORKDIR /src/soroban-rpc
-RUN go build -o /bin/soroban-rpc ./cmd/soroban-rpc
+WORKDIR /go/src/github.com/stellar/soroban-tools
 
+ADD . ./
 
-FROM ubuntu:20.04
-ARG STELLAR_CORE_VERSION
-ENV STELLAR_CORE_VERSION=${STELLAR_CORE_VERSION:-*}
-ENV STELLAR_CORE_BINARY_PATH /usr/bin/stellar-core
+RUN git config --global --add safe.directory "/go/src/github.com/stellar/soroban-tools"
+
+ENV CARGO_HOME=/rust/.cargo
+ENV RUSTUP_HOME=/rust/.rust
+ENV PATH="/usr/local/go/bin:$CARGO_HOME/bin:${PATH}"
 ENV DEBIAN_FRONTEND=noninteractive
-
-# ca-certificates are required to make tls connections
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl wget gnupg apt-utils
-RUN wget -qO - https://apt.stellar.org/SDF.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true apt-key add -
-RUN echo "deb https://apt.stellar.org focal stable" >/etc/apt/sources.list.d/SDF.list
-RUN echo "deb https://apt.stellar.org focal unstable" >/etc/apt/sources.list.d/SDF-unstable.list
-RUN apt-get update && apt-get install -y stellar-core=${STELLAR_CORE_VERSION}
+RUN apt-get update
+RUN apt-get install -y build-essential
 RUN apt-get clean
 
-COPY --from=build /bin/soroban-rpc /app/
-ENTRYPOINT ["/app/soroban-rpc"]
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUST_TOOLCHAIN_VERSION
+
+RUN make build-soroban-rpc
+RUN mv soroban-rpc /bin/soroban-rpc
+
+ENTRYPOINT ["/bin/soroban-rpc"]

--- a/cmd/soroban-rpc/docker/Dockerfile
+++ b/cmd/soroban-rpc/docker/Dockerfile
@@ -20,4 +20,19 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUST_TOOLC
 RUN make build-soroban-rpc
 RUN mv soroban-rpc /bin/soroban-rpc
 
-ENTRYPOINT ["/bin/soroban-rpc"]
+FROM ubuntu:20.04
+ARG STELLAR_CORE_VERSION
+ENV STELLAR_CORE_VERSION=${STELLAR_CORE_VERSION:-*}
+ENV STELLAR_CORE_BINARY_PATH /usr/bin/stellar-core
+ENV DEBIAN_FRONTEND=noninteractive
+
+# ca-certificates are required to make tls connections
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl wget gnupg apt-utils
+RUN wget -qO - https://apt.stellar.org/SDF.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true apt-key add -
+RUN echo "deb https://apt.stellar.org focal stable" >/etc/apt/sources.list.d/SDF.list
+RUN echo "deb https://apt.stellar.org focal unstable" >/etc/apt/sources.list.d/SDF-unstable.list
+RUN apt-get update && apt-get install -y stellar-core=${STELLAR_CORE_VERSION}
+RUN apt-get clean
+
+COPY --from=build /bin/soroban-rpc /app/
+ENTRYPOINT ["/app/soroban-rpc"]


### PR DESCRIPTION
### What

the docker build file for soroban rpc fails with error during go build:
```
#6 33.81 /usr/bin/ld: cannot find -lpreflight
```

### Why

need the build to work, as quickstart uses it to build soroban-rpc, updated the dockerfile to use the Makefile `build-soroban-rpc` target

### Known limitations


