### PR TITLE
soroban-rpc: Add contract events to simulateTransaction's response

### DIFF
--- a/cmd/soroban-cli/tests/fixtures/test-wasms/hello_world/src/lib.rs
+++ b/cmd/soroban-cli/tests/fixtures/test-wasms/hello_world/src/lib.rs
@@ -19,6 +19,8 @@ impl Contract {
 
     pub fn auth(env: Env, addr: Address, world: Symbol) -> Vec<Symbol> {
         addr.require_auth();
+        // Emit test event
+        env.events().publish(("auth",), world.clone());
         vec![&env, Symbol::short("Hello"), world]
     }
 }

--- a/cmd/soroban-rpc/internal/methods/simulate_transaction.go
+++ b/cmd/soroban-rpc/internal/methods/simulate_transaction.go
@@ -23,6 +23,7 @@ type SimulateTransactionCost struct {
 
 type SimulateTransactionResult struct {
 	Auth      []string `json:"auth"`
+	Events    []string `json:"events"`
 	Footprint string   `json:"footprint"`
 	XDR       string   `json:"xdr"`
 }
@@ -98,6 +99,7 @@ func NewSimulateTransactionHandler(logger *log.Entry, ledgerEntryReader db.Ledge
 		return SimulateTransactionResponse{
 			Results: []SimulateTransactionResult{
 				{
+					Events:    result.Events,
 					Auth:      result.Auth,
 					Footprint: result.Footprint,
 					XDR:       result.Result,

--- a/cmd/soroban-rpc/internal/methods/simulate_transaction.go
+++ b/cmd/soroban-rpc/internal/methods/simulate_transaction.go
@@ -99,7 +99,7 @@ func NewSimulateTransactionHandler(logger *log.Entry, ledgerEntryReader db.Ledge
 		return SimulateTransactionResponse{
 			Results: []SimulateTransactionResult{
 				{
-					Events:    result.DiagnosticEvents,
+					Events:    result.Events,
 					Auth:      result.Auth,
 					Footprint: result.Footprint,
 					XDR:       result.Result,

--- a/cmd/soroban-rpc/internal/methods/simulate_transaction.go
+++ b/cmd/soroban-rpc/internal/methods/simulate_transaction.go
@@ -99,7 +99,7 @@ func NewSimulateTransactionHandler(logger *log.Entry, ledgerEntryReader db.Ledge
 		return SimulateTransactionResponse{
 			Results: []SimulateTransactionResult{
 				{
-					Events:    result.Events,
+					Events:    result.DiagnosticEvents,
 					Auth:      result.Auth,
 					Footprint: result.Footprint,
 					XDR:       result.Result,

--- a/cmd/soroban-rpc/internal/preflight/preflight.go
+++ b/cmd/soroban-rpc/internal/preflight/preflight.go
@@ -3,6 +3,7 @@ package preflight
 import (
 	"context"
 	"errors"
+	"math"
 	"runtime/cgo"
 	"time"
 	"unsafe"
@@ -111,7 +112,7 @@ func GoNullTerminatedStringSlice(str **C.char) []string {
 		// CGo doesn't have an easy way to do pointer arithmetic so,
 		// we are better off transforming the memory buffer into a large slice
 		// and finding the NULL termination after that
-		for _, a := range unsafe.Slice(str, 1<<20) {
+		for _, a := range unsafe.Slice(str, math.MaxInt) {
 			if a == nil {
 				// we found the ending nil
 				break

--- a/cmd/soroban-rpc/internal/preflight/preflight.go
+++ b/cmd/soroban-rpc/internal/preflight/preflight.go
@@ -3,7 +3,6 @@ package preflight
 import (
 	"context"
 	"errors"
-	"math"
 	"runtime/cgo"
 	"time"
 	"unsafe"
@@ -112,7 +111,7 @@ func GoNullTerminatedStringSlice(str **C.char) []string {
 		// CGo doesn't have an easy way to do pointer arithmetic so,
 		// we are better off transforming the memory buffer into a large slice
 		// and finding the NULL termination after that
-		for _, a := range unsafe.Slice(str, math.MaxInt) {
+		for _, a := range unsafe.Slice(str, 1<<20) {
 			if a == nil {
 				// we found the ending nil
 				break

--- a/cmd/soroban-rpc/internal/preflight/preflight.go
+++ b/cmd/soroban-rpc/internal/preflight/preflight.go
@@ -96,12 +96,12 @@ type PreflightParameters struct {
 }
 
 type Preflight struct {
-	Auth            []string // ContractAuths XDR in base64
-	Events          []string // ContractEvents XDR in base64
-	Footprint       string   // LedgerFootprint XDR in base64
-	Result          string   // SCVal XDR in base64
-	CPUInstructions uint64
-	MemoryBytes     uint64
+	Auth             []string // ContractAuths XDR in base64
+	DiagnosticEvents []string // DiagnosticEvents XDR in base64
+	Footprint        string   // LedgerFootprint XDR in base64
+	Result           string   // SCVal XDR in base64
+	CPUInstructions  uint64
+	MemoryBytes      uint64
 }
 
 // GoNullTerminatedStringSlice transforms a C NULL-terminated char** array to a Go string slice
@@ -163,12 +163,12 @@ func GetPreflight(ctx context.Context, params PreflightParameters) (Preflight, e
 	}
 
 	preflight := Preflight{
-		Auth:            GoNullTerminatedStringSlice(res.auth),
-		Events:          GoNullTerminatedStringSlice(res.events),
-		Footprint:       C.GoString(res.preflight),
-		Result:          C.GoString(res.result),
-		CPUInstructions: uint64(res.cpu_instructions),
-		MemoryBytes:     uint64(res.memory_bytes),
+		Auth:             GoNullTerminatedStringSlice(res.auth),
+		DiagnosticEvents: GoNullTerminatedStringSlice(res.events),
+		Footprint:        C.GoString(res.preflight),
+		Result:           C.GoString(res.result),
+		CPUInstructions:  uint64(res.cpu_instructions),
+		MemoryBytes:      uint64(res.memory_bytes),
 	}
 	return preflight, nil
 }

--- a/cmd/soroban-rpc/internal/preflight/preflight.go
+++ b/cmd/soroban-rpc/internal/preflight/preflight.go
@@ -97,12 +97,12 @@ type PreflightParameters struct {
 }
 
 type Preflight struct {
-	Auth             []string // ContractAuths XDR in base64
-	DiagnosticEvents []string // DiagnosticEvents XDR in base64
-	Footprint        string   // LedgerFootprint XDR in base64
-	Result           string   // SCVal XDR in base64
-	CPUInstructions  uint64
-	MemoryBytes      uint64
+	Auth            []string // ContractAuths XDR in base64
+	Events          []string // DiagnosticEvents XDR in base64
+	Footprint       string   // LedgerFootprint XDR in base64
+	Result          string   // SCVal XDR in base64
+	CPUInstructions uint64
+	MemoryBytes     uint64
 }
 
 // GoNullTerminatedStringSlice transforms a C NULL-terminated char** array to a Go string slice
@@ -164,12 +164,12 @@ func GetPreflight(ctx context.Context, params PreflightParameters) (Preflight, e
 	}
 
 	preflight := Preflight{
-		Auth:             GoNullTerminatedStringSlice(res.auth),
-		DiagnosticEvents: GoNullTerminatedStringSlice(res.events),
-		Footprint:        C.GoString(res.preflight),
-		Result:           C.GoString(res.result),
-		CPUInstructions:  uint64(res.cpu_instructions),
-		MemoryBytes:      uint64(res.memory_bytes),
+		Auth:            GoNullTerminatedStringSlice(res.auth),
+		Events:          GoNullTerminatedStringSlice(res.events),
+		Footprint:       C.GoString(res.preflight),
+		Result:          C.GoString(res.result),
+		CPUInstructions: uint64(res.cpu_instructions),
+		MemoryBytes:     uint64(res.memory_bytes),
 	}
 	return preflight, nil
 }

--- a/cmd/soroban-rpc/internal/preflight/preflight.go
+++ b/cmd/soroban-rpc/internal/preflight/preflight.go
@@ -97,10 +97,29 @@ type PreflightParameters struct {
 
 type Preflight struct {
 	Auth            []string // ContractAuths XDR in base64
+	Events          []string // ContractEvents XDR in base64
 	Footprint       string   // LedgerFootprint XDR in base64
 	Result          string   // SCVal XDR in base64
 	CPUInstructions uint64
 	MemoryBytes     uint64
+}
+
+// GoNullTerminatedStringSlice transforms a C NULL-terminated char** array to a Go string slice
+func GoNullTerminatedStringSlice(str **C.char) []string {
+	var result []string
+	if str != nil {
+		// CGo doesn't have an easy way to do pointer arithmetic so,
+		// we are better off transforming the memory buffer into a large slice
+		// and finding the NULL termination after that
+		for _, a := range unsafe.Slice(str, 1<<20) {
+			if a == nil {
+				// we found the ending nil
+				break
+			}
+			result = append(result, C.GoString(a))
+		}
+	}
+	return result
 }
 
 func GetPreflight(ctx context.Context, params PreflightParameters) (Preflight, error) {
@@ -143,23 +162,9 @@ func GetPreflight(ctx context.Context, params PreflightParameters) (Preflight, e
 		return Preflight{}, errors.New(C.GoString(res.error))
 	}
 
-	// Get the auth data
-	var auth []string
-	if res.auth != nil {
-		// CGo doesn't have an easy way to do pointer arithmetic so,
-		// we are better off transforming the memory buffer into a large slice
-		// and finding the NULL termination after that
-		for _, a := range unsafe.Slice(res.auth, 1<<20) {
-			if a == nil {
-				// we found the ending nil
-				break
-			}
-			auth = append(auth, C.GoString(a))
-		}
-	}
-
 	preflight := Preflight{
-		Auth:            auth,
+		Auth:            GoNullTerminatedStringSlice(res.auth),
+		Events:          GoNullTerminatedStringSlice(res.events),
 		Footprint:       C.GoString(res.preflight),
 		Result:          C.GoString(res.result),
 		CPUInstructions: uint64(res.cpu_instructions),

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -434,17 +434,18 @@ func TestSimulateInvokeContractTransactionSucceeds(t *testing.T) {
 
 	// check the events
 	assert.Len(t, response.Results[0].Events, 1)
-	var event xdr.ContractEvent
+	var event xdr.DiagnosticEvent
 	err = xdr.SafeUnmarshalBase64(response.Results[0].Events[0], &event)
 	assert.NoError(t, err)
-	assert.Equal(t, xdr.Hash(contractID), *event.ContractId)
-	assert.Equal(t, xdr.ContractEventTypeContract, event.Type)
-	assert.Equal(t, int32(0), event.Body.V)
-	assert.Equal(t, xdr.ScValTypeScvSymbol, event.Body.V0.Data.Type)
-	assert.Equal(t, xdr.ScSymbol("world"), *event.Body.V0.Data.Sym)
-	assert.Len(t, event.Body.V0.Topics, 1)
-	assert.Equal(t, xdr.ScValTypeScvString, event.Body.V0.Topics[0].Type)
-	assert.Equal(t, xdr.ScString("auth"), *event.Body.V0.Topics[0].Str)
+	assert.True(t, event.InSuccessfulContractCall)
+	assert.Equal(t, xdr.Hash(contractID), *event.Event.ContractId)
+	assert.Equal(t, xdr.ContractEventTypeContract, event.Event.Type)
+	assert.Equal(t, int32(0), event.Event.Body.V)
+	assert.Equal(t, xdr.ScValTypeScvSymbol, event.Event.Body.V0.Data.Type)
+	assert.Equal(t, xdr.ScSymbol("world"), *event.Event.Body.V0.Data.Sym)
+	assert.Len(t, event.Event.Body.V0.Topics, 1)
+	assert.Equal(t, xdr.ScValTypeScvString, event.Event.Body.V0.Topics[0].Type)
+	assert.Equal(t, xdr.ScString("auth"), *event.Event.Body.V0.Topics[0].Str)
 }
 
 func TestSimulateTransactionError(t *testing.T) {

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -431,6 +431,20 @@ func TestSimulateInvokeContractTransactionSucceeds(t *testing.T) {
 	assert.Equal(t, xdr.ScValTypeScvSymbol, world.Type)
 	assert.Equal(t, xdr.ScSymbol("world"), *world.Sym)
 	assert.Nil(t, obtainedAuth.RootInvocation.SubInvocations)
+
+	// check the events
+	assert.Len(t, response.Results[0].Events, 1)
+	var event xdr.ContractEvent
+	err = xdr.SafeUnmarshalBase64(response.Results[0].Events[0], &event)
+	assert.NoError(t, err)
+	assert.Equal(t, xdr.Hash(contractID), *event.ContractId)
+	assert.Equal(t, xdr.ContractEventTypeContract, event.Type)
+	assert.Equal(t, int32(0), event.Body.V)
+	assert.Equal(t, xdr.ScValTypeScvSymbol, event.Body.V0.Data.Type)
+	assert.Equal(t, xdr.ScSymbol("world"), *event.Body.V0.Data.Sym)
+	assert.Len(t, event.Body.V0.Topics, 1)
+	assert.Equal(t, xdr.ScValTypeScvString, event.Body.V0.Topics[0].Type)
+	assert.Equal(t, xdr.ScString("auth"), *event.Body.V0.Topics[0].Str)
 }
 
 func TestSimulateTransactionError(t *testing.T) {

--- a/cmd/soroban-rpc/lib/preflight.h
+++ b/cmd/soroban-rpc/lib/preflight.h
@@ -16,6 +16,7 @@ typedef struct CPreflightResult {
     char *result; // SCVal XDR in base64
     char *preflight; // LedgerFootprint XDR in base64
     char **auth; // NULL terminated array of XDR ContractAuths in base64
+    char **events; // NULL terminated array of XDR ContractEvents in base64
     uint64_t cpu_instructions;
     uint64_t memory_bytes;
 } CPreflightResult;

--- a/cmd/soroban-rpc/lib/preflight.h
+++ b/cmd/soroban-rpc/lib/preflight.h
@@ -16,7 +16,7 @@ typedef struct CPreflightResult {
     char *result; // SCVal XDR in base64
     char *preflight; // LedgerFootprint XDR in base64
     char **auth; // NULL terminated array of XDR ContractAuths in base64
-    char **events; // NULL terminated array of XDR ContractEvents in base64
+    char **events; // NULL terminated array of XDR DiagnosticEvents in base64
     uint64_t cpu_instructions;
     uint64_t memory_bytes;
 } CPreflightResult;


### PR DESCRIPTION
### What

Add contract events to simulateTransaction's response. This change modifies libpreflight to return contract events and the `simulateTransaction` JSONRPC method to include contract events in its response.

### Why

Closes https://github.com/stellar/soroban-tools/issues/475

### Known limitations

N/A

TODO:
* [ ] Update soroban-rpc documentation at https://github.com/stellar/soroban-docs
