### PR TITLE
Try out the new action to automatically update the CompletedSprint field when issue closed

### DIFF
--- a/.github/workflows/update-completed-sprint-on-issue-closed.yml
+++ b/.github/workflows/update-completed-sprint-on-issue-closed.yml
@@ -1,0 +1,12 @@
+name: Update CompletedSprint on Issue Closed
+
+on:
+  issues:
+    types: [closed]
+  pull_request:
+    types: [closed]
+
+
+jobs:
+  update_completed_sprint:
+    uses: stellar/actions.github/workflows/update-completed-sprint-on-issue-closed.yml

--- a/.github/workflows/update-completed-sprint-on-issue-closed.yml
+++ b/.github/workflows/update-completed-sprint-on-issue-closed.yml
@@ -9,6 +9,6 @@ on:
 jobs:
   update_completed_sprint:
     uses: stellar/actions/.github/workflows/update-completed-sprint-on-issue-closed.yml@main
-  with:
-    project_name: "Platform Scrum"
-    field_name: "CompletedSprint"
+    with:
+      project_name: "Platform Scrum"
+      field_name: "CompletedSprint"

--- a/.github/workflows/update-completed-sprint-on-issue-closed.yml
+++ b/.github/workflows/update-completed-sprint-on-issue-closed.yml
@@ -6,7 +6,9 @@ on:
   pull_request:
     types: [closed]
 
-
 jobs:
   update_completed_sprint:
     uses: stellar/actions.github/workflows/update-completed-sprint-on-issue-closed.yml
+  with:
+    project_name: "Platform Scrum"
+    field_name: "CompletedSprint"

--- a/.github/workflows/update-completed-sprint-on-issue-closed.yml
+++ b/.github/workflows/update-completed-sprint-on-issue-closed.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   update_completed_sprint:
-    uses: stellar/actions.github/workflows/update-completed-sprint-on-issue-closed.yml
+    uses: stellar/actions/.github/workflows/update-completed-sprint-on-issue-closed.yml@main
   with:
     project_name: "Platform Scrum"
     field_name: "CompletedSprint"


### PR DESCRIPTION
### What

Automatically assign the `CompletedSprint` field when an issue or PR is closed.

### Why

Because we keep forgetting, which is a pain for @mollykarcher.

### Known limitations

Just trying it on this repo, in case it doesn't work. The oauth key restrictions mean we can't test this locally without just pushing it and seeing. If it works we should use it on other repos as well.

Depends on https://github.com/stellar/actions/pull/51