### PR TITLE
Try using a docker image layer caching to speed up e2e testing

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,8 +55,8 @@ jobs:
           path: soroban-tools
       - uses: stellar/actions/rust-cache@main
       - run: |
-          docker pull golang 1.20
-          docker pull golang 1.19.1
+          docker pull golang:1.20
+          docker pull golang:1.19.1
           docker pull ubuntu:focal
           if [ -n "$SYSTEM_TEST_CORE_IMAGE" ]; then
             docker pull "$SYSTEM_TEST_CORE_IMAGE"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -105,7 +105,6 @@ jobs:
           build-args: |
             BUILDKIT_CONTEXT_KEEP_GIT_DIR=true
             CONFIGURE_FLAGS=${{ env.SYSTEM_TEST_CORE_COMPILE_CONFIGURE_FLAGS }}
-          target: builder
           push: false
           tags: stellar/system-test-core:dev
           cache-from: type=gha

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Build horizon
         uses: docker/build-push-action@v4
         with:
-          context: $SYSTEM_TEST_GO_GIT_REF
+          context: ${{ env.SYSTEM_TEST_GO_GIT_REF }}
           file: services/horizon/docker/Dockerfile.dev
           target: builder
           push: false
@@ -71,7 +71,7 @@ jobs:
       - name: Build friendbot
         uses: docker/build-push-action@v4
         with:
-          context: $SYSTEM_TEST_GO_GIT_REF
+          context: ${{ env.SYSTEM_TEST_GO_GIT_REF }}
           file: services/friendbot/docker/Dockerfile
           push: false
           tags: stellar/system-test-friendbot:dev
@@ -90,7 +90,7 @@ jobs:
         with:
           file: cmd/soroban-rpc/docker/Dockerfile
           build-args:
-            - DOCKERHUB_RUST_VERSION=$SYSTEM_TEST_RUST_TOOLCHAIN_VERSION
+            - DOCKERHUB_RUST_VERSION=${{ env.SYSTEM_TEST_RUST_TOOLCHAIN_VERSION }}
           target: builder
           push: false
           tags: stellar/system-test-soroban-cli:dev
@@ -99,11 +99,11 @@ jobs:
       - name: Build stellar-core
         uses: docker/build-push-action@v4
         with:
-          context: $SYSTEM_TEST_CORE_GIT_REF
+          context: ${{ env.SYSTEM_TEST_CORE_GIT_REF }}
           file: docker/Dockerfile.testing
           build-args:
             - BUILDKIT_CONTEXT_KEEP_GIT_DIR=true
-            - CONFIGURE_FLAGS=$SYSTEM_TEST_CORE_COMPILE_CONFIGURE_FLAGS
+            - CONFIGURE_FLAGS=${{ env.SYSTEM_TEST_CORE_COMPILE_CONFIGURE_FLAGS }}
           target: builder
           push: false
           tags: stellar/system-test-soroban-cli:dev
@@ -113,9 +113,9 @@ jobs:
       - name: Build quickstart
         uses: docker/build-push-action@v4
         with:
-          context: $SYSTEM_TEST_QUICKSTART_GIT_REF
+          context: ${{ env.SYSTEM_TEST_QUICKSTART_GIT_REF }}
           build-args:
-            - STELLAR_CORE_IMAGE_REF=$SYSTEM_TEST_CORE_GIT_REF
+            - STELLAR_CORE_IMAGE_REF=${{ env.SYSTEM_TEST_CORE_GIT_REF }}
             - HORIZON_IMAGE_REF=stellar/system-test-horizon:dev
             - FRIENDBOT_IMAGE_REF=stellar/system-test-friendbot:dev
             - SOROBAN_RPC_IMAGE_REF=stellar/system-test-soroban-rpc:dev
@@ -130,9 +130,9 @@ jobs:
           build-args:
             - QUICKSTART_IMAGE_REF=stellar/system-test-base:dev
             - SOROBAN_CLI_IMAGE_REF=stellar/system-test-soroban-cli:dev
-            - RUST_TOOLCHAIN_VERSION=$SYSTEM_TEST_RUST_TOOLCHAIN_VERSION
+            - RUST_TOOLCHAIN_VERSION=${{ env.SYSTEM_TEST_RUST_TOOLCHAIN_VERSION }}
             - NODE_VERSION=14.20.0
