### PR TITLE
update go monorepo dep

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/spf13/cast v0.0.0-20150508191742-4d07383ffe94 // indirect
 	github.com/spf13/jwalterweatherman v0.0.0-20141219030609-3d60171a6431 // indirect
 	github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475 // indirect
-	github.com/stellar/go v0.0.0-20230214183242-5e40cf447ff2
+	github.com/stellar/go v0.0.0-20230214233659-c9b7633302bd
 	github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee // indirect
 	github.com/stretchr/objx v0.4.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -169,12 +169,8 @@ github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475 h1:RtZIgreTwcayPTOw7G5
 github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189 h1:fvB1AFbBd6SfI9Rd0ooAJp8uLkZDbZaLFHi7ZnNP6uI=
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
-github.com/stellar/go v0.0.0-20230209170627-5a136482f453 h1:vAxPnPqgMKLhNjGpVOUnDQsY2SYiNRq8PaPbdpQJxTo=
-github.com/stellar/go v0.0.0-20230209170627-5a136482f453/go.mod h1:QXwuKmYVvqQZlByv0EeNb0Rgog9AP+eMmARcdt3h2rI=
-github.com/stellar/go v0.0.0-20230213182533-241e2cdec717 h1:H1eRGomzqNOWMqH2lju/JOZIbkp9qnKRK3YZ//A9Ql4=
-github.com/stellar/go v0.0.0-20230213182533-241e2cdec717/go.mod h1:QXwuKmYVvqQZlByv0EeNb0Rgog9AP+eMmARcdt3h2rI=
-github.com/stellar/go v0.0.0-20230214183242-5e40cf447ff2 h1:NYaZlo3+aOjGtCr6kTyaAzgI6IizmcMwSZ+i2KFccpQ=
-github.com/stellar/go v0.0.0-20230214183242-5e40cf447ff2/go.mod h1:QXwuKmYVvqQZlByv0EeNb0Rgog9AP+eMmARcdt3h2rI=
+github.com/stellar/go v0.0.0-20230214233659-c9b7633302bd h1:ba/WJEiVdu0fgR3y638btogezTmeeQYnSFe4hQd1Fu4=
+github.com/stellar/go v0.0.0-20230214233659-c9b7633302bd/go.mod h1:QXwuKmYVvqQZlByv0EeNb0Rgog9AP+eMmARcdt3h2rI=
 github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee h1:fbVs0xmXpBvVS4GBeiRmAE3Le70ofAqFMch1GTiq/e8=
 github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
### What

update go monorepo dep

### Why

the horizon repo is ready for release, sync with soroban-tools

### Known limitations

N/A
