### PR TITLE
Use an 8-core box to build on windows, so we get more disk

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,7 +50,7 @@ jobs:
           target: x86_64-apple-darwin
         - os: macos-latest
           target: aarch64-apple-darwin
-        - os: windows-latest
+        - os: windows-latest-8-cores
           target: x86_64-pc-windows-msvc
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
### What

Use an 8-core windows github runner to get 150gb disk.

### Why

Should fix the failure here: https://github.com/stellar/soroban-tools/pull/585

### Known limitations

[TODO or N/A]
