### PR TITLE
soroban-rpc: adapt to value overhaul changes

### DIFF
--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -90,7 +90,7 @@ jobs:
     env:
       SOROBAN_RPC_INTEGRATION_TESTS_ENABLED: true
       SOROBAN_RPC_INTEGRATION_TESTS_CAPTIVE_CORE_BIN: /usr/bin/stellar-core
-      PROTOCOL_20_CORE_DEBIAN_PKG_VERSION: 19.7.1-1204.871accefc.focal~soroban
+      PROTOCOL_20_CORE_DEBIAN_PKG_VERSION: 19.8.1-1238.903afe5e1.focal~soroban
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/cmd/soroban-rpc/internal/methods/get_events_test.go
+++ b/cmd/soroban-rpc/internal/methods/get_events_test.go
@@ -22,10 +22,10 @@ func TestTopicFilterMatches(t *testing.T) {
 		Type: xdr.ScValTypeScvSymbol,
 		Sym:  &transferSym,
 	}
-	sixtyfour := xdr.Int64(64)
+	sixtyfour := xdr.Uint64(64)
 	number := xdr.ScVal{
-		Type: xdr.ScValTypeScvU63,
-		U63:  &sixtyfour,
+		Type: xdr.ScValTypeScvU64,
+		U64:  &sixtyfour,
 	}
 	star := "*"
 	for _, tc := range []struct {
@@ -191,8 +191,8 @@ func TestTopicFilterJSON(t *testing.T) {
 	assert.NoError(t, json.Unmarshal([]byte("[\"*\"]"), &got))
 	assert.Equal(t, TopicFilter{{wildcard: &star}}, got)
 
-	sixtyfour := xdr.Int64(64)
-	scval := xdr.ScVal{Type: xdr.ScValTypeScvU63, U63: &sixtyfour}
+	sixtyfour := xdr.Uint64(64)
+	scval := xdr.ScVal{Type: xdr.ScValTypeScvU64, U64: &sixtyfour}
 	scvalstr, err := xdr.MarshalBase64(scval)
 	assert.NoError(t, err)
 	assert.NoError(t, json.Unmarshal([]byte(fmt.Sprintf("[%q]", scvalstr)), &got))
@@ -514,7 +514,7 @@ func TestGetEvents(t *testing.T) {
 		var txMeta []xdr.TransactionMeta
 		contractID := xdr.Hash([32]byte{})
 		for i := 0; i < 10; i++ {
-			number := xdr.Int64(i)
+			number := xdr.Uint64(i)
 			txMeta = append(txMeta, transactionMetaWithEvents(
 				[]xdr.ContractEvent{
 					// Generate a unique topic like /counter/4 for each event so we can check
@@ -522,16 +522,16 @@ func TestGetEvents(t *testing.T) {
 						contractID,
 						xdr.ScVec{
 							xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &counter},
-							xdr.ScVal{Type: xdr.ScValTypeScvU63, U63: &number},
+							xdr.ScVal{Type: xdr.ScValTypeScvU64, U64: &number},
 						},
-						xdr.ScVal{Type: xdr.ScValTypeScvU63, U63: &number},
+						xdr.ScVal{Type: xdr.ScValTypeScvU64, U64: &number},
 					),
 				},
 			))
 		}
 		assert.NoError(t, store.IngestEvents(ledgerCloseMetaWithEvents(1, now.Unix(), txMeta...)))
 
-		number := xdr.Int64(4)
+		number := xdr.Uint64(4)
 		handler := eventsRPCHandler{
 			scanner:      store,
 			maxLimit:     10000,
@@ -543,7 +543,7 @@ func TestGetEvents(t *testing.T) {
 				{Topics: []TopicFilter{
 					[]SegmentFilter{
 						{scval: &xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &counter}},
-						{scval: &xdr.ScVal{Type: xdr.ScValTypeScvU63, U63: &number}},
+						{scval: &xdr.ScVal{Type: xdr.ScValTypeScvU64, U64: &number}},
 					},
 				}},
 			},
@@ -553,8 +553,8 @@ func TestGetEvents(t *testing.T) {
 		id := events.Cursor{Ledger: 1, Tx: 5, Op: 0, Event: 0}.String()
 		assert.NoError(t, err)
 		value, err := xdr.MarshalBase64(xdr.ScVal{
-			Type: xdr.ScValTypeScvU63,
-			U63:  &number,
+			Type: xdr.ScValTypeScvU64,
+			U64:  &number,
 		})
 		assert.NoError(t, err)
 		expected := []EventInfo{
@@ -576,7 +576,7 @@ func TestGetEvents(t *testing.T) {
 		store := events.NewMemoryStore("unit-tests", 100)
 		contractID := xdr.Hash([32]byte{})
 		otherContractID := xdr.Hash([32]byte{1})
-		number := xdr.Int64(1)
+		number := xdr.Uint64(1)
 		txMeta := []xdr.TransactionMeta{
 			// This matches neither the contract id nor the topic
 			transactionMetaWithEvents([]xdr.ContractEvent{
@@ -585,7 +585,7 @@ func TestGetEvents(t *testing.T) {
 					xdr.ScVec{
 						xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &counter},
 					},
-					xdr.ScVal{Type: xdr.ScValTypeScvU63, U63: &number},
+					xdr.ScVal{Type: xdr.ScValTypeScvU64, U64: &number},
 				),
 			}),
 			// This matches the contract id but not the topic
@@ -595,7 +595,7 @@ func TestGetEvents(t *testing.T) {
 					xdr.ScVec{
 						xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &counter},
 					},
-					xdr.ScVal{Type: xdr.ScValTypeScvU63, U63: &number},
+					xdr.ScVal{Type: xdr.ScValTypeScvU64, U64: &number},
 				),
 			}),
 			// This matches the topic but not the contract id
@@ -604,9 +604,9 @@ func TestGetEvents(t *testing.T) {
 					otherContractID,
 					xdr.ScVec{
 						xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &counter},
-						xdr.ScVal{Type: xdr.ScValTypeScvU63, U63: &number},
+						xdr.ScVal{Type: xdr.ScValTypeScvU64, U64: &number},
 					},
-					xdr.ScVal{Type: xdr.ScValTypeScvU63, U63: &number},
+					xdr.ScVal{Type: xdr.ScValTypeScvU64, U64: &number},
 				),
 			}),
 			// This matches both the contract id and the topic
