### PR TITLE
fix: allow using ENV to add identity and pass secret

### DIFF
--- a/cmd/soroban-cli/src/config/mod.rs
+++ b/cmd/soroban-cli/src/config/mod.rs
@@ -57,7 +57,7 @@ impl Cmd {
 #[derive(Debug, clap::Args, Clone)]
 pub struct Args {
     /// Secret Key used to sign transaction sent to the rpc server
-    #[clap(long, conflicts_with = "identity")]
+    #[clap(long, conflicts_with = "identity", env = "SOROBAN_SECRET_KEY")]
     pub secret_key: Option<String>,
 
     #[clap(flatten)]

--- a/cmd/soroban-cli/src/config/secret.rs
+++ b/cmd/soroban-cli/src/config/secret.rs
@@ -23,6 +23,7 @@ pub enum Error {
 #[derive(Debug, clap::Args, Clone)]
 pub struct Args {
     /// Add using secret_key
+    /// Can provide with SOROBAN_SECRET_KEY
     #[clap(long, conflicts_with = "seed-phrase")]
     pub secret_key: bool,
     /// Add using 12 word seed phrase to generate secret_key
@@ -32,7 +33,9 @@ pub struct Args {
 
 impl Args {
     pub fn read_secret(&self) -> Result<Secret, Error> {
-        if self.secret_key {
+        if let Ok(secret_key) = std::env::var("SOROBAN_SECRET_KEY") {
+            Ok(Secret::SecretKey { secret_key })
+        } else if self.secret_key {
             println!("Type a secret key: ");
             let secret_key = read_password()?;
             let secret_key = PrivateKey::from_string(&secret_key)


### PR DESCRIPTION
### What
```
soroban config identity add <NAME>
```

Now accepts SOROBAN_SECRET_KEY to set the secret and --secret-key also accepts it.
### Why

Needed for SQ


### Known limitations

[TODO or N/A]
