### PR TITLE
soroban-rpc: Check DB on health endpoint

### DIFF
--- a/cmd/soroban-rpc/internal/jsonrpc.go
+++ b/cmd/soroban-rpc/internal/jsonrpc.go
@@ -43,7 +43,7 @@ type HandlerParams struct {
 // NewJSONRPCHandler constructs a Handler instance
 func NewJSONRPCHandler(cfg *config.LocalConfig, params HandlerParams) (Handler, error) {
 	bridge := jhttp.NewBridge(handler.Map{
-		"getHealth":           methods.NewHealthCheck(),
+		"getHealth":           methods.NewHealthCheck(params.LedgerEntryReader),
 		"getEvents":           methods.NewGetEventsHandler(params.EventStore, cfg.MaxEventsLimit, cfg.DefaultEventsLimit),
 		"getNetwork":          methods.NewGetNetworkHandler(cfg.NetworkPassphrase, cfg.FriendbotURL, params.CoreClient),
 		"getLedgerEntry":      methods.NewGetLedgerEntryHandler(params.Logger, params.LedgerEntryReader),


### PR DESCRIPTION
### What

Make sure that the DB is ready in the `getHealth()` endpoint

### Why

`soroban-rpc` is not really ready until we reach the first checkpoint (before which the DB won't be ready, and ingestion won't be able to start)

### Known limitations

The `getHealth` endpoint now becomes a bit heavier