### PR TITLE
fix(CLI): string XDR parsing

### DIFF
--- a/cmd/soroban-cli/src/strval.rs
+++ b/cmd/soroban-cli/src/strval.rs
@@ -190,6 +190,7 @@ impl Spec {
             .map_or_else(
                 |e| match t {
                     ScType::Symbol
+                    | ScType::String
                     | ScType::Bytes
                     | ScType::BytesN(_)
                     | ScType::U128
@@ -229,6 +230,7 @@ impl Spec {
                 | ScType::I64
                 | ScType::U32
                 | ScType::U64
+                | ScType::String
                 | ScType::Symbol
                 | ScType::Address
                 | ScType::Bytes


### PR DESCRIPTION
### What

Finish adding support for the String type.

### Why

Finish adding XDR support for available SDK types.

### Known limitations

No tests as currently am finishing up #528, but given that it acts the same as a symbol it seems good enough.  But will add proper test once the other PR is merged