### PR TITLE
change e2e to use last stable soroban examples for test contracts

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,7 +42,7 @@ jobs:
       SYSTEM_TEST_VERBOSE_OUTPUT: "true"
 
       # the soroban test cases will compile various contracts from the examples repo
-      SYSTEM_TEST_SOROBAN_EXAMPLES_GIT_HASH: main
+      SYSTEM_TEST_SOROBAN_EXAMPLES_GIT_HASH: v0.7.0
       SYSTEM_TEST_SOROBAN_EXAMPLES_GIT_REPO: "https://github.com/stellar/soroban-examples.git"
     steps:
       - uses: actions/checkout@v3
@@ -71,4 +71,5 @@ jobs:
         run: |
           docker run --rm -t --name e2e_test stellar/system-test:dev \
           --VerboseOutput $SYSTEM_TEST_VERBOSE_OUTPUT  \
-          --TestFilter "${{ matrix.scenario-filter }}"     
+          --TestFilter "${{ matrix.scenario-filter }}" \
+          --SorobanExamplesGitHash $SYSTEM_TEST_SOROBAN_EXAMPLES_GIT_HASH


### PR DESCRIPTION


### What

setting e2e to use last stable version v0.7.0 of soroban examples for contracts to use in tests

### Why

latest main on soroban examples has recent commits that seem to be causing breaking change for the contracts to be used by e2e tests, need to triage that problem further, this change is meant to just get the e2e back to passing in interim.

### Known limitations

