### PR TITLE
Update core for system-tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,7 @@ jobs:
 
       # core git ref should be latest commit for stable soroban functionality
       # the core bin can either be compiled in-line here as part of ci, 
-      SYSTEM_TEST_CORE_GIT_REF: https://github.com/stellar/stellar-core.git#871accefc0c4a703c1321b4f0e48cf6e03b41960
+      SYSTEM_TEST_CORE_GIT_REF: https://github.com/stellar/stellar-core.git#53ea43ace0c72a3177a1c387f7a896e82fb0f1af
       SYSTEM_TEST_CORE_COMPILE_CONFIGURE_FLAGS: "--disable-tests --enable-next-protocol-version-unsafe-for-production"
       # or can use option to pull a pre-compiled image instead
       # SYSTEM_TEST_CORE_IMAGE: 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest-16-cores
     env:
       # the gh tag of system-test repo version to run 
-      SYSTEM_TEST_GIT_REF: v1.0.8
+      SYSTEM_TEST_GIT_REF: 3f54b84543126967620f8f00ac043c12e477ab6e
 
       # the soroban tools source code to compile and run from system test
       # refers to checked out source of current git hub ref context 


### PR DESCRIPTION
### What

Update the stellar-core version for system-tests

### Why

To match https://github.com/stellar/go/pull/4814, and see if the system-tests pass with the newer core version xdr.

This might fix https://github.com/stellar/system-test/issues/41

### Known limitations

[TODO or N/A]
