### PR TITLE
try using 4 core gh runner for e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest-4-cores
     env:
       # the gh tag of system-test repo version to run 
-      SYSTEM_TEST_GIT_REF: v1.0.10
+      SYSTEM_TEST_GIT_REF: v1.0.11
 
       # the soroban tools source code to compile and run from system test
       # refers to checked out source of current git hub ref context 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         scenario-filter: ["^TestDappDevelop$/^.*$"]
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest-4-cores
     env:
       # the gh tag of system-test repo version to run 
       SYSTEM_TEST_GIT_REF: v1.0.10


### PR DESCRIPTION
### What

use 4 core gh runner for e2e workflow, and see if the duration times are still good with that compute level.

### Why

potential savings in compute costs by using a lower core runner

### Known limitations

the duration time for gha workflow of e2e is compute intensive
