### PR TITLE
fix(CLI): revert taring published arifacts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,6 +54,10 @@ jobs:
       with:
         name: ${{ env.NAME }}
         path: 'target/${{ matrix.target }}/release/soroban${{ matrix.ext }}'
+    - name: Compress 
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czvf $NAME.tar.gz soroban${{ matrix.ext }}
     - name: Upload
       uses: actions/github-script@v6
       with:
@@ -63,6 +67,6 @@ jobs:
             owner: context.repo.owner,
             repo: context.repo.repo,
             release_id: ${{ github.event.release.id }},
-            name: '${{ env.NAME }}${{ matrix.ext }}',
-            data: fs.readFileSync('target/${{ matrix.target }}/release/soroban${{ matrix.ext }}'),
+            name: '${{ env.NAME }}.tar.gz',
+            data: fs.readFileSync('target/${{ matrix.target }}/release/${{ env.NAME }}.tar.gz'),
           });

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,14 +50,14 @@ jobs:
         tar xvfz soroban-cli-$VERSION.crate
         cd soroban-cli-$VERSION
         cargo build --target-dir=../.. --features opt --release --target ${{ matrix.target }}
+    - name: Compress 
+      run: |
+          cd target/${{ matrix.target }}/release
+          tar czvf $NAME.tar.gz soroban${{ matrix.ext }}
     - uses: actions/upload-artifact@v3
       with:
         name: ${{ env.NAME }}
         path: 'target/${{ matrix.target }}/release/soroban${{ matrix.ext }}'
-    - name: Compress 
-        run: |
-          cd target/${{ matrix.target }}/release
-          tar czvf $NAME.tar.gz soroban${{ matrix.ext }}
     - name: Upload
       uses: actions/github-script@v6
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,7 +57,7 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: ${{ env.NAME }}
-        path: 'target/${{ matrix.target }}/release/soroban${{ matrix.ext }}'
+        path: 'target/${{ matrix.target }}/release/${{ env.NAME }}.tar.gz'
     - name: Upload
       uses: actions/github-script@v6
       with:

--- a/cmd/soroban-cli/Cargo.toml
+++ b/cmd/soroban-cli/Cargo.toml
@@ -16,6 +16,10 @@ default-run = "soroban"
 name = "soroban"
 path = "src/bin/main.rs"
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.{ archive-format }"
+bin-dir = "{ bin }{ binary-ext }"
+
 [[bin]]
 name = "doc-gen"
 path = "src/bin/doc-gen.rs"

--- a/cmd/soroban-cli/Cargo.toml
+++ b/cmd/soroban-cli/Cargo.toml
@@ -17,7 +17,7 @@ name = "soroban"
 path = "src/bin/main.rs"
 
 [package.metadata.binstall]
-pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }{ archive-suffix }"
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.{ archive-suffix }"
 bin-dir = "{ bin }{ binary-ext }"
 
 [[bin]]

--- a/cmd/soroban-cli/Cargo.toml
+++ b/cmd/soroban-cli/Cargo.toml
@@ -17,7 +17,7 @@ name = "soroban"
 path = "src/bin/main.rs"
 
 [package.metadata.binstall]
-pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.{ archive-format }"
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }{ archive-suffix }"
 bin-dir = "{ bin }{ binary-ext }"
 
 [[bin]]


### PR DESCRIPTION
### What

Add back packaging the executables when publishing.


### Why

Tools like cargo-binstall expect the artifacts to be packaged. Also some OSes like macos disallow executing raw executables downloaded. However, those that are untar'd are fine.

After adding the needed fields to the CLI's Cargo.toml
```bash
cargo binstall soroban-cli --force --manifest-path ~/c/s/soroban-cli/cmd/soroban-cli/Cargo.toml 
```

``` INFO resolve: Resolving package: 'soroban-cli'
 WARN resolve: Error while checking fetcher invalid url: Invalid pkg-url { repo }/releases/download/v{ version }/{ name }-{ target } for soroban-cli@0.7.1 on aarch64-apple-darwin: pkg-fmt is not specified, yet pkg-url does not contain format, archive-format or archive-suffix which is required for automatically deducing pkg-fmt
 WARN resolve: Error while checking fetcher invalid url: Invalid pkg-url { repo }/releases/download/v{ version }/{ name }-{ target } for soroban-cli@0.7.1 on x86_64-apple-darwin: pkg-fmt is not specified, yet pkg-url does not contain format, archive-format or archive-suffix which is required for automatically deducing pkg-fmt
 WARN resolve: Error while checking fetcher invalid url: Invalid pkg-url { repo }/releases/download/v{ version }/{ name }-{ target } for soroban-cli@0.7.1 on universal-apple-darwin: pkg-fmt is not specified, yet pkg-url does not contain format, archive-format or archive-suffix which is required for automatically deducing pkg-fmt
 WARN resolve: Error while checking fetcher invalid url: Invalid pkg-url { repo }/releases/download/v{ version }/{ name }-{ target } for soroban-cli@0.7.1 on universal2-apple-darwin: pkg-fmt is not specified, yet pkg-url does not contain format, archive-format or archive-suffix which is required for automatically deducing pkg-fmt
 WARN The package soroban-cli v0.7.1 will be installed from source (with cargo)
Do you wish to continue? yes/[no]

Outputs:
```


### Known limitations

[TODO or N/A]
