### PR TITLE
bump soroban versions for cargo, go, e2e

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,7 +16,7 @@ jobs:
       TOOLS_REF: ${{ github.ref }}
       SYSTEM_TEST_GIT_REF: v1.0.4
       # core git ref is latest commit for stable soroban functionality
-      SYSTEM_TEST_CORE_GIT_REF: 3a201d2b5ecee34d6dcc0466633783f27b7fa97c
+      SYSTEM_TEST_CORE_GIT_REF: 871accefc0c4a703c1321b4f0e48cf6e03b41960
       SYSTEM_TEST_CORE_COMPILE_CONFIGURE_FLAGS: "--disable-tests --enable-next-protocol-version-unsafe-for-production"
       SYSTEM_TEST_RUST_TOOLCHAIN_VERSION: stable
       SYSTEM_TEST_QUICKSTART_GIT_REF: master

--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -89,7 +89,7 @@ jobs:
     env:
       SOROBAN_RPC_INTEGRATION_TESTS_ENABLED: true
       SOROBAN_RPC_INTEGRATION_TESTS_CAPTIVE_CORE_BIN: /usr/bin/stellar-core
-      PROTOCOL_20_CORE_DEBIAN_PKG_VERSION: 19.7.1-1178.e352f0012.focal~soroban
+      PROTOCOL_20_CORE_DEBIAN_PKG_VERSION: 19.7.1-1204.871accefc.focal~soroban
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,19 +8,19 @@ members = [
 default-members = ["cmd/soroban-cli"]
 
 [workspace.dependencies.soroban-env-host]
-version = "0.0.13"
+version = "0.0.14"
 
 [workspace.dependencies.soroban-spec]
-version = "0.5.0"
+version = "0.6.0"
 
 [workspace.dependencies.soroban-token-spec]
-version = "0.5.0"
+version = "0.6.0"
 
 [workspace.dependencies.soroban-sdk]
-version = "0.5.0"
+version = "0.6.0"
 
 [workspace.dependencies.soroban-ledger-snapshot]
-version = "0.5.0"
+version = "0.6.0"
 
 [workspace.dependencies.stellar-strkey]
 version = "0.0.7"

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/spf13/cast v0.0.0-20150508191742-4d07383ffe94 // indirect
 	github.com/spf13/jwalterweatherman v0.0.0-20141219030609-3d60171a6431 // indirect
 	github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475 // indirect
-	github.com/stellar/go v0.0.0-20230213182533-241e2cdec717
+	github.com/stellar/go v0.0.0-20230214183242-5e40cf447ff2
 	github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee // indirect
 	github.com/stretchr/objx v0.4.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -173,6 +173,8 @@ github.com/stellar/go v0.0.0-20230209170627-5a136482f453 h1:vAxPnPqgMKLhNjGpVOUn
 github.com/stellar/go v0.0.0-20230209170627-5a136482f453/go.mod h1:QXwuKmYVvqQZlByv0EeNb0Rgog9AP+eMmARcdt3h2rI=
 github.com/stellar/go v0.0.0-20230213182533-241e2cdec717 h1:H1eRGomzqNOWMqH2lju/JOZIbkp9qnKRK3YZ//A9Ql4=
 github.com/stellar/go v0.0.0-20230213182533-241e2cdec717/go.mod h1:QXwuKmYVvqQZlByv0EeNb0Rgog9AP+eMmARcdt3h2rI=
+github.com/stellar/go v0.0.0-20230214183242-5e40cf447ff2 h1:NYaZlo3+aOjGtCr6kTyaAzgI6IizmcMwSZ+i2KFccpQ=
+github.com/stellar/go v0.0.0-20230214183242-5e40cf447ff2/go.mod h1:QXwuKmYVvqQZlByv0EeNb0Rgog9AP+eMmARcdt3h2rI=
 github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee h1:fbVs0xmXpBvVS4GBeiRmAE3Le70ofAqFMch1GTiq/e8=
 github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
### What

bump soroban versions to latest for preview7 release

### Why

all soroban refs need to be at latest versions for release

### Known limitations