-            - JS_SOROBAN_CLIENT_NPM_VERSION=$SYSTEM_TEST_JS_SOROBAN_CLIENT_NPM_VERSION
+            - JS_SOROBAN_CLIENT_NPM_VERSION=${{ env.SYSTEM_TEST_JS_SOROBAN_CLIENT_NPM_VERSION }}
           push: false
           tags: stellar/system-test:dev
           cache-from: type=gha

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,6 +30,7 @@ jobs:
       # sets the version of rust toolchain that will be pre-installed in the 
       # test runtime environment, tests invoke rustc/cargo
       SYSTEM_TEST_RUST_TOOLCHAIN_VERSION: stable
+      SYSTEM_TEST_RUST_IMAGE: rust:latest
 
       # sets the version of soroban-js-client used by tests
       SYSTEM_TEST_JS_SOROBAN_CLIENT_NPM_VERSION: https://github.com/stellar/js-soroban-client.git#main
@@ -90,7 +91,7 @@ jobs:
         with:
           file: cmd/soroban-cli/docker/Dockerfile
           build-args: |
-            DOCKERHUB_RUST_VERSION=${{ env.SYSTEM_TEST_RUST_TOOLCHAIN_VERSION }}
+            DOCKERHUB_RUST_VERSION=${{ env.SYSTEM_TEST_RUST_IMAGE }}
           target: builder
           push: false
           tags: stellar/system-test-soroban-cli:dev

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,7 +54,10 @@ jobs:
         with:
           path: soroban-tools
       - uses: stellar/actions/rust-cache@main
-      - run: test "$SYSTEM_TEST_CORE_IMAGE" && docker pull $SYSTEM_TEST_CORE_IMAGE
+      - run: |
+          if [ -n "$SYSTEM_TEST_CORE_IMAGE" ]; then
+            docker pull "$SYSTEM_TEST_CORE_IMAGE"
+          fi
       - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -89,8 +89,8 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           file: cmd/soroban-rpc/docker/Dockerfile
-          build-args:
-            DOCKERHUB_RUST_VERSION: ${{ env.SYSTEM_TEST_RUST_TOOLCHAIN_VERSION }}
+          build-args: |
+            DOCKERHUB_RUST_VERSION=${{ env.SYSTEM_TEST_RUST_TOOLCHAIN_VERSION }}
           target: builder
           push: false
           tags: stellar/system-test-soroban-cli:dev
@@ -101,9 +101,9 @@ jobs:
         with:
           context: ${{ env.SYSTEM_TEST_CORE_GIT_REF }}
           file: docker/Dockerfile.testing
-          build-args:
-            BUILDKIT_CONTEXT_KEEP_GIT_DIR: true
-            CONFIGURE_FLAGS: ${{ env.SYSTEM_TEST_CORE_COMPILE_CONFIGURE_FLAGS }}
+          build-args: |
+            BUILDKIT_CONTEXT_KEEP_GIT_DIR=true
+            CONFIGURE_FLAGS=${{ env.SYSTEM_TEST_CORE_COMPILE_CONFIGURE_FLAGS }}
           target: builder
           push: false
           tags: stellar/system-test-soroban-cli:dev
@@ -114,11 +114,11 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: ${{ env.SYSTEM_TEST_QUICKSTART_GIT_REF }}
-          build-args:
-            - STELLAR_CORE_IMAGE_REF=${{ env.SYSTEM_TEST_CORE_GIT_REF }}
-            - HORIZON_IMAGE_REF=stellar/system-test-horizon:dev
-            - FRIENDBOT_IMAGE_REF=stellar/system-test-friendbot:dev
-            - SOROBAN_RPC_IMAGE_REF=stellar/system-test-soroban-rpc:dev
+          build-args: |
+            STELLAR_CORE_IMAGE_REF=${{ env.SYSTEM_TEST_CORE_GIT_REF }}
+            HORIZON_IMAGE_REF=stellar/system-test-horizon:dev
+            FRIENDBOT_IMAGE_REF=stellar/system-test-friendbot:dev
+            SOROBAN_RPC_IMAGE_REF=stellar/system-test-soroban-rpc:dev
           push: false
           tags: stellar/system-test-base:dev
           cache-from: type=gha
