### PR TITLE
update e2e to use latest system-test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,7 +18,7 @@ jobs:
 
       # the soroban tools source code to compile and run from system test
       # refers to checked out source of current git hub ref context 
-      SYSTEM_TEST_SOROBAN_TOOLS_REF: ${{ $GITHUB_WORKSPACE/soroban-tools }}
+      SYSTEM_TEST_SOROBAN_TOOLS_REF: ${{ github.workspace }}/soroban-tools
 
       # core git ref should be latest commit for stable soroban functionality
       # the core bin can either be compiled in-line here as part of ci, 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,30 +13,61 @@ jobs:
         scenario-filter: ["^TestDappDevelop$/^.*$"]
     runs-on: ubuntu-latest
     env:
-      TOOLS_REF: ${{ github.ref }}
-      SYSTEM_TEST_GIT_REF: v1.0.6
-      # core git ref is latest commit for stable soroban functionality
-      SYSTEM_TEST_CORE_GIT_REF: 871accefc0c4a703c1321b4f0e48cf6e03b41960
-      SYSTEM_TEST_CORE_COMPILE_CONFIGURE_FLAGS: "--disable-tests --enable-next-protocol-version-unsafe-for-production"
+      # the gh tag of system-test repo version to run 
+      SYSTEM_TEST_GIT_REF: v1.0.7
+
+      # the soroban tools source code to compile and run from system test
+      # refers to checked out source of current git hub ref context 
+      SYSTEM_TEST_SOROBAN_TOOLS_REF: ${{ $GITHUB_WORKSPACE/soroban-tools }}
+
+      # core git ref should be latest commit for stable soroban functionality
+      # the core bin can either be compiled in-line here as part of ci, 
+      # SYSTEM_TEST_CORE_GIT_REF: 871accefc0c4a703c1321b4f0e48cf6e03b41960
+      # SYSTEM_TEST_CORE_COMPILE_CONFIGURE_FLAGS: "--disable-tests --enable-next-protocol-version-unsafe-for-production"
+      # or can use option to pull a pre-compiled image instead, namely to save time during ci run
+      SYSTEM_TEST_CORE_IMAGE: sreuland/system-test-core:871accefc0c4a
       SYSTEM_TEST_RUST_TOOLCHAIN_VERSION: stable
-      SYSTEM_TEST_QUICKSTART_GIT_REF: master
+     
+      # system test will build quickstart image internally to use for running the service stack
+      # configured in standalone network mode(core, rpc)
+      SYSTEM_TEST_QUICKSTART_GIT_REF: https://github.com/stellar/quickstart#master
+      
+      # triggers system test to log out details from quickstart's logs and test steps
       SYSTEM_TEST_VERBOSE_OUTPUT: "true"
+
+      # the soroban test cases will compile contracts from the examples repo
       SYSTEM_TEST_SOROBAN_EXAMPLES_GIT_HASH: main
       SYSTEM_TEST_SOROBAN_EXAMPLES_GIT_REPO: "https://github.com/stellar/soroban-examples.git"
+      
+      # friendbot/horizon are not be used directly by soroban tests,
+      # however are required for system-test to build, providing pre-compiled images
+      # shortens the ci run time. 
+      # These image refs are of latest tagged commit on go/soroban-xdr-next
+      SYSTEM_TEST_FRIENDBOT_IMAGE: sreuland/system-test-friendbot:ab3ce11f409
+      SYSTEM_TEST_HORIZON_IMAGE: sreuland/system-test-horizon:ab3ce11f409
     steps:
       - uses: actions/checkout@v3
         with:
           repository: stellar/system-test
           ref: ${{ env.SYSTEM_TEST_GIT_REF }}
-      - uses: stellar/actions/rust-cache@main 
+          path: system-test
+      - uses: actions/checkout@v3
+        with:
+          path: soroban-tools
+      - uses: stellar/actions/rust-cache@main
       - name: Build system test with component versions
         run: |
-          make CORE_GIT_REF=$SYSTEM_TEST_CORE_GIT_REF \
+          cd $GITHUB_WORKSPACE/system-test; \
+          make \
+              CORE_GIT_REF=$SYSTEM_TEST_CORE_GIT_REF \
               CORE_COMPILE_CONFIGURE_FLAGS="$SYSTEM_TEST_CORE_COMPILE_CONFIGURE_FLAGS" \
