### PR TITLE
new build arg for version override on dockerfile build of soroban rpc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: check build test
 export RUSTFLAGS=-Dwarnings -Dclippy::all -Dclippy::pedantic
 
 ifeq ($(strip $(REPOSITORY_VERSION)),)
-    override REPOSITORY_VERSION = "$(shell git describe --tags --always --abbrev=0 --match='v[0-9]*.[0-9]*.[0-9]*' 2> /dev/null | sed 's/^.//')"
+	override REPOSITORY_VERSION = "$(shell git describe --tags --always --abbrev=0 --match='v[0-9]*.[0-9]*.[0-9]*' 2> /dev/null | sed 's/^.//')"
 endif  
 REPOSITORY_COMMIT_HASH := "$(shell git rev-parse HEAD)"
 REPOSITORY_BRANCH := "$(shell git rev-parse --abbrev-ref HEAD)"

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@ all: check build test
 
 export RUSTFLAGS=-Dwarnings -Dclippy::all -Dclippy::pedantic
 
-REPOSITORY_VERSION ?= "$(shell git describe --tags --always --abbrev=0 --match='v[0-9]*.[0-9]*.[0-9]*' 2> /dev/null | sed 's/^.//')"
+ifeq ($(strip $(REPOSITORY_VERSION)),)
+    override REPOSITORY_VERSION = "$(shell git describe --tags --always --abbrev=0 --match='v[0-9]*.[0-9]*.[0-9]*' 2> /dev/null | sed 's/^.//')"
+endif  
 REPOSITORY_COMMIT_HASH := "$(shell git rev-parse HEAD)"
 REPOSITORY_BRANCH := "$(shell git rev-parse --abbrev-ref HEAD)"
 BUILD_TIMESTAMP ?= $(shell date '+%Y-%m-%dT%H:%M:%S')

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ all: check build test
 
 export RUSTFLAGS=-Dwarnings -Dclippy::all -Dclippy::pedantic
 
+# Want to treat empty assignment, `REPOSITORY_VERSION=` the same as absence or unset.
+# By default make `?=` operator will treat empty assignment as a set value and will not use the default value.
+# Both cases should fallback to default of getting the version from git tag.
 ifeq ($(strip $(REPOSITORY_VERSION)),)
 	override REPOSITORY_VERSION = "$(shell git describe --tags --always --abbrev=0 --match='v[0-9]*.[0-9]*.[0-9]*' 2> /dev/null | sed 's/^.//')"
 endif  

--- a/cmd/soroban-rpc/docker/Dockerfile
+++ b/cmd/soroban-rpc/docker/Dockerfile
@@ -1,5 +1,6 @@
 FROM golang:1.19.1 as build
 ARG RUST_TOOLCHAIN_VERSION=stable
+ARG REPOSITORY_VERSION
 
 WORKDIR /go/src/github.com/stellar/soroban-tools
 
@@ -17,7 +18,7 @@ RUN apt-get clean
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUST_TOOLCHAIN_VERSION
 
-RUN make build-soroban-rpc
+RUN make REPOSITORY_VERSION=${REPOSITORY_VERSION} build-soroban-rpc
 RUN mv soroban-rpc /bin/soroban-rpc
 
 FROM ubuntu:20.04


### PR DESCRIPTION
### What

added new build arg for version override on dockerfile for soroban rpc

### Why

need ability to override the version stamp placed into soroban rpc bin, default is derive from git tag, but some environments like Jenkins package builder, may have a user defined Version value that should be stamped into bin instead.

### Known limitations

