### PR TITLE
Bump all dependencies to support structured debug events

### DIFF
--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -90,7 +90,7 @@ jobs:
     env:
       SOROBAN_RPC_INTEGRATION_TESTS_ENABLED: true
       SOROBAN_RPC_INTEGRATION_TESTS_CAPTIVE_CORE_BIN: /usr/bin/stellar-core
-      PROTOCOL_20_CORE_DEBIAN_PKG_VERSION: 19.8.1-1238.903afe5e1.focal~soroban
+      PROTOCOL_20_CORE_DEBIAN_PKG_VERSION: 19.8.1-1243.53ea43ace.focal~soroban
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,7 +1898,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=d39dd845d5bf31f976cdfea9bc7c2f8da8396b6b#d39dd845d5bf31f976cdfea9bc7c2f8da8396b6b"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=7dde7cb0b35957856a1e0c11432e00532ae20cf8#7dde7cb0b35957856a1e0c11432e00532ae20cf8"
 dependencies = [
  "crate-git-revision",
  "ethnum",
@@ -1912,7 +1912,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=d39dd845d5bf31f976cdfea9bc7c2f8da8396b6b#d39dd845d5bf31f976cdfea9bc7c2f8da8396b6b"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=7dde7cb0b35957856a1e0c11432e00532ae20cf8#7dde7cb0b35957856a1e0c11432e00532ae20cf8"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1921,7 +1921,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=d39dd845d5bf31f976cdfea9bc7c2f8da8396b6b#d39dd845d5bf31f976cdfea9bc7c2f8da8396b6b"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=7dde7cb0b35957856a1e0c11432e00532ae20cf8#7dde7cb0b35957856a1e0c11432e00532ae20cf8"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -1943,7 +1943,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=d39dd845d5bf31f976cdfea9bc7c2f8da8396b6b#d39dd845d5bf31f976cdfea9bc7c2f8da8396b6b"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=7dde7cb0b35957856a1e0c11432e00532ae20cf8#7dde7cb0b35957856a1e0c11432e00532ae20cf8"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1958,7 +1958,7 @@ dependencies = [
 [[package]]
 name = "soroban-ledger-snapshot"
 version = "0.6.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=ab96798be9f4b77570ed032cb58743942592114a#ab96798be9f4b77570ed032cb58743942592114a"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=d6109a43262852d8374b60f18cb5304a3a368350#d6109a43262852d8374b60f18cb5304a3a368350"
 dependencies = [
  "serde",
  "serde_json",
@@ -1969,7 +1969,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=d39dd845d5bf31f976cdfea9bc7c2f8da8396b6b#d39dd845d5bf31f976cdfea9bc7c2f8da8396b6b"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=7dde7cb0b35957856a1e0c11432e00532ae20cf8#7dde7cb0b35957856a1e0c11432e00532ae20cf8"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1980,7 +1980,7 @@ dependencies = [
 [[package]]
 name = "soroban-sdk"
 version = "0.6.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=ab96798be9f4b77570ed032cb58743942592114a#ab96798be9f4b77570ed032cb58743942592114a"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=d6109a43262852d8374b60f18cb5304a3a368350#d6109a43262852d8374b60f18cb5304a3a368350"
 dependencies = [
  "bytes-lit",
  "ed25519-dalek",
@@ -1995,7 +1995,7 @@ dependencies = [
 [[package]]
 name = "soroban-sdk-macros"
 version = "0.6.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=ab96798be9f4b77570ed032cb58743942592114a#ab96798be9f4b77570ed032cb58743942592114a"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=d6109a43262852d8374b60f18cb5304a3a368350#d6109a43262852d8374b60f18cb5304a3a368350"
 dependencies = [
  "darling",
  "itertools",
@@ -2011,7 +2011,7 @@ dependencies = [
 [[package]]
 name = "soroban-spec"
 version = "0.6.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=ab96798be9f4b77570ed032cb58743942592114a#ab96798be9f4b77570ed032cb58743942592114a"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=d6109a43262852d8374b60f18cb5304a3a368350#d6109a43262852d8374b60f18cb5304a3a368350"
 dependencies = [
  "base64 0.13.1",
  "darling",
@@ -2032,7 +2032,7 @@ dependencies = [
 [[package]]
 name = "soroban-token-spec"
 version = "0.6.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=ab96798be9f4b77570ed032cb58743942592114a#ab96798be9f4b77570ed032cb58743942592114a"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=d6109a43262852d8374b60f18cb5304a3a368350#d6109a43262852d8374b60f18cb5304a3a368350"
 dependencies = [
  "soroban-sdk",
 ]
@@ -2099,7 +2099,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "0.0.14"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=74999cea9be22fe20cb030d6e485795ab2269045#74999cea9be22fe20cb030d6e485795ab2269045"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=07aff1190dc3f97b889d31b2bfb77098e7db55ce#07aff1190dc3f97b889d31b2bfb77098e7db55ce"
 dependencies = [
  "base64 0.13.1",
  "crate-git-revision",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,29 +10,29 @@ default-members = ["cmd/soroban-cli"]
 [workspace.dependencies.soroban-env-host]
 version = "0.0.14"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "d39dd845d5bf31f976cdfea9bc7c2f8da8396b6b"
+rev = "7dde7cb0b35957856a1e0c11432e00532ae20cf8"
 
 [workspace.dependencies.soroban-spec]
 version = "0.6.0"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "ab96798be9f4b77570ed032cb58743942592114a"
+rev = "d6109a43262852d8374b60f18cb5304a3a368350"
 
 
 [workspace.dependencies.soroban-token-spec]
 version = "0.6.0"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "ab96798be9f4b77570ed032cb58743942592114a"
+rev = "d6109a43262852d8374b60f18cb5304a3a368350"
 
 
 [workspace.dependencies.soroban-sdk]
 version = "0.6.0"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "ab96798be9f4b77570ed032cb58743942592114a"
+rev = "d6109a43262852d8374b60f18cb5304a3a368350"
 
 [workspace.dependencies.soroban-ledger-snapshot]
 version = "0.6.0"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "ab96798be9f4b77570ed032cb58743942592114a"
+rev = "d6109a43262852d8374b60f18cb5304a3a368350"
 
 [workspace.dependencies.stellar-strkey]
 version = "0.0.7"

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -10,7 +10,7 @@ use soroban_env_host::xdr::{ScBytes, ScContractExecutable, ScSpecFunctionV0};
 use soroban_env_host::Host;
 use soroban_env_host::{
     budget::{Budget, CostType},
-    events::HostEvent,
+    events::Event,
     storage::Storage,
     xdr::{
         self, AccountId, AddressWithNonce, ContractAuth, ContractCodeEntry, ContractDataEntry,
@@ -394,11 +394,13 @@ impl Cmd {
 
         for (i, event) in events.0.iter().enumerate() {
             eprint!("#{i}: ");
-            match event {
-                HostEvent::Contract(e) => {
+            match &event.event {
+                Event::Contract(e) => {
                     eprintln!("event: {}", serde_json::to_string(&e).unwrap());
                 }
-                HostEvent::Debug(e) => eprintln!("debug: {e}"),
+                Event::Debug(e) => eprintln!("debug: {e}"),
+                // TODO: print structued debug events in a nicer way
+                Event::StructuredDebug(e) => eprintln!("structured debug: {e:?}"),
             }
         }
 

--- a/cmd/soroban-cli/src/commands/events.rs
+++ b/cmd/soroban-cli/src/commands/events.rs
@@ -747,24 +747,30 @@ mod tests {
         // ensure the properties match.
 
         let events: Vec<events::HostEvent> = vec![
-            events::HostEvent::Contract(xdr::ContractEvent {
-                ext: xdr::ExtensionPoint::V0,
-                contract_id: Some(xdr::Hash([0; 32])),
-                type_: xdr::ContractEventType::Contract,
-                body: xdr::ContractEventBody::V0(xdr::ContractEventV0 {
-                    topics: xdr::ScVec(vec![].try_into().unwrap()),
-                    data: xdr::ScVal::U32(12345),
+            events::HostEvent {
+                event: events::Event::Contract(xdr::ContractEvent {
+                    ext: xdr::ExtensionPoint::V0,
+                    contract_id: Some(xdr::Hash([0; 32])),
+                    type_: xdr::ContractEventType::Contract,
+                    body: xdr::ContractEventBody::V0(xdr::ContractEventV0 {
+                        topics: xdr::ScVec(vec![].try_into().unwrap()),
+                        data: xdr::ScVal::U32(12345),
+                    }),
                 }),
-            }),
-            events::HostEvent::Contract(xdr::ContractEvent {
-                ext: xdr::ExtensionPoint::V0,
-                contract_id: Some(xdr::Hash([0x1; 32])),
-                type_: xdr::ContractEventType::Contract,
-                body: xdr::ContractEventBody::V0(xdr::ContractEventV0 {
-                    topics: xdr::ScVec(vec![].try_into().unwrap()),
-                    data: xdr::ScVal::I32(67890),
+                failed_call: false,
+            },
+            events::HostEvent {
+                event: events::Event::Contract(xdr::ContractEvent {
+                    ext: xdr::ExtensionPoint::V0,
+                    contract_id: Some(xdr::Hash([0x1; 32])),
+                    type_: xdr::ContractEventType::Contract,
+                    body: xdr::ContractEventBody::V0(xdr::ContractEventV0 {
+                        topics: xdr::ScVec(vec![].try_into().unwrap()),
+                        data: xdr::ScVal::I32(67890),
+                    }),
                 }),
-            }),
+                failed_call: false,
+            },
         ];
 
         let snapshot = soroban_ledger_snapshot::LedgerSnapshot {

--- a/cmd/soroban-cli/src/commands/events.rs
+++ b/cmd/soroban-cli/src/commands/events.rs
@@ -494,11 +494,16 @@ pub fn commit(
     };
 
     for (i, event) in new_events.iter().enumerate() {
-        let contract_event = match event {
-            events::HostEvent::Contract(e) => e,
-            events::HostEvent::Debug(e) => {
+        let contract_event = match &event.event {
+            events::Event::Contract(e) => e,
+            events::Event::Debug(e) => {
                 return Err(Error::Generic(
                     format!("debug events unsupported: {e:#?}").into(),
+                ))
+            }
+            events::Event::StructuredDebug(e) => {
+                return Err(Error::Generic(
+                    format!("structured debug events unsupported: {e:#?}").into(),
                 ))
             }
         };
@@ -548,6 +553,7 @@ pub fn commit(
             event_type: match contract_event.type_ {
                 xdr::ContractEventType::Contract => "contract",
                 xdr::ContractEventType::System => "system",
+                xdr::ContractEventType::Diagnostic => "diagnostic",
             }
             .to_string(),
             paging_token: id.clone(),

--- a/cmd/soroban-rpc/internal/test/docker-compose.yml
+++ b/cmd/soroban-rpc/internal/test/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     # Note: Please keep the image pinned to an immutable tag matching the Captive Core version.
     #       This avoid implicit updates which break compatibility between
     #       the Core container and captive core.
-    image: ${CORE_IMAGE:-2opremio/stellar-core:19.8.1-1238.903afe5e1.focal-soroban}
+    image: ${CORE_IMAGE:-2opremio/stellar-core:19.8.1-1243.53ea43ace.focal-soroban}
     depends_on:
       - core-postgres
     restart: on-failure


### PR DESCRIPTION
The Golang dependencies already had XDR support for structured debug events whilst Core and the Rust dependencies didn't.

This caused the soroban-rpc integration tests to break with XDR decoding errors.

This change bumps Core and the Rust dependencies to also support structured debug events.