@@ -127,12 +127,12 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: $GITHUB_WORKSPACE/system-test
-          build-args:
-            - QUICKSTART_IMAGE_REF=stellar/system-test-base:dev
-            - SOROBAN_CLI_IMAGE_REF=stellar/system-test-soroban-cli:dev
-            - RUST_TOOLCHAIN_VERSION=${{ env.SYSTEM_TEST_RUST_TOOLCHAIN_VERSION }}
-            - NODE_VERSION=14.20.0
-            - JS_SOROBAN_CLIENT_NPM_VERSION=${{ env.SYSTEM_TEST_JS_SOROBAN_CLIENT_NPM_VERSION }}
+          build-args: |
+            QUICKSTART_IMAGE_REF=stellar/system-test-base:dev
+            SOROBAN_CLI_IMAGE_REF=stellar/system-test-soroban-cli:dev
+            RUST_TOOLCHAIN_VERSION=${{ env.SYSTEM_TEST_RUST_TOOLCHAIN_VERSION }}
+            NODE_VERSION=14.20.0
+            JS_SOROBAN_CLIENT_NPM_VERSION=${{ env.SYSTEM_TEST_JS_SOROBAN_CLIENT_NPM_VERSION }}
           push: false
           tags: stellar/system-test:dev
           cache-from: type=gha

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,7 +34,7 @@ jobs:
       # sets the version of soroban-js-client used by tests
       SYSTEM_TEST_JS_SOROBAN_CLIENT_NPM_VERSION: https://github.com/stellar/js-soroban-client.git#main
 
-      SYSTEM_TEST_GO_GIT_REF: https://github.com/stellar/go.git\#soroban-xdr-next
+      SYSTEM_TEST_GO_GIT_REF: https://github.com/stellar/go.git#soroban-xdr-next
      
       # system test will build quickstart image internally to use for running the service stack
       # configured in standalone network mode(core, rpc)

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,6 +55,9 @@ jobs:
           path: soroban-tools
       - uses: stellar/actions/rust-cache@main
       - run: |
+          docker pull golang 1.20
+          docker pull golang 1.19.1
+          docker pull ubuntu:focal
           if [ -n "$SYSTEM_TEST_CORE_IMAGE" ]; then
             docker pull "$SYSTEM_TEST_CORE_IMAGE"
           fi

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,8 +54,7 @@ jobs:
         with:
           path: soroban-tools
       - uses: stellar/actions/rust-cache@main
-      - run: docker pull $SYSTEM_TEST_CORE_IMAGE
-        if: ${{ SYSTEM_TEST_CORE_IMAGE != '' }}
+      - run: test "$SYSTEM_TEST_CORE_IMAGE" && docker pull $SYSTEM_TEST_CORE_IMAGE
       - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -85,10 +85,10 @@ jobs:
           tags: stellar/system-test-soroban-rpc:dev
           cache-from: type=gha
           cache-to: type=gha,mode=max
-      - name: Build stellar-cli
+      - name: Build soroban-cli
         uses: docker/build-push-action@v4
         with:
-          file: cmd/soroban-rpc/docker/Dockerfile
+          file: cmd/soroban-cli/docker/Dockerfile
           build-args: |
             DOCKERHUB_RUST_VERSION=${{ env.SYSTEM_TEST_RUST_TOOLCHAIN_VERSION }}
           target: builder

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,7 +55,7 @@ jobs:
           path: soroban-tools
       - uses: stellar/actions/rust-cache@main
       - run: docker pull $SYSTEM_TEST_CORE_IMAGE
-        if: ${{ $SYSTEM_TEST_CORE_IMAGE != '' }}
+        if: ${{ SYSTEM_TEST_CORE_IMAGE != '' }}
       - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,6 +54,14 @@ jobs:
         with:
           path: soroban-tools
       - uses: stellar/actions/rust-cache@main
+      - run: docker pull $SYSTEM_TEST_CORE_IMAGE
+        if: ${{ $SYSTEM_TEST_CORE_IMAGE != '' }}
+      - uses: satackey/action-docker-layer-caching@v0.0.11
+        continue-on-error: true
+        with:
+          key: system-test-docker-cache-{hash}
+          restore-keys: |
+            system-test-docker-cache-
       - name: Build system test with component versions
         run: |
           cd $GITHUB_WORKSPACE/system-test; \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,6 +33,8 @@ jobs:
 
       # sets the version of soroban-js-client used by tests
       SYSTEM_TEST_JS_SOROBAN_CLIENT_NPM_VERSION: https://github.com/stellar/js-soroban-client.git#main