@@ -615,9 +615,9 @@ func TestGetEvents(t *testing.T) {
 					contractID,
 					xdr.ScVec{
 						xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &counter},
-						xdr.ScVal{Type: xdr.ScValTypeScvU63, U63: &number},
+						xdr.ScVal{Type: xdr.ScValTypeScvU64, U64: &number},
 					},
-					xdr.ScVal{Type: xdr.ScValTypeScvU63, U63: &number},
+					xdr.ScVal{Type: xdr.ScValTypeScvU64, U64: &number},
 				),
 			}),
 		}
@@ -636,7 +636,7 @@ func TestGetEvents(t *testing.T) {
 					Topics: []TopicFilter{
 						[]SegmentFilter{
 							{scval: &xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &counter}},
-							{scval: &xdr.ScVal{Type: xdr.ScValTypeScvU63, U63: &number}},
+							{scval: &xdr.ScVal{Type: xdr.ScValTypeScvU64, U64: &number}},
 						},
 					},
 				},
@@ -646,8 +646,8 @@ func TestGetEvents(t *testing.T) {
 
 		id := events.Cursor{Ledger: 1, Tx: 4, Op: 0, Event: 0}.String()
 		value, err := xdr.MarshalBase64(xdr.ScVal{
-			Type: xdr.ScValTypeScvU63,
-			U63:  &number,
+			Type: xdr.ScValTypeScvU64,
+			U64:  &number,
 		})
 		assert.NoError(t, err)
 		expected := []EventInfo{
@@ -722,15 +722,15 @@ func TestGetEvents(t *testing.T) {
 		contractID := xdr.Hash([32]byte{})
 		var txMeta []xdr.TransactionMeta
 		for i := 0; i < 180; i++ {
-			number := xdr.Int64(i)
+			number := xdr.Uint64(i)
 			txMeta = append(txMeta, transactionMetaWithEvents(
 				[]xdr.ContractEvent{
 					contractEvent(
 						contractID,
 						xdr.ScVec{
-							xdr.ScVal{Type: xdr.ScValTypeScvU63, U63: &number},
+							xdr.ScVal{Type: xdr.ScValTypeScvU64, U64: &number},
 						},
-						xdr.ScVal{Type: xdr.ScValTypeScvU63, U63: &number},
+						xdr.ScVal{Type: xdr.ScValTypeScvU64, U64: &number},
 					),
 				},
 			))

--- a/cmd/soroban-rpc/internal/test/docker-compose.yml
+++ b/cmd/soroban-rpc/internal/test/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     # Note: Please keep the image pinned to an immutable tag matching the Captive Core version.
     #       This avoid implicit updates which break compatibility between
     #       the Core container and captive core.
-    image: ${CORE_IMAGE:-2opremio/stellar-core:19.7.1-1178.e352f0012.focal-soroban}
+    image: ${CORE_IMAGE:-2opremio/stellar-core:19.8.1-1238.903afe5e1.focal-soroban}
     depends_on:
       - core-postgres
     restart: on-failure

--- a/cmd/soroban-rpc/internal/test/get_ledger_entry_test.go
+++ b/cmd/soroban-rpc/internal/test/get_ledger_entry_test.go
@@ -31,7 +31,9 @@ func TestGetLedgerEntryNotFound(t *testing.T) {
 		Type: xdr.LedgerEntryTypeContractData,
 		ContractData: &xdr.LedgerKeyContractData{
 			ContractId: contractID,
-			Key:        getContractCodeLedgerKey(),
+			Key: xdr.ScVal{
+				Type: xdr.ScValTypeScvLedgerKeyContractExecutable,
+			},
 		},
 	})
 	require.NoError(t, err)

--- a/cmd/soroban-rpc/internal/test/transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/transaction_test.go
@@ -80,8 +80,8 @@ func TestSendTransactionSucceedsWithResults(t *testing.T) {
 	resultVal := *invokeHostFunctionResult.Success
 	expectedContractID, err := hex.DecodeString("ea9fcb81ae54a29f6b3bf293847d3fd7e9a369fd1c80acafec6abd571317e0c2")
 	assert.NoError(t, err)
-	expectedObj := &xdr.ScObject{Type: xdr.ScObjectTypeScoBytes, Bin: &expectedContractID}
-	expectedScVal := xdr.ScVal{Type: xdr.ScValTypeScvObject, Obj: &expectedObj}
+	contractIDBytes := xdr.ScBytes(expectedContractID)
+	expectedScVal := xdr.ScVal{Type: xdr.ScValTypeScvBytes, Bytes: &contractIDBytes}
 	assert.True(t, expectedScVal.Equals(resultVal))
 
 	expectedResult := xdr.TransactionResult{

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/sirupsen/logrus v1.4.1
 	github.com/spf13/cobra v0.0.0-20160830174925-9c28e4bbd74e
 	github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189
-	github.com/stellar/go v0.0.0-20230307175517-b2d1e113c534
+	github.com/stellar/go v0.0.0-20230320165241-a5f3278b8282
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/mod v0.6.0
 )

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475 h1:RtZIgreTwcayPTOw7G5
 github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189 h1:fvB1AFbBd6SfI9Rd0ooAJp8uLkZDbZaLFHi7ZnNP6uI=
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
-github.com/stellar/go v0.0.0-20230307175517-b2d1e113c534 h1:ecxXXWGTHRY765WueJi8QCN21Ckxb0XNIRDbNbZ5TG4=
-github.com/stellar/go v0.0.0-20230307175517-b2d1e113c534/go.mod h1:QXwuKmYVvqQZlByv0EeNb0Rgog9AP+eMmARcdt3h2rI=
+github.com/stellar/go v0.0.0-20230320165241-a5f3278b8282 h1:Lijy4+s8ZwC6omEHHI4zThxxqKkQ0q1JyUn0WLfKFgI=
+github.com/stellar/go v0.0.0-20230320165241-a5f3278b8282/go.mod h1:QXwuKmYVvqQZlByv0EeNb0Rgog9AP+eMmARcdt3h2rI=
 github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee h1:fbVs0xmXpBvVS4GBeiRmAE3Le70ofAqFMch1GTiq/e8=
 github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
### What

Adapt soroban-rpc to the new value overhaul XDR changes (that is https://github.com/stellar/go/pull/4814 , which in turn comes from https://github.com/stellar/stellar-xdr/pull/70 )

### Why

It's part of https://github.com/stellar/soroban-tools/issues/471

It closes https://github.com/stellar/soroban-tools/issues/477

### Known limitations

TODO:
- [ ] fix integration tests (it requires bumping the core build)