### PR TITLE
fixed phantomjs e2e build error

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest-4-cores
     env:
       # the gh tag of system-test repo version to run 
-      SYSTEM_TEST_GIT_REF: v1.0.11
+      SYSTEM_TEST_GIT_REF: v1.0.12
 
       # the soroban tools source code to compile and run from system test
       # refers to checked out source of current git hub ref context 


### PR DESCRIPTION
### What

bumping system test ver to [1.0.12](https://github.com/stellar/system-test/releases/tag/v1.0.12)

### Why

this version will fix the system test docker build err on phantomjs

### Known limitations


