### PR TITLE
soroban-rpc: Limit preflight-computation concurrency through a worker pool

### DIFF
--- a/cmd/soroban-rpc/internal/config/config.go
+++ b/cmd/soroban-rpc/internal/config/config.go
@@ -27,4 +27,5 @@ type LocalConfig struct {
 	MaxEventsLimit                   uint
 	DefaultEventsLimit               uint
 	MaxHealthyLedgerLatency          time.Duration
+	PreflightWorkerCount             uint
 }

--- a/cmd/soroban-rpc/internal/jsonrpc.go
+++ b/cmd/soroban-rpc/internal/jsonrpc.go
@@ -38,6 +38,7 @@ type HandlerParams struct {
 	CoreClient        *stellarcore.Client
 	LedgerEntryReader db.LedgerEntryReader
 	Logger            *log.Entry
+	PreflightGetter   methods.PreflightGetter
 }
 
 // NewJSONRPCHandler constructs a Handler instance
@@ -49,7 +50,7 @@ func NewJSONRPCHandler(cfg *config.LocalConfig, params HandlerParams) (Handler, 
 		"getLedgerEntry":      methods.NewGetLedgerEntryHandler(params.Logger, params.LedgerEntryReader),
 		"getTransaction":      methods.NewGetTransactionHandler(params.TransactionStore),
 		"sendTransaction":     methods.NewSendTransactionHandler(params.Logger, params.TransactionStore, cfg.NetworkPassphrase, params.CoreClient),
-		"simulateTransaction": methods.NewSimulateTransactionHandler(params.Logger, cfg.NetworkPassphrase, params.LedgerEntryReader),
+		"simulateTransaction": methods.NewSimulateTransactionHandler(params.Logger, params.PreflightGetter),
 	}, nil)
 	corsMiddleware := cors.New(cors.Options{
 		AllowedOrigins: []string{"*"},

--- a/cmd/soroban-rpc/internal/preflight/pool.go
+++ b/cmd/soroban-rpc/internal/preflight/pool.go
@@ -1,0 +1,72 @@
+package preflight
+
+import (
+	"context"
+	"sync"
+
+	"github.com/stellar/go/support/log"
+	"github.com/stellar/go/xdr"
+
+	"github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/db"
+)
+
+type workerResult struct {
+	preflight Preflight
+	err       error
+}
+
+type workerRequest struct {
+	ctx        context.Context
+	params     PreflightParameters
+	resultChan chan<- workerResult
+}
+
+type PreflightWorkerPool struct {
+	ledgerEntryReader db.LedgerEntryReader
+	networkPassphrase string
+	logger            *log.Entry
+	requestChan       chan workerRequest
+	wg                sync.WaitGroup
+}
+
+func NewPreflightWorkerPool(workerCount uint, ledgerEntryReader db.LedgerEntryReader, networkPassphrase string, logger *log.Entry) *PreflightWorkerPool {
+	result := PreflightWorkerPool{
+		ledgerEntryReader: ledgerEntryReader,
+		networkPassphrase: networkPassphrase,
+		logger:            logger,
+		requestChan:       make(chan workerRequest),
+	}
+	for i := uint(0); i < workerCount; i++ {
+		result.wg.Add(1)
+		go result.work()
+	}
+	return &result
+}
+
+func (pwp *PreflightWorkerPool) work() {
+	defer pwp.wg.Done()
+	for request := range pwp.requestChan {
+		preflight, err := GetPreflight(request.ctx, request.params)
+		request.resultChan <- workerResult{preflight, err}
+	}
+}
+
+func (pwp *PreflightWorkerPool) Close() {
+	close(pwp.requestChan)
+	pwp.wg.Wait()
+}
+
+func (pwp *PreflightWorkerPool) GetPreflight(ctx context.Context, sourceAccount xdr.AccountId, op xdr.InvokeHostFunctionOp) (Preflight, error) {
+	params := PreflightParameters{
+		Logger:             pwp.logger,
+		SourceAccount:      sourceAccount,
+		InvokeHostFunction: op,
+		NetworkPassphrase:  pwp.networkPassphrase,
+		LedgerEntryReader:  pwp.ledgerEntryReader,
+	}
+	resultC := make(chan workerResult)
+	defer close(resultC)
+	pwp.requestChan <- workerRequest{ctx, params, resultC}
+	result := <-resultC
+	return result.preflight, result.err
+}

--- a/cmd/soroban-rpc/internal/test/integration.go
+++ b/cmd/soroban-rpc/internal/test/integration.go
@@ -9,6 +9,7 @@ import (
 	"os/signal"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"sync"
 	"syscall"
@@ -113,6 +114,7 @@ func (i *Test) launchDaemon() {
 		MaxEventsLimit:                   10000,
 		DefaultEventsLimit:               100,
 		MaxHealthyLedgerLatency:          time.Second * 10,
+		PreflightWorkerCount:             uint(runtime.NumCPU()),
 	}
 	i.daemon = daemon.MustNew(config)
 	i.server = httptest.NewServer(i.daemon)

--- a/cmd/soroban-rpc/main.go
+++ b/cmd/soroban-rpc/main.go
@@ -5,6 +5,7 @@ import (
 	"go/types"
 	"math"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
@@ -226,6 +227,14 @@ func main() {
 			ConfigKey:   &maxHealthyLedgerLatencySeconds,
 			FlagDefault: uint(30),
 			Required:    false,
+		},
+		{
+			Name:        "preflight-worker-count",
+			ConfigKey:   &serviceConfig.PreflightWorkerCount,
+			OptType:     types.Uint,
+			Required:    false,
+			FlagDefault: uint(runtime.NumCPU()),
+			Usage:       "Number of workers (read goroutines) used to compute preflights",
 		},
 	}
 	cmd := &cobra.Command{

--- a/cmd/soroban-rpc/main.go
+++ b/cmd/soroban-rpc/main.go
@@ -256,7 +256,7 @@ func main() {
 				os.Exit(-1)
 			}
 			if serviceConfig.PreflightWorkerCount < 1 {
-				fmt.Print("preflight-worker-count must be > 0")
+				fmt.Println("preflight-worker-count must be > 0")
 				os.Exit(-1)
 			}
 

--- a/cmd/soroban-rpc/main.go
+++ b/cmd/soroban-rpc/main.go
@@ -255,6 +255,10 @@ func main() {
 				)
 				os.Exit(-1)
 			}
+			if serviceConfig.PreflightWorkerCount < 1 {
+				fmt.Print("preflight-worker-count must be > 0")
+				os.Exit(-1)
+			}
 
 			serviceConfig.CaptiveCoreHTTPPort = uint16(captiveCoreHTTPPort)
 			if serviceConfig.StellarCoreURL == "" {


### PR DESCRIPTION
### What

Limit preflight-computation concurrency through a worker pool

The number of workers can be configured through `--preflight-worker-count` and defaults to the number of CPUs in the machine.

### Why

preflight-obtention is CPU-bound, according to @tsachiherman it is a good idea to limit it to the number of course. 

### Known limitations

I am on the fence about this though (the OS will be self-limiting in this regard). Also, although the worker pool code is not overly complicated it does add some complexity.
