### PR TITLE
updated go mod ref to latest on soroban-xdr-next

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/spf13/cast v0.0.0-20150508191742-4d07383ffe94 // indirect
 	github.com/spf13/jwalterweatherman v0.0.0-20141219030609-3d60171a6431 // indirect
 	github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475 // indirect
-	github.com/stellar/go v0.0.0-20230214233659-c9b7633302bd
+	github.com/stellar/go v0.0.0-20230215201937-ab3ce11f4093
 	github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee // indirect
 	github.com/stretchr/objx v0.4.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -171,6 +171,8 @@ github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189 h1:fvB1AFbBd6SfI9Rd0oo
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
 github.com/stellar/go v0.0.0-20230214233659-c9b7633302bd h1:ba/WJEiVdu0fgR3y638btogezTmeeQYnSFe4hQd1Fu4=
 github.com/stellar/go v0.0.0-20230214233659-c9b7633302bd/go.mod h1:QXwuKmYVvqQZlByv0EeNb0Rgog9AP+eMmARcdt3h2rI=
+github.com/stellar/go v0.0.0-20230215201937-ab3ce11f4093 h1:hcp2zZ2r2erWoVDUIaeZ9ZDuH5gf779mYyIZ3x4dDSo=
+github.com/stellar/go v0.0.0-20230215201937-ab3ce11f4093/go.mod h1:QXwuKmYVvqQZlByv0EeNb0Rgog9AP+eMmARcdt3h2rI=
 github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee h1:fbVs0xmXpBvVS4GBeiRmAE3Le70ofAqFMch1GTiq/e8=
 github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION


### What

updated go monorepo dep for with `go get github.com/stellar/go@soroban-xdr-next`

### Why

pull in fix that was pushed to monorepo:soroban-xdr-next, https://github.com/stellar/go/pull/4772

### Known limitations


