### PR TITLE
soroban-rpc: libpreflight: Avoid panicking when address and nonce are both None

### DIFF
--- a/cmd/soroban-rpc/lib/preflight/src/lib.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/lib.rs
@@ -218,6 +218,7 @@ fn recorded_auth_payloads_to_c(
 fn recorded_auth_payload_to_xdr(payload: &RecordedAuthPayload) -> ContractAuth {
     let address_with_nonce = match (payload.address.clone(), payload.nonce) {
         (Some(address), Some(nonce)) => Some(AddressWithNonce { address, nonce }),
+        (None, None) => None,
         // the address and the nonce can't be present independently
         (a,n) =>
             panic!("recorded_auth_payload_to_xdr: address and nonce present independently (address: {:?}, nonce: {:?})", a, n),


### PR DESCRIPTION
Followup to  #553 

(Found out by @sreuland at https://github.com/stellar/soroban-tools/commit/9be3f2c5036ad2db237df98516b9ae872f9fd997#r108326767 )

