### PR TITLE
soroban-rpc: Store all ledger entry types

### DIFF
--- a/cmd/soroban-rpc/internal/ingest/ledgerentry.go
+++ b/cmd/soroban-rpc/internal/ingest/ledgerentry.go
@@ -32,50 +32,16 @@ func (s *Service) ingestLedgerEntryChanges(ctx context.Context, reader ingest.Ch
 
 func ingestLedgerEntryChange(writer db.LedgerEntryWriter, change ingest.Change) error {
 	if change.Post == nil {
-		ledgerKey, relevant, err := getRelevantLedgerKeyFromData(change.Pre.Data)
+		ledgerKey, err := xdr.GetLedgerKeyFromData(change.Pre.Data)
 		if err != nil {
 			return err
 		}
-		if !relevant {
-			return nil
-		}
-
 		return writer.DeleteLedgerEntry(ledgerKey)
 	} else {
-		ledgerKey, relevant, err := getRelevantLedgerKeyFromData(change.Post.Data)
+		ledgerKey, err := xdr.GetLedgerKeyFromData(change.Post.Data)
 		if err != nil {
 			return err
 		}
-		if !relevant {
-			return nil
-		}
-
 		return writer.UpsertLedgerEntry(ledgerKey, *change.Post)
 	}
-}
-
-func getRelevantLedgerKeyFromData(data xdr.LedgerEntryData) (xdr.LedgerKey, bool, error) {
-	var key xdr.LedgerKey
-	switch data.Type {
-	case xdr.LedgerEntryTypeAccount:
-		if err := key.SetAccount(data.Account.AccountId); err != nil {
-			return key, false, err
-		}
-	case xdr.LedgerEntryTypeTrustline:
-		if err := key.SetTrustline(data.TrustLine.AccountId, data.TrustLine.Asset); err != nil {
-			return key, false, err
-		}
-	case xdr.LedgerEntryTypeContractData:
-		if err := key.SetContractData(data.ContractData.ContractId, data.ContractData.Key); err != nil {
-			return key, false, err
-		}
-	case xdr.LedgerEntryTypeContractCode:
-		if err := key.SetContractCode(data.ContractCode.Hash); err != nil {
-			return key, false, err
-		}
-	default:
-		// we don't care about any other entry types for now
-		return key, false, nil
-	}
-	return key, true, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -3,22 +3,24 @@ module github.com/stellar/soroban-tools
 go 1.20
 
 require (
+	github.com/Masterminds/squirrel v1.5.0
 	github.com/creachadair/jrpc2 v0.41.1
 	github.com/go-git/go-git/v5 v5.4.2
+	github.com/jmoiron/sqlx v1.2.0
 	github.com/mattn/go-sqlite3 v1.14.16
+	github.com/pelletier/go-toml v1.9.0
+	github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00
 	github.com/rubenv/sql-migrate v0.0.0-20190717103323-87ce952f7079
 	github.com/sirupsen/logrus v1.4.1
 	github.com/spf13/cobra v0.0.0-20160830174925-9c28e4bbd74e
 	github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189
+	github.com/stellar/go v0.0.0-20230307175517-b2d1e113c534
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/mod v0.6.0
 )
 
-require gopkg.in/gorp.v1 v1.7.1 // indirect
-
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
-	github.com/Masterminds/squirrel v1.5.0
 	github.com/Microsoft/go-winio v0.4.16 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect
@@ -36,7 +38,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
-	github.com/jmoiron/sqlx v1.2.0
 	github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
 	github.com/kr/pretty v0.2.1 // indirect
@@ -48,21 +49,18 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v0.0.0-20150613213606-2caf8efc9366 // indirect
-	github.com/pelletier/go-toml v1.9.0
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829 // indirect
 	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 // indirect
 	github.com/prometheus/common v0.2.0 // indirect
 	github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1 // indirect
-	github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00
 	github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521 // indirect
 	github.com/segmentio/go-loggly v0.5.1-0.20171222203950-eb91657e62b2 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/spf13/cast v0.0.0-20150508191742-4d07383ffe94 // indirect
 	github.com/spf13/jwalterweatherman v0.0.0-20141219030609-3d60171a6431 // indirect
 	github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475 // indirect
-	github.com/stellar/go v0.0.0-20230215201937-ab3ce11f4093
 	github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee // indirect
 	github.com/stretchr/objx v0.4.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.0 // indirect
@@ -72,6 +70,7 @@ require (
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 // indirect
 	golang.org/x/sys v0.1.0 // indirect
 	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/gorp.v1 v1.7.1 // indirect
 	gopkg.in/tylerb/graceful.v1 v1.2.13 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475 h1:RtZIgreTwcayPTOw7G5
 github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189 h1:fvB1AFbBd6SfI9Rd0ooAJp8uLkZDbZaLFHi7ZnNP6uI=
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
-github.com/stellar/go v0.0.0-20230215201937-ab3ce11f4093 h1:hcp2zZ2r2erWoVDUIaeZ9ZDuH5gf779mYyIZ3x4dDSo=
-github.com/stellar/go v0.0.0-20230215201937-ab3ce11f4093/go.mod h1:QXwuKmYVvqQZlByv0EeNb0Rgog9AP+eMmARcdt3h2rI=
+github.com/stellar/go v0.0.0-20230307175517-b2d1e113c534 h1:ecxXXWGTHRY765WueJi8QCN21Ckxb0XNIRDbNbZ5TG4=
+github.com/stellar/go v0.0.0-20230307175517-b2d1e113c534/go.mod h1:QXwuKmYVvqQZlByv0EeNb0Rgog9AP+eMmARcdt3h2rI=
 github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee h1:fbVs0xmXpBvVS4GBeiRmAE3Le70ofAqFMch1GTiq/e8=
 github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
### What

Store the value of all the ledger entries, regardless of their type.

### Why

https://github.com/stellar/soroban-tools/issues/378

This will allow the `getLedgerEntry` method to work for any ledger entry type (initially we only enabled the entries needed to implement `simulateTransaction`).

### Known limitations

In pubnet, it adds ~5GB extra to the DB (which isn't much since we are already at 27GB, most of which is from 24h of txmeta)
