### PR TITLE
Add support for soroban-cli --version flag

### DIFF
--- a/cmd/soroban-cli/src/main.rs
+++ b/cmd/soroban-cli/src/main.rs
@@ -19,10 +19,10 @@ const HEADING_RPC: &str = "OPTIONS (RPC)";
 #[derive(Parser, Debug)]
 #[clap(
     name = "soroban",
-    version,
+    version = Box::leak(Box::new(version::short())).as_str(),
+    long_version = Box::leak(Box::new(version::long())).as_str(),
     about = "https://soroban.stellar.org",
     disable_help_subcommand = true,
-    disable_version_flag = true
 )]
 #[clap(global_setting(AppSettings::DeriveDisplayOrder))]
 struct Root {

--- a/cmd/soroban-cli/src/version.rs
+++ b/cmd/soroban-cli/src/version.rs
@@ -10,19 +10,27 @@ pub struct Cmd;
 impl Cmd {
     #[allow(clippy::unused_self)]
     pub fn run(&self) {
-        println!("soroban {} ({GIT_REVISION})", env!("CARGO_PKG_VERSION"));
+        println!("{}", long());
+    }
+}
 
-        let env = soroban_env_host::VERSION;
-        println!("soroban-env {} ({})", env.pkg, env.rev);
-        println!("soroban-env interface version {}", meta::INTERFACE_VERSION);
+pub fn short() -> String {
+    format!("{} ({GIT_REVISION})", env!("CARGO_PKG_VERSION"))
+}
 
-        let xdr = soroban_env_host::VERSION.xdr;
-        println!(
+pub fn long() -> String {
+    let env = soroban_env_host::VERSION;
+    let xdr = soroban_env_host::VERSION.xdr;
+    vec![
+        short(),
+        format!("soroban-env {} ({})", env.pkg, env.rev),
+        format!("soroban-env interface version {}", meta::INTERFACE_VERSION),
+        format!(
             "stellar-xdr {} ({})
 xdr next ({})",
             xdr.pkg, xdr.rev, xdr.xdr_next,
-        );
-    }
+        ),
+    ].join("\n")
 }
 
 // Check that the XDR cannel in use is 'next' to ensure that the version output


### PR DESCRIPTION
### What

Use `clap` flags to enable support for:
```sh
$ soroban -V
soroban 0.6.0 (v0.6.1-19-g1b1557497b33f15f114d9b278385c20ec898bf0a)

$ soroban --version
soroban 0.6.0 (v0.6.1-19-g1b1557497b33f15f114d9b278385c20ec898bf0a)
soroban-env 0.0.14 (d06aaddca61f011cc64ec098b464233423197c3a)
soroban-env interface version 29
stellar-xdr 0.0.14 (55f47d302a3bbcd34cf32bfcd28abccfaeffc5e0)
xdr next (df18148747e807618acf4639db41c4fd6f0be9fc)
```

### Why

Because I keep typing `soroban --version` and expecting it to work, so other people probably do too.

### Known limitations

This does not remove `soroban version` subcommand. However the `-V/--version` flags override any subcommands. So:
```sh
$ soroban -V contract # if we specify both -V and a subcommand:
soroban 0.6.0 (v0.6.1-19-g1b1557497b33f15f114d9b278385c20ec898bf0a)
```
