### PR TITLE
Update soroban ref versions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,7 @@ jobs:
 
       # core git ref should be latest commit for stable soroban functionality
       # the core bin can either be compiled in-line here as part of ci, 
-      SYSTEM_TEST_CORE_GIT_REF: https://github.com/stellar/stellar-core.git#064a2787acb9e98c70567523785333581ee1ffa4
+      SYSTEM_TEST_CORE_GIT_REF: https://github.com/stellar/stellar-core.git#61f76a1137b82cbf6724c54bdd325daebed28151
       SYSTEM_TEST_CORE_COMPILE_CONFIGURE_FLAGS: "--disable-tests --enable-next-protocol-version-unsafe-for-production"
       # or can use option to pull a pre-compiled image instead
       # SYSTEM_TEST_CORE_IMAGE: 
@@ -42,7 +42,7 @@ jobs:
       SYSTEM_TEST_VERBOSE_OUTPUT: "true"
 
       # the soroban test cases will compile various contracts from the examples repo
-      SYSTEM_TEST_SOROBAN_EXAMPLES_GIT_HASH: v0.7.0
+      SYSTEM_TEST_SOROBAN_EXAMPLES_GIT_HASH: main
       SYSTEM_TEST_SOROBAN_EXAMPLES_GIT_REPO: "https://github.com/stellar/soroban-examples.git"
     steps:
       - uses: actions/checkout@v3

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/sirupsen/logrus v1.4.1
 	github.com/spf13/cobra v0.0.0-20160830174925-9c28e4bbd74e
 	github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189
-	github.com/stellar/go v0.0.0-20230417211416-596d7bbec78b
+	github.com/stellar/go v0.0.0-20230420161348-768b7a1aa986
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/mod v0.6.0
 )

--- a/go.sum
+++ b/go.sum
@@ -169,8 +169,8 @@ github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475 h1:RtZIgreTwcayPTOw7G5
 github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189 h1:fvB1AFbBd6SfI9Rd0ooAJp8uLkZDbZaLFHi7ZnNP6uI=
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
-github.com/stellar/go v0.0.0-20230417211416-596d7bbec78b h1:YGp5il8MhnAjdwDW9jS+6kOtHHD3iP7euQJnmK69bd4=
-github.com/stellar/go v0.0.0-20230417211416-596d7bbec78b/go.mod h1:DHmAo7QjGEJa0yef6NXOh+083h/S6OsdRhOwav6Om1A=
+github.com/stellar/go v0.0.0-20230420161348-768b7a1aa986 h1:tE4dGZgNRTY9qWt44rVUOLlw8AbMsI19hukfaHsHSp0=
+github.com/stellar/go v0.0.0-20230420161348-768b7a1aa986/go.mod h1:DHmAo7QjGEJa0yef6NXOh+083h/S6OsdRhOwav6Om1A=
 github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee h1:fbVs0xmXpBvVS4GBeiRmAE3Le70ofAqFMch1GTiq/e8=
 github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
### What

bumped up the versions of core to [61f76a1137b](https://github.com/stellar/stellar-core/commit/61f76a1137b82cbf6724c54bdd325daebed28151) and soroban-examples to main in e2e tests and pulled in the latest for `github.com/stellar/go` from `soroban-xdr-next` as that has new xdr defs.
### Why

They were previously at Preview8 versions, but newer soroban rs env interface and xdr has been added and soroban-tools had the rs env updated but needed xdr update for rpc ingestion and e2e needed to point at latest refs.

### Known limitations

