### PR TITLE
feat(CLI): add SOROBAN_(NETWORK/CONTRACT_ID)

### DIFF
--- a/cmd/soroban-cli/src/commands/config/locator.rs
+++ b/cmd/soroban-cli/src/commands/config/locator.rs
@@ -67,7 +67,7 @@ pub struct Args {
     #[arg(long)]
     pub global: bool,
 
-    #[arg(long)]
+    #[arg(long, help_heading = "TESTING_OPTIONS")]
     pub pwd: Option<PathBuf>,
 }
 

--- a/cmd/soroban-cli/src/commands/config/network/mod.rs
+++ b/cmd/soroban-cli/src/commands/config/network/mod.rs
@@ -71,7 +71,8 @@ pub struct Args {
     #[arg(
         long,
         conflicts_with = "network_passphrase",
-        conflicts_with = "rpc_url"
+        conflicts_with = "rpc_url",
+        env = "SOROBAN_NETWORK"
     )]
     pub network: Option<String>,
 }

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -32,6 +32,7 @@ use super::super::{
     events,
 };
 use crate::{
+    commands::HEADING_SANDBOX,
     rpc::{self, Client},
     strval::{self, Spec},
     utils::{self, create_ledger_footprint, default_account_ledger_entry},
@@ -43,17 +44,11 @@ use crate::{
 #[group(skip)]
 pub struct Cmd {
     /// Contract ID to invoke
-    #[arg(long = "id")]
+    #[arg(long = "id", env = "SOROBAN_CONTRACT_ID")]
     pub contract_id: String,
     /// WASM file of the contract to invoke (if using sandbox will deploy this file)
     #[arg(long)]
     pub wasm: Option<std::path::PathBuf>,
-    /// Output the cost execution to stderr
-    #[arg(long = "cost")]
-    pub cost: bool,
-    /// Run with an unlimited budget
-    #[arg(long = "unlimited-budget", conflicts_with = "rpc_url")]
-    pub unlimited_budget: bool,
     /// Output the footprint to stderr
     #[arg(long = "footprint")]
     pub footprint: bool,
@@ -63,6 +58,13 @@ pub struct Cmd {
     /// Output the contract events for the transaction to stderr
     #[arg(long = "events")]
     pub events: bool,
+
+    /// Output the cost execution to stderr
+    #[arg(long = "cost", conflicts_with = "rpc_url", conflicts_with="network", help_heading = HEADING_SANDBOX)]
+    pub cost: bool,
+    /// Run with an unlimited budget
+    #[arg(long = "unlimited-budget", conflicts_with = "rpc_url", conflicts_with="network", help_heading = HEADING_SANDBOX)]
+    pub unlimited_budget: bool,
 
     // Function name as subcommand, then arguments for that function as `--arg-name value`
     #[arg(last = true, id = "CONTRACT_FN_AND_ARGS")]

--- a/docs/soroban-cli-full-docs.md
+++ b/docs/soroban-cli-full-docs.md
@@ -185,11 +185,11 @@ soroban contract invoke ... -- --help
 
 * `--id <CONTRACT_ID>` — Contract ID to invoke
 * `--wasm <WASM>` — WASM file of the contract to invoke (if using sandbox will deploy this file)
-* `--cost` — Output the cost execution to stderr
-* `--unlimited-budget` — Run with an unlimited budget
 * `--footprint` — Output the footprint to stderr
 * `--auth` — Output the contract auth for the transaction to stderr
 * `--events` — Output the contract events for the transaction to stderr
+* `--cost` — Output the cost execution to stderr
+* `--unlimited-budget` — Run with an unlimited budget
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
 * `--network <NETWORK>` — Name of network to use from config


### PR DESCRIPTION
### What

Add two new ENV variables to allow the network and contract id to be set.

Also improved help headings to make things clearer.

### Why

This way you can set which network with an ENV variable which is useful for testing and scripts.

### Known limitations

[TODO or N/A]
