### PR TITLE
soroban-rpc: build libpreflight in its own workflow step

### DIFF
--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -29,9 +29,8 @@ jobs:
       - uses: ./.github/actions/setup-go
         with:
           go-version: ${{ matrix.go }}
-      - run: |
-          make build-libpreflight
-          go test -race -cover -timeout 25m -v ./cmd/soroban-rpc/...
+      - run: make build-libpreflight
+      - run: go test -race -cover -timeout 25m -v ./cmd/soroban-rpc/...
 
   build:
     name: Build
@@ -73,9 +72,11 @@ jobs:
           sudo apt-get install -y gcc-10-aarch64-linux-gnu
           echo 'CC=aarch64-linux-gnu-gcc-10' >> $GITHUB_ENV
 
+      - name: Build libpreflight
+        run: CARGO_BUILD_TARGET=${{ matrix.rust_target }} make build-libpreflight
+
       - name: Build Soroban RPC reproducible build
         run: |
-          CARGO_BUILD_TARGET=${{ matrix.rust_target }} make build-libpreflight
           CGO_ENABLED=1 GOARCH=${{ matrix.go_arch }} go build -trimpath -buildvcs=false ./cmd/soroban-rpc
           ls -lh soroban-rpc
           file soroban-rpc
@@ -130,7 +131,9 @@ jobs:
           sudo pip3 install pyopenssl --upgrade
           sudo pip3 install docker-compose
 
+      - name: Build libpreflight
+        run: make build-libpreflight
+      
       - name: Run Soroban RPC Integration Tests
         run: |
-          make build-libpreflight
           go test -race -timeout 25m -v ./cmd/soroban-rpc/internal/test/...


### PR DESCRIPTION
This reduces the noise when finding test errors
