### PR TITLE
Update rust deps for new release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1907,8 +1907,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=7dde7cb0b35957856a1e0c11432e00532ae20cf8#7dde7cb0b35957856a1e0c11432e00532ae20cf8"
+version = "0.0.15"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=cf83838ae8a07a00224f0a5a3500eb7969bac7cf#cf83838ae8a07a00224f0a5a3500eb7969bac7cf"
 dependencies = [
  "crate-git-revision",
  "ethnum",
@@ -1921,8 +1921,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=7dde7cb0b35957856a1e0c11432e00532ae20cf8#7dde7cb0b35957856a1e0c11432e00532ae20cf8"
+version = "0.0.15"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=cf83838ae8a07a00224f0a5a3500eb7969bac7cf#cf83838ae8a07a00224f0a5a3500eb7969bac7cf"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1930,8 +1930,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=7dde7cb0b35957856a1e0c11432e00532ae20cf8#7dde7cb0b35957856a1e0c11432e00532ae20cf8"
+version = "0.0.15"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=cf83838ae8a07a00224f0a5a3500eb7969bac7cf#cf83838ae8a07a00224f0a5a3500eb7969bac7cf"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -1952,8 +1952,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=7dde7cb0b35957856a1e0c11432e00532ae20cf8#7dde7cb0b35957856a1e0c11432e00532ae20cf8"
+version = "0.0.15"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=cf83838ae8a07a00224f0a5a3500eb7969bac7cf#cf83838ae8a07a00224f0a5a3500eb7969bac7cf"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1967,8 +1967,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "0.6.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=d6109a43262852d8374b60f18cb5304a3a368350#d6109a43262852d8374b60f18cb5304a3a368350"
+version = "0.7.0"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=8abd3353c728f09ee1c8a2544f67a853e915afc2#8abd3353c728f09ee1c8a2544f67a853e915afc2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1978,8 +1978,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-native-sdk-macros"
-version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=7dde7cb0b35957856a1e0c11432e00532ae20cf8#7dde7cb0b35957856a1e0c11432e00532ae20cf8"
+version = "0.0.15"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=cf83838ae8a07a00224f0a5a3500eb7969bac7cf#cf83838ae8a07a00224f0a5a3500eb7969bac7cf"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1989,8 +1989,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "0.6.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=d6109a43262852d8374b60f18cb5304a3a368350#d6109a43262852d8374b60f18cb5304a3a368350"
+version = "0.7.0"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=8abd3353c728f09ee1c8a2544f67a853e915afc2#8abd3353c728f09ee1c8a2544f67a853e915afc2"
 dependencies = [
  "bytes-lit",
  "ed25519-dalek",
@@ -2004,8 +2004,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "0.6.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=d6109a43262852d8374b60f18cb5304a3a368350#d6109a43262852d8374b60f18cb5304a3a368350"
+version = "0.7.0"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=8abd3353c728f09ee1c8a2544f67a853e915afc2#8abd3353c728f09ee1c8a2544f67a853e915afc2"
 dependencies = [
  "darling",
  "itertools",
@@ -2020,8 +2020,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "0.6.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=d6109a43262852d8374b60f18cb5304a3a368350#d6109a43262852d8374b60f18cb5304a3a368350"
+version = "0.7.0"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=8abd3353c728f09ee1c8a2544f67a853e915afc2#8abd3353c728f09ee1c8a2544f67a853e915afc2"
 dependencies = [
  "base64 0.13.1",
  "darling",
@@ -2041,8 +2041,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-token-spec"
-version = "0.6.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=d6109a43262852d8374b60f18cb5304a3a368350#d6109a43262852d8374b60f18cb5304a3a368350"
+version = "0.7.0"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=8abd3353c728f09ee1c8a2544f67a853e915afc2#8abd3353c728f09ee1c8a2544f67a853e915afc2"
 dependencies = [
  "soroban-sdk",
 ]
@@ -2108,8 +2108,8 @@ dependencies = [
 
 [[package]]
 name = "stellar-xdr"
-version = "0.0.14"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=07aff1190dc3f97b889d31b2bfb77098e7db55ce#07aff1190dc3f97b889d31b2bfb77098e7db55ce"
+version = "0.0.15"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=4655b635c698bb3bbc628bdba456df627c42ee3a#4655b635c698bb3bbc628bdba456df627c42ee3a"
 dependencies = [
  "base64 0.13.1",
  "crate-git-revision",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,31 +8,31 @@ members = [
 default-members = ["cmd/soroban-cli"]
 
 [workspace.dependencies.soroban-env-host]
-version = "0.0.14"
+version = "0.0.15"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "7dde7cb0b35957856a1e0c11432e00532ae20cf8"
+rev = "cf83838ae8a07a00224f0a5a3500eb7969bac7cf"
 
 [workspace.dependencies.soroban-spec]
-version = "0.6.0"
+version = "0.7.0"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "d6109a43262852d8374b60f18cb5304a3a368350"
+rev = "8abd3353c728f09ee1c8a2544f67a853e915afc2"
 
 
 [workspace.dependencies.soroban-token-spec]
-version = "0.6.0"
+version = "0.7.0"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "d6109a43262852d8374b60f18cb5304a3a368350"
+rev = "8abd3353c728f09ee1c8a2544f67a853e915afc2"
 
 
 [workspace.dependencies.soroban-sdk]
-version = "0.6.0"
+version = "0.7.0"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "d6109a43262852d8374b60f18cb5304a3a368350"
+rev = "8abd3353c728f09ee1c8a2544f67a853e915afc2"
 
 [workspace.dependencies.soroban-ledger-snapshot]
-version = "0.6.0"
+version = "0.7.0"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "d6109a43262852d8374b60f18cb5304a3a368350"
+rev = "8abd3353c728f09ee1c8a2544f67a853e915afc2"
 
 [workspace.dependencies.stellar-strkey]
 version = "0.0.7"


### PR DESCRIPTION
### What

Update rs-soroban-env to 0.0.15
Update rs-soroban-sdk to 0.7.0

### Why

Because those are the new latest released versions, which will drag in the latest xdr as well.

### Known limitations

[TODO or N/A]