+
+      SYSTEM_TEST_GO_GIT_REF: https://github.com/stellar/go.git\#soroban-xdr-next
      
       # system test will build quickstart image internally to use for running the service stack
       # configured in standalone network mode(core, rpc)
@@ -54,32 +56,87 @@ jobs:
         with:
           path: soroban-tools
       - uses: stellar/actions/rust-cache@main
-      - run: |
-          docker pull golang:1.20
-          docker pull golang:1.19.1
-          docker pull ubuntu:focal
-          if [ -n "$SYSTEM_TEST_CORE_IMAGE" ]; then
-            docker pull "$SYSTEM_TEST_CORE_IMAGE"
-          fi
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build horizon
+        uses: docker/build-push-action@v4
         with:
-          key: system-test-docker-cache-{hash}
-          restore-keys: |
-            system-test-docker-cache-
-      - name: Build system test with component versions
-        run: |
-          cd $GITHUB_WORKSPACE/system-test; \
-          make \
-              CORE_GIT_REF=$SYSTEM_TEST_CORE_GIT_REF \
-              CORE_COMPILE_CONFIGURE_FLAGS="$SYSTEM_TEST_CORE_COMPILE_CONFIGURE_FLAGS" \
-              CORE_IMAGE=$SYSTEM_TEST_CORE_IMAGE \
-              SOROBAN_RPC_GIT_REF=$SYSTEM_TEST_SOROBAN_TOOLS_REF \
-              SOROBAN_CLI_GIT_REF=$SYSTEM_TEST_SOROBAN_TOOLS_REF \
-              RUST_TOOLCHAIN_VERSION=$SYSTEM_TEST_RUST_TOOLCHAIN_VERSION \
-              QUICKSTART_GIT_REF=$SYSTEM_TEST_QUICKSTART_GIT_REF \
-              JS_SOROBAN_CLIENT_NPM_VERSION=$SYSTEM_TEST_JS_SOROBAN_CLIENT_NPM_VERSION \
-              build
+          context: $SYSTEM_TEST_GO_GIT_REF
+          file: services/horizon/docker/Dockerfile.dev
+          target: builder
+          push: false
+          tags: stellar/system-test-horizon:dev
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Build friendbot
+        uses: docker/build-push-action@v4
+        with:
+          context: $SYSTEM_TEST_GO_GIT_REF
+          file: services/friendbot/docker/Dockerfile
+          push: false
+          tags: stellar/system-test-friendbot:dev
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Build soroban-rpc
+        uses: docker/build-push-action@v4
+        with:
+          file: cmd/soroban-rpc/docker/Dockerfile
+          push: false
+          tags: stellar/system-test-soroban-rpc:dev
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Build stellar-cli
+        uses: docker/build-push-action@v4
+        with:
+          file: cmd/soroban-rpc/docker/Dockerfile
+          build-args:
+            - DOCKERHUB_RUST_VERSION=$SYSTEM_TEST_RUST_TOOLCHAIN_VERSION
+          target: builder
+          push: false
+          tags: stellar/system-test-soroban-cli:dev
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Build stellar-core
+        uses: docker/build-push-action@v4
+        with:
+          context: $SYSTEM_TEST_CORE_GIT_REF
+          file: docker/Dockerfile.testing
+          build-args:
+            - BUILDKIT_CONTEXT_KEEP_GIT_DIR=true
+            - CONFIGURE_FLAGS=$SYSTEM_TEST_CORE_COMPILE_CONFIGURE_FLAGS
+          target: builder
+          push: false
+          tags: stellar/system-test-soroban-cli:dev
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build quickstart
+        uses: docker/build-push-action@v4
+        with:
+          context: $SYSTEM_TEST_QUICKSTART_GIT_REF
+          build-args:
+            - STELLAR_CORE_IMAGE_REF=$SYSTEM_TEST_CORE_GIT_REF
+            - HORIZON_IMAGE_REF=stellar/system-test-horizon:dev
+            - FRIENDBOT_IMAGE_REF=stellar/system-test-friendbot:dev
+            - SOROBAN_RPC_IMAGE_REF=stellar/system-test-soroban-rpc:dev
+          push: false
+          tags: stellar/system-test-base:dev
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Build system test
+        uses: docker/build-push-action@v4
+        with:
+          context: $GITHUB_WORKSPACE/system-test
+          build-args:
+            - QUICKSTART_IMAGE_REF=stellar/system-test-base:dev
+            - SOROBAN_CLI_IMAGE_REF=stellar/system-test-soroban-cli:dev
+            - RUST_TOOLCHAIN_VERSION=$SYSTEM_TEST_RUST_TOOLCHAIN_VERSION
+            - NODE_VERSION=14.20.0
+            - JS_SOROBAN_CLIENT_NPM_VERSION=$SYSTEM_TEST_JS_SOROBAN_CLIENT_NPM_VERSION
+          push: false
+          tags: stellar/system-test:dev
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       - name: Run system test scenarios
         run: |
           docker run --rm -t --name e2e_test stellar/system-test:dev \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -106,7 +106,7 @@ jobs:
             CONFIGURE_FLAGS=${{ env.SYSTEM_TEST_CORE_COMPILE_CONFIGURE_FLAGS }}
           target: builder
           push: false