-              SOROBAN_RPC_GIT_REF=$TOOLS_REF \
+              CORE_IMAGE=$SYSTEM_TEST_CORE_IMAGE \
+              SOROBAN_RPC_GIT_REF=$SYSTEM_TEST_SOROBAN_TOOLS_REF \
+              SOROBAN_CLI_GIT_REF=$SYSTEM_TEST_SOROBAN_TOOLS_REF \
               RUST_TOOLCHAIN_VERSION=$SYSTEM_TEST_RUST_TOOLCHAIN_VERSION \
-              SOROBAN_CLI_GIT_REF=$TOOLS_REF \
               QUICKSTART_GIT_REF=$SYSTEM_TEST_QUICKSTART_GIT_REF \
+              HORIZON_IMAGE=$SYSTEM_TEST_HORIZON_IMAGE \
+              FRIENDBOT_IMAGE=$SYSTEM_TEST_FRIENDBOT_IMAGE \
               build
       - name: Run system test scenarios
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,7 +30,7 @@ jobs:
      
       # system test will build quickstart image internally to use for running the service stack
       # configured in standalone network mode(core, rpc)
-      SYSTEM_TEST_QUICKSTART_GIT_REF: https://github.com/stellar/quickstart#master
+      SYSTEM_TEST_QUICKSTART_GIT_REF: https://github.com/stellar/quickstart.git#master
       
       # triggers system test to log out details from quickstart's logs and test steps
       SYSTEM_TEST_VERBOSE_OUTPUT: "true"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         scenario-filter: ["^TestDappDevelop$/^.*$"]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     env:
       # the gh tag of system-test repo version to run 
       SYSTEM_TEST_GIT_REF: v1.0.7
@@ -22,10 +22,13 @@ jobs:
 
       # core git ref should be latest commit for stable soroban functionality
       # the core bin can either be compiled in-line here as part of ci, 
-      SYSTEM_TEST_CORE_GIT_REF: https://github.com/stellar/stellar-core.git#871accefc0c4a703c1321b4f0e48cf6e03b41960
-      SYSTEM_TEST_CORE_COMPILE_CONFIGURE_FLAGS: "--disable-tests --enable-next-protocol-version-unsafe-for-production"
+      #SYSTEM_TEST_CORE_GIT_REF: https://github.com/stellar/stellar-core.git#871accefc0c4a703c1321b4f0e48cf6e03b41960
+      #SYSTEM_TEST_CORE_COMPILE_CONFIGURE_FLAGS: "--disable-tests --enable-next-protocol-version-unsafe-for-production"
       # or can use option to pull a pre-compiled image instead
-      # SYSTEM_TEST_CORE_IMAGE: sreuland/system-test-core:871accefc0c4a
+      SYSTEM_TEST_CORE_IMAGE: sreuland/system-test-core:871accefc0c4a
+      
+      # sets the version of rust toolchain that will be pre-installed in the 
+      # test runtime environment, tests invoke rustc/cargo
       SYSTEM_TEST_RUST_TOOLCHAIN_VERSION: stable
      
       # system test will build quickstart image internally to use for running the service stack

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,7 @@ jobs:
 
       # core git ref should be latest commit for stable soroban functionality
       # the core bin can either be compiled in-line here as part of ci, 
-      SYSTEM_TEST_CORE_GIT_REF: 871accefc0c4a703c1321b4f0e48cf6e03b41960
+      SYSTEM_TEST_CORE_GIT_REF: https://github.com/stellar/stellar-core.git#871accefc0c4a703c1321b4f0e48cf6e03b41960
       SYSTEM_TEST_CORE_COMPILE_CONFIGURE_FLAGS: "--disable-tests --enable-next-protocol-version-unsafe-for-production"
       # or can use option to pull a pre-compiled image instead
       # SYSTEM_TEST_CORE_IMAGE: sreuland/system-test-core:871accefc0c4a

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,10 +22,10 @@ jobs:
 
       # core git ref should be latest commit for stable soroban functionality
       # the core bin can either be compiled in-line here as part of ci, 
-      #SYSTEM_TEST_CORE_GIT_REF: https://github.com/stellar/stellar-core.git#871accefc0c4a703c1321b4f0e48cf6e03b41960
-      #SYSTEM_TEST_CORE_COMPILE_CONFIGURE_FLAGS: "--disable-tests --enable-next-protocol-version-unsafe-for-production"
+      SYSTEM_TEST_CORE_GIT_REF: https://github.com/stellar/stellar-core.git#871accefc0c4a703c1321b4f0e48cf6e03b41960
+      SYSTEM_TEST_CORE_COMPILE_CONFIGURE_FLAGS: "--disable-tests --enable-next-protocol-version-unsafe-for-production"
       # or can use option to pull a pre-compiled image instead
