### PR TITLE
Add meta output to soroban-cli contract inspect output

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/inspect.rs
+++ b/cmd/soroban-cli/src/commands/contract/inspect.rs
@@ -19,12 +19,7 @@ pub enum Error {
 impl Cmd {
     pub fn run(&self) -> Result<(), Error> {
         println!("File: {}", self.wasm.wasm.to_string_lossy());
-        let parsed = self.wasm.parse()?;
-        if parsed.env_meta.len() > 0 {
-            print!("{:#?}", (parsed.env_meta, parsed.spec.clone()));
-        } else {
-            print!("{:#?}", (parsed.spec));
-        }
+        println!("{}", self.wasm.parse()?);
         Ok(())
     }
 }

--- a/cmd/soroban-cli/src/commands/contract/inspect.rs
+++ b/cmd/soroban-cli/src/commands/contract/inspect.rs
@@ -19,7 +19,12 @@ pub enum Error {
 impl Cmd {
     pub fn run(&self) -> Result<(), Error> {
         println!("File: {}", self.wasm.wasm.to_string_lossy());
-        print!("{:#?}", self.wasm.parse()?.spec);
+        let parsed = self.wasm.parse()?;
+        if parsed.env_meta.len() > 0 {
+            print!("{:#?}", (parsed.env_meta, parsed.spec.clone()));
+        } else {
+            print!("{:#?}", (parsed.spec));
+        }
         Ok(())
     }
 }

--- a/cmd/soroban-cli/src/wasm.rs
+++ b/cmd/soroban-cli/src/wasm.rs
@@ -6,7 +6,7 @@ use std::{
     path::Path,
 };
 
-use soroban_env_host::xdr::{self, ReadXdr, ScEnvMetaEntry, ScSpecEntry, ScMetaEntry, ScMetaV0};
+use soroban_env_host::xdr::{self, ReadXdr, ScEnvMetaEntry, ScMetaEntry, ScMetaV0, ScSpecEntry};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -143,7 +143,7 @@ impl Display for ContractSpec {
             writeln!(f, "Contract Meta: {meta}")?;
             for meta_entry in &self.meta {
                 match meta_entry {
-                    ScMetaEntry::ScMetaV0(ScMetaV0{key, val}) => {
+                    ScMetaEntry::ScMetaV0(ScMetaV0 { key, val }) => {
                         writeln!(f, " • {key}: {val}")?;
                     }
                 }
@@ -163,7 +163,8 @@ impl Display for ContractSpec {
                         func.inputs.as_slice(),
                         func.outputs.as_slice(),
                         if func.doc.len() > 0 {
-                            "\n   Docs: ".to_owned()+&func.doc.to_string_lossy().replace("\n", "\n         ")
+                            "\n   Docs: ".to_owned()
+                                + &func.doc.to_string_lossy().replace("\n", "\n         ")
                         } else {
                             "".to_string()
                         }

--- a/cmd/soroban-cli/src/wasm.rs
+++ b/cmd/soroban-cli/src/wasm.rs
@@ -139,8 +139,8 @@ impl Display for ContractSpec {
             writeln!(f, "Env Meta: None")?;
         }
 
-        if let Some(meta) = &self.meta_base64 {
-            writeln!(f, "Contract Meta: {meta}")?;
+        if let Some(_meta) = &self.meta_base64 {
+            writeln!(f, "Contract Meta:")?;
             for meta_entry in &self.meta {
                 match meta_entry {
                     ScMetaEntry::ScMetaV0(ScMetaV0 { key, val }) => {
@@ -152,34 +152,50 @@ impl Display for ContractSpec {
             writeln!(f, "Contract Meta: None")?;
         }
 
-        if let Some(spec_base64) = &self.spec_base64 {
-            writeln!(f, "Contract Spec: {spec_base64}")?;
+        if let Some(_spec_base64) = &self.spec_base64 {
+            writeln!(f, "Contract Spec:")?;
             for spec_entry in &self.spec {
                 match spec_entry {
-                    ScSpecEntry::FunctionV0(func) => writeln!(
-                        f,
-                        " • Function: {}\n   Inputs: ({:?})\n   Returns: ({:?}){}\n",
-                        func.name.to_string_lossy(),
-                        func.inputs.as_slice(),
-                        func.outputs.as_slice(),
+                    ScSpecEntry::FunctionV0(func) => {
+                        writeln!(
+                            f,
+                            " • Function: {}\n     Inputs: {}\n     Returns: {}",
+                            func.name.to_string_lossy(),
+                            indent(&format!("{:#?}", func.inputs), 5).trim(),
+                            indent(&format!("{:#?}", func.outputs), 5).trim(),
+                        )?;
                         if func.doc.len() > 0 {
-                            "\n   Docs: ".to_owned()
-                                + &func.doc.to_string_lossy().replace("\n", "\n         ")
-                        } else {
-                            "".to_string()
+                            writeln!(
+                                f,
+                                "\n     Docs: {}",
+                                &indent(&func.doc.to_string_lossy(), 11).trim()
+                            )?;
                         }
-                    )?,
+                        writeln!(f)?;
+                    }
                     ScSpecEntry::UdtUnionV0(udt) => {
-                        writeln!(f, " • Union: {udt:?}\n")?;
+                        writeln!(
+                            f,
+                            " • Union: {}\n",
+                            indent(&format!("{:#?}", udt), 3).trim()
+                        )?;
                     }
                     ScSpecEntry::UdtStructV0(udt) => {
-                        writeln!(f, " • Struct: {udt:?}\n")?;
+                        writeln!(
+                            f,
+                            " • Struct: {}\n",
+                            indent(&format!("{:#?}", udt), 3).trim()
+                        )?;
                     }
                     ScSpecEntry::UdtEnumV0(udt) => {
-                        writeln!(f, " • Enum: {udt:?}\n")?;
+                        writeln!(f, " • Enum: {}\n", indent(&format!("{:#?}", udt), 3).trim())?;
                     }
                     ScSpecEntry::UdtErrorEnumV0(udt) => {
-                        writeln!(f, " • Error: {udt:?}\n")?;
+                        writeln!(
+                            f,
+                            " • Error: {}\n",
+                            indent(&format!("{:#?}", udt), 3).trim()
+                        )?;
                     }
                 }
             }
@@ -188,6 +204,14 @@ impl Display for ContractSpec {
         }
         Ok(())
     }
+}
+
+fn indent(s: &str, n: usize) -> String {
+    let pad = " ".repeat(n);
+    s.lines()
+        .map(|line| format!("{}{}", pad, line))
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// # Errors

--- a/cmd/soroban-cli/src/wasm.rs
+++ b/cmd/soroban-cli/src/wasm.rs
@@ -135,8 +135,9 @@ impl Display for ContractSpec {
                     }
                 }
             }
+            writeln!(f)?;
         } else {
-            writeln!(f, "Env Meta: None")?;
+            writeln!(f, "Env Meta: None\n")?;
         }
 
         if let Some(_meta) = &self.meta_base64 {
@@ -148,8 +149,9 @@ impl Display for ContractSpec {
                     }
                 }
             }
+            writeln!(f)?;
         } else {
-            writeln!(f, "Contract Meta: None")?;
+            writeln!(f, "Contract Meta: None\n")?;
         }
 
         if let Some(_spec_base64) = &self.spec_base64 {
@@ -157,45 +159,97 @@ impl Display for ContractSpec {
             for spec_entry in &self.spec {
                 match spec_entry {
                     ScSpecEntry::FunctionV0(func) => {
-                        writeln!(
-                            f,
-                            " • Function: {}\n     Inputs: {}\n     Returns: {}",
-                            func.name.to_string_lossy(),
-                            indent(&format!("{:#?}", func.inputs), 5).trim(),
-                            indent(&format!("{:#?}", func.outputs), 5).trim(),
-                        )?;
+                        writeln!(f, " • Function: {}", func.name.to_string_lossy())?;
                         if func.doc.len() > 0 {
                             writeln!(
                                 f,
-                                "\n     Docs: {}",
+                                "     Docs: {}",
                                 &indent(&func.doc.to_string_lossy(), 11).trim()
                             )?;
                         }
+                        writeln!(
+                            f,
+                            "     Inputs: {}",
+                            indent(&format!("{:#?}", func.inputs), 5).trim()
+                        )?;
+                        writeln!(
+                            f,
+                            "     Output: {}",
+                            indent(&format!("{:#?}", func.outputs), 5).trim()
+                        )?;
                         writeln!(f)?;
                     }
                     ScSpecEntry::UdtUnionV0(udt) => {
-                        writeln!(
-                            f,
-                            " • Union: {}\n",
-                            indent(&format!("{:#?}", udt), 3).trim()
-                        )?;
+                        // TODO: What is `lib`? Do we need that?
+                        writeln!(f, " • Union: {}", udt.name.to_string_lossy())?;
+                        if udt.doc.len() > 0 {
+                            writeln!(
+                                f,
+                                "     Docs: {}",
+                                indent(&udt.doc.to_string_lossy(), 10).trim()
+                            )?;
+                        }
+                        writeln!(f, "     Cases:")?;
+                        for case in udt.cases.iter() {
+                            writeln!(f, "      • {}", indent(&format!("{:#?}", case), 8).trim())?;
+                        }
+                        writeln!(f)?;
                     }
                     ScSpecEntry::UdtStructV0(udt) => {
-                        writeln!(
-                            f,
-                            " • Struct: {}\n",
-                            indent(&format!("{:#?}", udt), 3).trim()
-                        )?;
+                        // TODO: What is `lib`? Do we need that?
+                        writeln!(f, " • Struct: {}", udt.name.to_string_lossy())?;
+                        if udt.doc.len() > 0 {
+                            writeln!(
+                                f,
+                                "     Docs: {}",
+                                indent(&udt.doc.to_string_lossy(), 10).trim()
+                            )?;
+                        }
+                        writeln!(f, "     Fields:")?;
+                        for field in udt.fields.iter() {
+                            writeln!(
+                                f,
+                                "      • {}: {}",
+                                field.name.to_string_lossy(),
+                                indent(&format!("{:#?}", field.type_), 8).trim()
+                            )?;
+                            if field.doc.len() > 0 {
+                                writeln!(f, "{}", indent(&format!("{:#?}", field.doc), 8))?;
+                            }
+                        }
+                        writeln!(f)?;
                     }
                     ScSpecEntry::UdtEnumV0(udt) => {
-                        writeln!(f, " • Enum: {}\n", indent(&format!("{:#?}", udt), 3).trim())?;
+                        // TODO: What is `lib`? Do we need that?
+                        writeln!(f, " • Enum: {}", udt.name.to_string_lossy())?;
+                        if udt.doc.len() > 0 {
+                            writeln!(
+                                f,
+                                "     Docs: {}",
+                                indent(&udt.doc.to_string_lossy(), 10).trim()
+                            )?;
+                        }
+                        writeln!(f, "     Cases:")?;
+                        for case in udt.cases.iter() {
+                            writeln!(f, "      • {}", indent(&format!("{:#?}", case), 8).trim())?;
+                        }
+                        writeln!(f)?;
                     }
                     ScSpecEntry::UdtErrorEnumV0(udt) => {
-                        writeln!(
-                            f,
-                            " • Error: {}\n",
-                            indent(&format!("{:#?}", udt), 3).trim()
-                        )?;
+                        // TODO: What is `lib`? Do we need that?
+                        writeln!(f, " • Error: {}", udt.name.to_string_lossy())?;
+                        if udt.doc.len() > 0 {
+                            writeln!(
+                                f,
+                                "     Docs: {}",
+                                indent(&udt.doc.to_string_lossy(), 10).trim()
+                            )?;
+                        }
+                        writeln!(f, "     Cases:")?;
+                        for case in udt.cases.iter() {
+                            writeln!(f, "      • {}", indent(&format!("{:#?}", case), 8).trim())?;
+                        }
+                        writeln!(f)?;
                     }
                 }
             }

--- a/cmd/soroban-cli/src/wasm.rs
+++ b/cmd/soroban-cli/src/wasm.rs
@@ -163,7 +163,7 @@ impl Display for ContractSpec {
                         func.inputs.as_slice(),
                         func.outputs.as_slice(),
                         if func.doc.len() > 0 {
-                            "\n   Docs: ".to_owned()+&func.doc.to_string_lossy()
+                            "\n   Docs: ".to_owned()+&func.doc.to_string_lossy().replace("\n", "\n         ")
                         } else {
                             "".to_string()
                         }

--- a/cmd/soroban-cli/src/wasm.rs
+++ b/cmd/soroban-cli/src/wasm.rs
@@ -6,7 +6,9 @@ use std::{
     path::Path,
 };
 
-use soroban_env_host::xdr::{self, ReadXdr, ScEnvMetaEntry, ScMetaEntry, ScMetaV0, ScSpecEntry};
+use soroban_env_host::xdr::{
+    self, ReadXdr, ScEnvMetaEntry, ScMetaEntry, ScMetaV0, ScSpecEntry, StringM,
+};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -180,8 +182,7 @@ impl Display for ContractSpec {
                         writeln!(f)?;
                     }
                     ScSpecEntry::UdtUnionV0(udt) => {
-                        // TODO: What is `lib`? Do we need that?
-                        writeln!(f, " • Union: {}", udt.name.to_string_lossy())?;
+                        writeln!(f, " • Union: {}", format_name(&udt.lib, &udt.name))?;
                         if udt.doc.len() > 0 {
                             writeln!(
                                 f,
@@ -196,8 +197,7 @@ impl Display for ContractSpec {
                         writeln!(f)?;
                     }
                     ScSpecEntry::UdtStructV0(udt) => {
-                        // TODO: What is `lib`? Do we need that?
-                        writeln!(f, " • Struct: {}", udt.name.to_string_lossy())?;
+                        writeln!(f, " • Struct: {}", format_name(&udt.lib, &udt.name))?;
                         if udt.doc.len() > 0 {
                             writeln!(
                                 f,
@@ -220,8 +220,7 @@ impl Display for ContractSpec {
                         writeln!(f)?;
                     }
                     ScSpecEntry::UdtEnumV0(udt) => {
-                        // TODO: What is `lib`? Do we need that?
-                        writeln!(f, " • Enum: {}", udt.name.to_string_lossy())?;
+                        writeln!(f, " • Enum: {}", format_name(&udt.lib, &udt.name))?;
                         if udt.doc.len() > 0 {
                             writeln!(
                                 f,
@@ -236,8 +235,7 @@ impl Display for ContractSpec {
                         writeln!(f)?;
                     }
                     ScSpecEntry::UdtErrorEnumV0(udt) => {
-                        // TODO: What is `lib`? Do we need that?
-                        writeln!(f, " • Error: {}", udt.name.to_string_lossy())?;
+                        writeln!(f, " • Error: {}", format_name(&udt.lib, &udt.name))?;
                         if udt.doc.len() > 0 {
                             writeln!(
                                 f,
@@ -266,6 +264,14 @@ fn indent(s: &str, n: usize) -> String {
         .map(|line| format!("{}{}", pad, line))
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+fn format_name(lib: &StringM<80>, name: &StringM<60>) -> String {
+    if lib.len() > 0 {
+        format!("{}::{}", lib.to_string_lossy(), name.to_string_lossy())
+    } else {
+        format!("{}", name.to_string_lossy())
+    }
 }
 
 /// # Errors


### PR DESCRIPTION
### What

If there is env meta to show for the contract, include it in the output of `soroban contract inspect --wasm foo.wasm`

This also improves the `contract inspect` output, to format output nicer, and include doc strings.
e.g.
```
 • Function: withdraw
     Docs: Whatever docstring the function has goes here.
     Inputs: VecM(
         [
             ScSpecFunctionInputV0 {
                 doc: StringM(),
                 name: StringM(to),
                 type_: Address,
             },
             ScSpecFunctionInputV0 {
                 doc: StringM(),
                 name: StringM(share_amount),
                 type_: I128,
             },
             ScSpecFunctionInputV0 {
                 doc: StringM(),
                 name: StringM(min_a),
                 type_: I128,
             },
             ScSpecFunctionInputV0 {
                 doc: StringM(),
                 name: StringM(min_b),
                 type_: I128,
             },
         ],
     )
     Output: VecM(
         [
             Tuple(
                 ScSpecTypeTuple {
                     value_types: VecM(
                         [
                             I128,
                             I128,
                         ],
                     ),
                 },
             ),
         ],
     )
```

### Why

Fixes https://github.com/stellar/soroban-tools/issues/593

We will actually be putting useful info (hopefully) into the meta, so outputting it will be helpful to devs.

### Known limitations

~We need https://github.com/stellar/rs-soroban-sdk/issues/735 to test this out for realsies.~

Confirm that the new meta field will be at `contractmetav0`.
- [x] Test it with https://github.com/stellar/soroban-examples/pull/241