-          tags: stellar/system-test-soroban-cli:dev
+          tags: stellar/system-test-core:dev
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -115,7 +115,7 @@ jobs:
         with:
           context: ${{ env.SYSTEM_TEST_QUICKSTART_GIT_REF }}
           build-args: |
-            STELLAR_CORE_IMAGE_REF=${{ env.SYSTEM_TEST_CORE_GIT_REF }}
+            STELLAR_CORE_IMAGE_REF=stellar/system-test-core:dev
             HORIZON_IMAGE_REF=stellar/system-test-horizon:dev
             FRIENDBOT_IMAGE_REF=stellar/system-test-friendbot:dev
             SOROBAN_RPC_IMAGE_REF=stellar/system-test-soroban-rpc:dev

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -90,7 +90,7 @@ jobs:
         with:
           file: cmd/soroban-rpc/docker/Dockerfile
           build-args:
-            - DOCKERHUB_RUST_VERSION=${{ env.SYSTEM_TEST_RUST_TOOLCHAIN_VERSION }}
+            DOCKERHUB_RUST_VERSION: ${{ env.SYSTEM_TEST_RUST_TOOLCHAIN_VERSION }}
           target: builder
           push: false
           tags: stellar/system-test-soroban-cli:dev
@@ -102,8 +102,8 @@ jobs:
           context: ${{ env.SYSTEM_TEST_CORE_GIT_REF }}
           file: docker/Dockerfile.testing
           build-args:
-            - BUILDKIT_CONTEXT_KEEP_GIT_DIR=true
-            - CONFIGURE_FLAGS=${{ env.SYSTEM_TEST_CORE_COMPILE_CONFIGURE_FLAGS }}
+            BUILDKIT_CONTEXT_KEEP_GIT_DIR: true
+            CONFIGURE_FLAGS: ${{ env.SYSTEM_TEST_CORE_COMPILE_CONFIGURE_FLAGS }}
           target: builder
           push: false
           tags: stellar/system-test-soroban-cli:dev

--- a/cmd/soroban-cli/docker/Dockerfile
+++ b/cmd/soroban-cli/docker/Dockerfile
@@ -1,0 +1,16 @@
+ARG DOCKERHUB_RUST_VERSION
+ARG SOROBAN_CLI_CRATE_VERSION
+
+FROM $DOCKERHUB_RUST_VERSION AS builder
+
+WORKDIR /soroban-tools
+COPY . .
+
+run if [ ! -z "$SOROBAN_CLI_CRATE_VERSION" ]; then \
+		cargo install \
+		--config net.git-fetch-with-cli=true \
+		--config build.jobs=6 -f --locked soroban-cli \
+		--version "$SOROBAN_CLI_CRATE_VERSION"; \
+	else \
+		make install_rust; \
+	fi


### PR DESCRIPTION
### What

Try using a docker layer cache in CI

### Why

Maybe it will help speed up e2e system tests, as they seem to be building core + cli from source each time.

### Testing

- First run: build 45m28s
- Re-running: cache_load: 7m36s + build: 33m8s + post-run-cleanup: 11m40s. Oof. Not really faster...
  - (It's still building everything.. Why is it still building everything!?)
  - Core rebuilds every time locally too. I bet it is the `git clean` with submodules...

- Ah, maybe https://docs.docker.com/build/ci/github-actions/cache/ would be a better (more official) solution, but it would mean unpacking the system-tests makefile
  - Aha! It might not! We could possibly use buildx inside the make file, and pass the cache options into the makefile
