### PR TITLE
soroban-cli: Use strval to parse new-style invoke cli args

### DIFF
--- a/cmd/soroban-cli/src/contract/invoke.rs
+++ b/cmd/soroban-cli/src/contract/invoke.rs
@@ -187,7 +187,7 @@ impl Cmd {
                         } else {
                             "null".to_string()
                         }
-                    },
+                    }
                     _ => matches_
                         .get_raw(&name)
                         .unwrap()

--- a/cmd/soroban-cli/src/contract/invoke.rs
+++ b/cmd/soroban-cli/src/contract/invoke.rs
@@ -170,7 +170,7 @@ impl Cmd {
         // clap wants everything to be static so we need to leak stuff.
         let static_spec: &'static Spec = Box::leak(Box::new(spec.clone()));
 
-        let cmd = build_custom_cmd(&self.function, inputs_map, static_spec)?;
+        let cmd = build_custom_cmd(&self.function, inputs_map, static_spec);
         let matches_ = cmd.get_matches_from(&self.slop);
 
         // create parsed_args in same order as the inputs to func
@@ -555,7 +555,7 @@ fn build_custom_cmd<'a>(
     name: &'a str,
     inputs_map: &'a HashMap<String, ScSpecTypeDef>,
     spec: &'static Spec,
-) -> Result<clap::App<'a>, Error> {
+) -> clap::App<'a> {
     // Todo make new error
     INSTANCE
         .set(inputs_map.keys().map(Clone::clone).collect::<Vec<String>>())
@@ -586,7 +586,7 @@ fn build_custom_cmd<'a>(
         cmd = cmd.arg(arg);
     }
     cmd.build();
-    Ok(cmd)
+    cmd
 }
 
 fn arg_value_name(name: &'static str, spec: &Spec, type_: &ScSpecTypeDef) -> Option<&'static str> {
@@ -658,8 +658,7 @@ fn arg_value_name(name: &'static str, spec: &Spec, type_: &ScSpecTypeDef) -> Opt
             Some(ScSpecEntry::UdtStructV0(_)) => Some("struct"),
             Some(ScSpecEntry::UdtUnionV0(_)) => Some("enum"),
             Some(ScSpecEntry::UdtEnumV0(_)) => Some("u32"),
-            Some(ScSpecEntry::FunctionV0(_) | ScSpecEntry::UdtErrorEnumV0(_)) => None,
-            None => None,
+            Some(ScSpecEntry::FunctionV0(_) | ScSpecEntry::UdtErrorEnumV0(_)) | None => None,
         },
         // No specific value name for these yet.
         ScSpecTypeDef::Val => None,

--- a/cmd/soroban-cli/src/strval.rs
+++ b/cmd/soroban-cli/src/strval.rs
@@ -517,7 +517,7 @@ impl Spec {
             }
 
             (ScObject::Bytes(v), ScSpecTypeDef::Bytes) => Value::String(to_lower_hex(v.as_slice())),
-            (ScObject::Bytes(_), ScSpecTypeDef::BytesN(_)) => todo!(),
+            (ScObject::Bytes(v), ScSpecTypeDef::BytesN(_)) => Value::String(to_lower_hex(v.as_slice())),
 
             (ScObject::Bytes(_), ScSpecTypeDef::Udt(_)) => todo!(),
 

--- a/cmd/soroban-cli/src/strval.rs
+++ b/cmd/soroban-cli/src/strval.rs
@@ -517,7 +517,9 @@ impl Spec {
             }
 
             (ScObject::Bytes(v), ScSpecTypeDef::Bytes) => Value::String(to_lower_hex(v.as_slice())),
-            (ScObject::Bytes(v), ScSpecTypeDef::BytesN(_)) => Value::String(to_lower_hex(v.as_slice())),
+            (ScObject::Bytes(v), ScSpecTypeDef::BytesN(_)) => {
+                Value::String(to_lower_hex(v.as_slice()))
+            }
 
             (ScObject::Bytes(_), ScSpecTypeDef::Udt(_)) => todo!(),
 

--- a/cmd/soroban-cli/src/strval.rs
+++ b/cmd/soroban-cli/src/strval.rs
@@ -38,7 +38,7 @@ impl From<()> for Error {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Spec(pub Option<Vec<ScSpecEntry>>);
 
 impl Spec {


### PR DESCRIPTION
Replaces https://github.com/stellar/soroban-tools/pull/402

### What

Use strval to parse all types of `soroban contract invoke --id 1 --fn hello -- --foo bar` type args.

### Why

Previously, i128/u128 (and many others) would panic, making the contract impossible to invoke. In particular, tokens use i128s now.

Previous error:
```
$ soroban contract invoke \
  --identity token-admin \
  --network standalone \
  --id b083cc4a3122f22f3ef0652718be7b2082b11f9efb26e8e687fd6fc960764656 \
  --fn init -- -h
thread 'main' panicked at 'not yet implemented', cmd/soroban-cli/src/contract/invoke.rs:612:34
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

New output:
```
$ soroban contract invoke \
  --identity token-admin \
  --network standalone \
  --id b083cc4a3122f22f3ef0652718be7b2082b11f9efb26e8e687fd6fc960764656 \
  --fn init -- -h
init

USAGE:
    init [OPTIONS]

OPTIONS:
    -h, --help                 Print help information
        --signers <Array<32_hex_bytes>>
```

### Known limitations

It would be nice if the output formats for types were a closer match to how you would input them. But I'm not super sure how to communicate that for all of them right now.

Current outputs are like:
```
--int <i128>
--vec <Array<i128>>
--option <Option<i128>>
--map <{symbol: i128}>
--address <address>
--set <Set<i128>>
--tuple <(symbol, i128)>
--complex <Option<Array<{symbol: 32_hex_bytes}>>>
--udt ... not shown
```

Suggestions for better output formatting are welcome!

Minor (existing) issue is parsing negative ints. The workaround I've used is an equals, like: `--int=-1`

- [x] Bug: omitting a flag for an optional arg seems to fail