-      SYSTEM_TEST_CORE_IMAGE: sreuland/system-test-core:871accefc0c4a
+      # SYSTEM_TEST_CORE_IMAGE: 
       
       # sets the version of rust toolchain that will be pre-installed in the 
       # test runtime environment, tests invoke rustc/cargo

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,10 +22,10 @@ jobs:
 
       # core git ref should be latest commit for stable soroban functionality
       # the core bin can either be compiled in-line here as part of ci, 
-      # SYSTEM_TEST_CORE_GIT_REF: 871accefc0c4a703c1321b4f0e48cf6e03b41960
-      # SYSTEM_TEST_CORE_COMPILE_CONFIGURE_FLAGS: "--disable-tests --enable-next-protocol-version-unsafe-for-production"
-      # or can use option to pull a pre-compiled image instead, namely to save time during ci run
-      SYSTEM_TEST_CORE_IMAGE: sreuland/system-test-core:871accefc0c4a
+      SYSTEM_TEST_CORE_GIT_REF: 871accefc0c4a703c1321b4f0e48cf6e03b41960
+      SYSTEM_TEST_CORE_COMPILE_CONFIGURE_FLAGS: "--disable-tests --enable-next-protocol-version-unsafe-for-production"
+      # or can use option to pull a pre-compiled image instead
+      # SYSTEM_TEST_CORE_IMAGE: sreuland/system-test-core:871accefc0c4a
       SYSTEM_TEST_RUST_TOOLCHAIN_VERSION: stable
      
       # system test will build quickstart image internally to use for running the service stack
@@ -35,16 +35,9 @@ jobs:
       # triggers system test to log out details from quickstart's logs and test steps
       SYSTEM_TEST_VERBOSE_OUTPUT: "true"
 
-      # the soroban test cases will compile contracts from the examples repo
+      # the soroban test cases will compile various contracts from the examples repo
       SYSTEM_TEST_SOROBAN_EXAMPLES_GIT_HASH: main
       SYSTEM_TEST_SOROBAN_EXAMPLES_GIT_REPO: "https://github.com/stellar/soroban-examples.git"
-      
-      # friendbot/horizon are not be used directly by soroban tests,
-      # however are required for system-test to build, providing pre-compiled images
-      # shortens the ci run time. 
-      # These image refs are of latest tagged commit on go/soroban-xdr-next
-      SYSTEM_TEST_FRIENDBOT_IMAGE: sreuland/system-test-friendbot:ab3ce11f409
-      SYSTEM_TEST_HORIZON_IMAGE: sreuland/system-test-horizon:ab3ce11f409
     steps:
       - uses: actions/checkout@v3
         with:
@@ -66,8 +59,6 @@ jobs:
               SOROBAN_CLI_GIT_REF=$SYSTEM_TEST_SOROBAN_TOOLS_REF \
               RUST_TOOLCHAIN_VERSION=$SYSTEM_TEST_RUST_TOOLCHAIN_VERSION \
               QUICKSTART_GIT_REF=$SYSTEM_TEST_QUICKSTART_GIT_REF \
-              HORIZON_IMAGE=$SYSTEM_TEST_HORIZON_IMAGE \
-              FRIENDBOT_IMAGE=$SYSTEM_TEST_FRIENDBOT_IMAGE \
               build
       - name: Run system test scenarios
         run: |


### PR DESCRIPTION
### What

updating system-test to use newer [1.0.7 system-test ](https://github.com/stellar/system-test/releases/tag/v1.0.7) version which has new test coverage on auth next, fix for latest cli compatibility(removal of the `--fn`), and some speed improvements on e2e test run duration.

[update] some performance testing results, using a larger gh runner profile with more cores sped up workflow execution of the system test suite, reducing typical 50+ minute duration to about 24 minutes. Furthermore, using a pre-compiled image for core, cut the duration time down to about 15 minutes. However, holding off on using core images for now from system test, since they are not published yet.

### Why

more test coverage on soroban functionality([auth next](https://github.com/stellar/system-test/pull/34)) and faster ci runtime

### Known limitations


