### PR TITLE
feat: add better docs for UDT and add examples for each arg

### DIFF
--- a/cmd/soroban-cli/src/contract/invoke.rs
+++ b/cmd/soroban-cli/src/contract/invoke.rs
@@ -27,7 +27,7 @@ use soroban_spec::read::FromWasmError;
 
 use crate::config;
 use crate::rpc::Client;
-use crate::strval::{arg_value_name, Spec};
+use crate::strval::Spec;
 use crate::utils::{create_ledger_footprint, default_account_ledger_entry};
 use crate::HEADING_SANDBOX;
 use crate::{events, rpc, strval, utils};
@@ -585,7 +585,7 @@ fn build_custom_cmd<'a>(name: &'a str, spec: &Spec) -> Result<clap::App<'a>, Err
             .value_parser(clap::builder::NonEmptyStringValueParser::new())
             .long_help(spec.doc(name, type_).unwrap());
 
-        if let Some(value_name) = arg_value_name(spec, type_) {
+        if let Some(value_name) = spec.arg_value_name(type_, 0) {
             arg = arg.value_name(Box::leak(value_name.into_boxed_str()));
         }
 

--- a/cmd/soroban-cli/src/contract/invoke.rs
+++ b/cmd/soroban-cli/src/contract/invoke.rs
@@ -152,7 +152,10 @@ impl Cmd {
         spec_entries: &[ScSpecEntry],
     ) -> Result<(String, Spec, ScVec), Error> {
         let spec = Spec(Some(spec_entries.to_vec()));
-        let mut cmd = clap::Command::new(&self.contract_id).no_binary_name(true);
+        let mut cmd = clap::Command::new(&self.contract_id)
+            .no_binary_name(true)
+            .term_width(300)
+            .max_term_width(300);
 
         for ScSpecFunctionV0 { name, .. } in spec.find_functions()? {
             let name: &'static str = Box::leak(name.to_string_lossy().into_boxed_str());
@@ -572,7 +575,10 @@ fn build_custom_cmd<'a>(name: &'a str, spec: &Spec) -> Result<clap::App<'a>, Err
         .iter()
         .map(|i| (i.name.to_string().unwrap(), i.type_.clone()))
         .collect::<HashMap<String, ScSpecTypeDef>>();
-    let mut cmd = clap::Command::new(name).no_binary_name(true);
+    let mut cmd = clap::Command::new(name)
+        .no_binary_name(true)
+        .term_width(300)
+        .max_term_width(300);
     let func = spec.find_function(name).unwrap();
     let doc: &'static str = Box::leak(func.doc.to_string_lossy().into_boxed_str());
     cmd = cmd.about(Some(doc));

--- a/cmd/soroban-cli/tests/fixtures/test-wasms/custom_type/src/lib.rs
+++ b/cmd/soroban-cli/tests/fixtures/test-wasms/custom_type/src/lib.rs
@@ -1,13 +1,11 @@
 #![no_std]
 use soroban_sdk::{
-    contractimpl, contracttype, symbol, vec, Address, Bytes, Env, Map, Set, Symbol, Vec,
+    contractimpl, contracttype, symbol, vec, Address, Bytes, BytesN, Env, Map, Set, Symbol, Vec,
 };
 
 pub struct Contract;
 
-/// A Struct
-/// Second line?
-/// "example"
+/// This is from the rust doc above the struct Test
 #[contracttype]
 pub struct Test {
     pub a: u32,
@@ -87,6 +85,10 @@ impl Contract {
         bytes
     }
 
+    pub fn bytes_n(_env: Env, bytes_n: BytesN<9>) -> BytesN<9> {
+        bytes_n
+    }
+
     pub fn card(_env: Env, card: RoyalCard) -> RoyalCard {
         card
     }
@@ -95,6 +97,7 @@ impl Contract {
         boolean
     }
 
+    /// Negates a boolean value
     pub fn not(_env: Env, boolean: bool) -> bool {
         !boolean
     }
@@ -129,6 +132,11 @@ impl Contract {
 
     pub fn tuple(_env: Env, tuple: (Symbol, u32)) -> (Symbol, u32) {
         tuple
+    }
+
+    /// Example of an optional argument
+    pub fn option(_env: Env, option: Option<u32>) -> Option<u32> {
+        option
     }
 }
 

--- a/cmd/soroban-cli/tests/fixtures/test-wasms/custom_type/src/lib.rs
+++ b/cmd/soroban-cli/tests/fixtures/test-wasms/custom_type/src/lib.rs
@@ -138,6 +138,31 @@ impl Contract {
     pub fn option(_env: Env, option: Option<u32>) -> Option<u32> {
         option
     }
+
+    #[allow(clippy::too_many_arguments, unused_variables)]
+    pub fn some_types(
+        _env: Env,
+        i32: i32,
+        bool: bool,
+        symbol: Symbol,
+        strukt: Test,
+        option: Option<u32>,
+        address: Address,
+        vec: Vec<u32>,
+        set: Set<Address>,
+        tuple: (Symbol, Address, Bytes),
+    ) {
+    }
+    #[allow(clippy::too_many_arguments, unused_variables)]
+    pub fn othertypes(
+        _env: Env,
+        map: Map<Symbol, u128>,
+        bytes: Bytes,
+        bytes_n: BytesN<9>,
+        const_enum: RoyalCard,
+        simple_enum: SimpleEnum,
+    ) {
+    }
 }
 
 #[cfg(test)]

--- a/cmd/soroban-cli/tests/fixtures/test-wasms/custom_type/src/lib.rs
+++ b/cmd/soroban-cli/tests/fixtures/test-wasms/custom_type/src/lib.rs
@@ -5,7 +5,9 @@ use soroban_sdk::{
 
 pub struct Contract;
 
-/// Test Struct Docs
+/// A Struct
+/// Second line?
+/// "example"
 #[contracttype]
 pub struct Test {
     pub a: u32,
@@ -39,6 +41,7 @@ pub enum ComplexEnum {
     Struct(Test),
     Tuple(TupleStruct),
     Enum(SimpleEnum),
+    Void,
 }
 
 #[contractimpl]
@@ -63,7 +66,7 @@ impl Contract {
         vec![&env, symbol!("Hello"), strukt.c]
     }
 
-    /// Example contract method passing in a struct
+    /// Example contract method that takes a struct
     pub fn strukt(_env: Env, strukt: Test) -> Test {
         strukt
     }

--- a/cmd/soroban-cli/tests/it/custom_types.rs
+++ b/cmd/soroban-cli/tests/it/custom_types.rs
@@ -26,7 +26,7 @@ fn generate_help() {
         .assert()
         .success()
         .stdout(predicates::str::contains(
-            "Example contract method that takes a struct",
+            "Example contract method which takes a struct",
         ));
 }
 

--- a/cmd/soroban-cli/tests/it/custom_types.rs
+++ b/cmd/soroban-cli/tests/it/custom_types.rs
@@ -26,7 +26,7 @@ fn generate_help() {
         .assert()
         .success()
         .stdout(predicates::str::contains(
-            "Example contract method passing in a struct",
+            "Example contract method that takes a struct",
         ));
 }
 
@@ -117,8 +117,16 @@ fn strukt_help() {
     invoke(&Sandbox::new(), "strukt")
         .arg("--help")
         .assert()
-        .stdout(predicates::str::contains("Example contract method"))
-        .stdout(predicates::str::contains("Test Struct Docs"));
+        .stdout(predicates::str::contains("Example: --strukt"))
+        .stdout(predicates::str::contains("A Struct"));
+}
+
+#[test]
+fn complex_enum_help() {
+    invoke(&Sandbox::new(), "complex")
+        .arg("--help")
+        .assert()
+        .stdout(predicates::str::contains("--complex [\"Struct\","));
 }
 
 #[test]

--- a/cmd/soroban-cli/tests/it/custom_types.rs
+++ b/cmd/soroban-cli/tests/it/custom_types.rs
@@ -117,8 +117,12 @@ fn strukt_help() {
     invoke(&Sandbox::new(), "strukt")
         .arg("--help")
         .assert()
-        .stdout(predicates::str::contains("Example: --strukt"))
-        .stdout(predicates::str::contains("A Struct"));
+        .stdout(predicates::str::contains(
+            "Example:\n              --strukt '{ \"a\": 1, \"b\": true, \"c\": \"hello\" }'",
+        ))
+        .stdout(predicates::str::contains(
+            "This is from the rust doc above the struct Test",
+        ));
 }
 
 #[test]
@@ -126,7 +130,9 @@ fn complex_enum_help() {
     invoke(&Sandbox::new(), "complex")
         .arg("--help")
         .assert()
-        .stdout(predicates::str::contains("--complex [\"Struct\","));
+        .stdout(predicates::str::contains(
+            "--complex '[\"Struct\", { \"a\": 1, \"b\": true, \"c\": \"hello\" }]'",
+        ));
 }
 
 #[test]


### PR DESCRIPTION
### What

Each contract method argument provides a full type for UDT and add an example input.

Examples:

```
ssome_types 


USAGE:
    some_types [OPTIONS]

OPTIONS:
        --address <Address>                          Example:
                                                       --address GDIY6AQQ75WMD4W46EYB7O6UYMHOCGQHLAQGQTKHDX4J2DYQCHVCR4W4
        --bool                                       Example:
                                                       --bool 
    -h, --help                                       Print help information
        --i32 <i32>                                  Example:
                                                       --i32 -1
        --option <Option<u32>>                       Example:
                                                       --option 1
        --set <Set<Address>>                         Example:
                                                       --set '[ "GDIY6AQQ75WMD4W46EYB7O6UYMHOCGQHLAQGQTKHDX4J2DYQCHVCR4W4" ]'
        --strukt <{ a: u32, b: bool, c: Symbol }>    This is from the rust doc above the struct Test
                                                     Example:
                                                       --strukt '{ "a": 1, "b": true, "c": "hello" }'
        --symbol <Symbol>                            Example:
                                                       --symbol hello
        --tuple <Tuple<Symbol, Address>>             Example:
                                                       --tuple '["hello", "GDIY6AQQ75WMD4W46EYB7O6UYMHOCGQHLAQGQTKHDX4J2DYQCHVCR4W4"]'
        --vec <Array<u32>>                           Example:
                                                       --vec '[ 1 ]'
```
```
othertypes 


USAGE:
    othertypes [OPTIONS]

OPTIONS:
        --bytes <hex_bytes>                       Example:
                                                    --bytes beefface123
        --bytes_n <9_hex_bytes>                   Example:
                                                    --bytes_n efefefefefefefefe
        --const_enum <11 | 12 | 13>               Example:
                                                    --const_enum 11
    -h, --help                                    Print help information
        --map <Map<Symbol, u128>>                 Example:
                                                    --map '{"hello": "1000" }'
        --simple_enum <First | Second | Third>    Example:
                                                    --simple_enum First
```

### Why

Currently it is difficult to understand how an XDR argument should be encoded into JSON.  By providing the type info and an example it should make it easier for users.

### Known limitations

Struct and map examples should include two different options for different shells.  For *sh's you can do the following `'{"a": 1}'` vs `"{\"a\": 1}"`.
