### PR TITLE
cli: Unveil broken Rust tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,7 +66,7 @@ jobs:
     - if: startsWith(matrix.target, 'x86_64')
       # specify directories explicitly to avoid building the preflight library (otherwise it will fail with missing symbols)
       run: |
-        for I in cmd/soroban-cli cmd/crates/soroban-test cmd/crates/soroban-test/tests/fixtures/test-wasms/hello_world ; do
+        for I in cmd/soroban-cli cmd/crates/soroban-test cmd/crates/soroban-test/ ; do
           cargo test --target ${{ matrix.target }} --manifest-path $I/Cargo.toml
         done
   publish-dry-run:


### PR DESCRIPTION


### What

Unveil tests which were broken and we didn't notice because they were not run by CI :S

### Why

We want all tests to pass

### Known limitations

N/A
