### PR TITLE
avoid publishing the preflight library

### DIFF
--- a/cmd/soroban-rpc/lib/preflight/Cargo.toml
+++ b/cmd/soroban-rpc/lib/preflight/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "preflight"
 version = "0.5.0"
+publish = false
 
 [lib]
 crate-type = ["staticlib"]


### PR DESCRIPTION
### What

avoid publishing the preflight package, which is used internally as part of the soroban-rpc build.

### Why

we don't need to publish this package.

### Known limitations

N/A
