### PR TITLE
bumped the go dep to latest from soroban-xdr-next

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/sirupsen/logrus v1.4.1
 	github.com/spf13/cobra v0.0.0-20160830174925-9c28e4bbd74e
 	github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189
-	github.com/stellar/go v0.0.0-20230320165241-a5f3278b8282
+	github.com/stellar/go v0.0.0-20230327144237-ddcb0c7dea5a
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/mod v0.6.0
 )

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475 h1:RtZIgreTwcayPTOw7G5
 github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189 h1:fvB1AFbBd6SfI9Rd0ooAJp8uLkZDbZaLFHi7ZnNP6uI=
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
-github.com/stellar/go v0.0.0-20230320165241-a5f3278b8282 h1:Lijy4+s8ZwC6omEHHI4zThxxqKkQ0q1JyUn0WLfKFgI=
-github.com/stellar/go v0.0.0-20230320165241-a5f3278b8282/go.mod h1:QXwuKmYVvqQZlByv0EeNb0Rgog9AP+eMmARcdt3h2rI=
+github.com/stellar/go v0.0.0-20230327144237-ddcb0c7dea5a h1:4M/FzFAhWqLF5p3/2x8pCWf6fvs1Rwa8ZsO/Md2VVV0=
+github.com/stellar/go v0.0.0-20230327144237-ddcb0c7dea5a/go.mod h1:QXwuKmYVvqQZlByv0EeNb0Rgog9AP+eMmARcdt3h2rI=
 github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee h1:fbVs0xmXpBvVS4GBeiRmAE3Le70ofAqFMch1GTiq/e8=
 github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
### What

the`github.com/stellar/go` dependency needed to be updated to latest commit on soroban-xdr-next branch

### Why

seeing errors when rpc tries to set `ENABLE_SOROBAN_DIAGNOSTIC_EVENTS` in core toml config

```
time="2023-03-26T23:44:55.322Z" level=fatal msg="Invalid captive core toml" error="could not unmarshal captive core toml: these fields are not supported by captive core: [\"ENABLE_SOROBAN_DIAGNOSTIC_EVENTS\"]" pid=3418
```

### Known limitations


