### PR TITLE
soroban-rpc: Calculate soroban transaction data in libpreflight

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,7 @@ jobs:
 
       # core git ref should be latest commit for stable soroban functionality
       # the core bin can either be compiled in-line here as part of ci, 
-      SYSTEM_TEST_CORE_GIT_REF: https://github.com/stellar/stellar-core.git#61f76a1137b82cbf6724c54bdd325daebed28151
+      SYSTEM_TEST_CORE_GIT_REF: https://github.com/stellar/stellar-core.git#57cc8198c95c95114d60f7c0f1498933ff57bd9b
       SYSTEM_TEST_CORE_COMPILE_CONFIGURE_FLAGS: "--disable-tests --enable-next-protocol-version-unsafe-for-production"
       # or can use option to pull a pre-compiled image instead
       # SYSTEM_TEST_CORE_IMAGE: 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1420,9 +1420,11 @@ dependencies = [
 name = "preflight"
 version = "0.7.1"
 dependencies = [
+ "base64 0.13.1",
  "libc",
  "sha2 0.10.6",
  "soroban-env-host",
+ "thiserror",
 ]
 
 [[package]]

--- a/cmd/soroban-rpc/internal/methods/simulate_transaction.go
+++ b/cmd/soroban-rpc/internal/methods/simulate_transaction.go
@@ -100,14 +100,11 @@ func NewSimulateTransactionHandler(logger *log.Entry, ledgerEntryReader db.Ledge
 
 		hostFunctionResults := make([]SimulateHostFunctionResult, len(result.Results))
 		for i := 0; i < len(hostFunctionResults); i++ {
-			hostFunctionResults[i].XDR = result.Results[i]
+			hostFunctionResults[i] = SimulateHostFunctionResult{
+				Auth: result.Results[i].Auth,
+				XDR:  result.Results[i].Result,
+			}
 		}
-
-		// For now, attribute the full auth and and events to the first function
-		//
-		// FIXME: this is wrong! we should be able to get the auth and events for each separate function
-		//        but needs to be implemented in libpreflight first
-		hostFunctionResults[0].Auth = result.Auth
 
 		return SimulateTransactionResponse{
 			Results:         hostFunctionResults,

--- a/cmd/soroban-rpc/internal/methods/simulate_transaction.go
+++ b/cmd/soroban-rpc/internal/methods/simulate_transaction.go
@@ -33,8 +33,8 @@ type SimulateTransactionResponse struct {
 	TransactionData string                       `json:"transactionData"` // SorobanTransactionData XDR in base64
 	Events          []string                     `json:"events"`          // DiagnosticEvent XDR in base64
 	MinResourceFee  int64                        `json:"minResourceFee,string"`
-	Results         []SimulateHostFunctionResult `json:"results,omitempty"`
-	Cost            SimulateTransactionCost      `json:"cost"`
+	Results         []SimulateHostFunctionResult `json:"results,omitempty"` // an array of the individual host function call results
+	Cost            SimulateTransactionCost      `json:"cost"`              // the effective cpu and memory cost of the invoked transaction execution.
 	LatestLedger    int64                        `json:"latestLedger,string"`
 }
 

--- a/cmd/soroban-rpc/internal/methods/simulate_transaction.go
+++ b/cmd/soroban-rpc/internal/methods/simulate_transaction.go
@@ -30,8 +30,8 @@ type SimulateHostFunctionResult struct {
 type SimulateTransactionResponse struct {
 	Error string `json:"error,omitempty"`
 	// TODO: update documentation and review field names
-	TransactionData string                       `json:"transaction_data"` // SorobanTransactionData XDR in base64
-	Events          []string                     `json:"events"`           // DiagnosticEvent XDR in base64
+	TransactionData string                       `json:"transactionData"` // SorobanTransactionData XDR in base64
+	Events          []string                     `json:"events"`          // DiagnosticEvent XDR in base64
 	MinResourceFee  int64                        `json:"minResourceFee,string"`
 	Results         []SimulateHostFunctionResult `json:"results,omitempty"`
 	Cost            SimulateTransactionCost      `json:"cost"`

--- a/cmd/soroban-rpc/internal/methods/simulate_transaction.go
+++ b/cmd/soroban-rpc/internal/methods/simulate_transaction.go
@@ -21,19 +21,23 @@ type SimulateTransactionCost struct {
 	MemoryBytes     uint64 `json:"memBytes,string"`
 }
 
+// TODO: should this refer to each InvokeHostFunctionOp within the transaction
+//
+//	or to each HostFunction within each InvokeHostFunctionOp
 type SimulateTransactionResult struct {
-	Auth      []string `json:"auth"`
-	Events    []string `json:"events"`
-	Footprint string   `json:"footprint"`
+	Auth   []string `json:"auth"`
+	Events []string `json:"events"`
 	// TODO: update documentation and review field name
-	XDRs []string `json:"xdrs"`
+	XDRs []string `json:"xdrs"` // SCVal XDRs in base64
 }
 
 type SimulateTransactionResponse struct {
-	Error        string                      `json:"error,omitempty"`
-	Results      []SimulateTransactionResult `json:"results,omitempty"`
-	Cost         SimulateTransactionCost     `json:"cost"`
-	LatestLedger int64                       `json:"latestLedger,string"`
+	Error string `json:"error,omitempty"`
+	// TODO: update documentation and review field name
+	TransactionData string                      `json:"transaction_data"` // SorobanTransactionData XDR in base64
+	Results         []SimulateTransactionResult `json:"results,omitempty"`
+	Cost            SimulateTransactionCost     `json:"cost"`
+	LatestLedger    int64                       `json:"latestLedger,string"`
 }
 
 type PreflightGetter interface {
@@ -99,12 +103,12 @@ func NewSimulateTransactionHandler(logger *log.Entry, ledgerEntryReader db.Ledge
 		return SimulateTransactionResponse{
 			Results: []SimulateTransactionResult{
 				{
-					Events:    result.Events,
-					Auth:      result.Auth,
-					Footprint: result.Footprint,
-					XDRs:      result.Results,
+					Events: result.Events,
+					Auth:   result.Auth,
+					XDRs:   result.Results,
 				},
 			},
+			TransactionData: result.TransactionData,
 			Cost: SimulateTransactionCost{
 				CPUInstructions: result.CPUInstructions,
 				MemoryBytes:     result.MemoryBytes,

--- a/cmd/soroban-rpc/internal/methods/simulate_transaction.go
+++ b/cmd/soroban-rpc/internal/methods/simulate_transaction.go
@@ -23,15 +23,15 @@ type SimulateTransactionCost struct {
 
 // SimulateHostFunctionResult contains the simulation result of each HostFunction within each InvokeHostFunctionOp
 type SimulateHostFunctionResult struct {
-	Auth   []string `json:"auth"`
-	Events []string `json:"events"`
-	XDR    string   `json:"xdr"`
+	Auth []string `json:"auth"`
+	XDR  string   `json:"xdr"`
 }
 
 type SimulateTransactionResponse struct {
 	Error string `json:"error,omitempty"`
-	// TODO: update documentation and review field name
+	// TODO: update documentation and review field names
 	TransactionData string                       `json:"transaction_data"` // SorobanTransactionData XDR in base64
+	Events          []string                     `json:"events"`           // DiagnosticEvent XDR in base64
 	MinResourceFee  int64                        `json:"minResourceFee,string"`
 	Results         []SimulateHostFunctionResult `json:"results,omitempty"`
 	Cost            SimulateTransactionCost      `json:"cost"`
@@ -107,11 +107,11 @@ func NewSimulateTransactionHandler(logger *log.Entry, ledgerEntryReader db.Ledge
 		//
 		// FIXME: this is wrong! we should be able to get the auth and events for each separate function
 		//        but needs to be implemented in libpreflight first
-		hostFunctionResults[0].Events = result.Events
 		hostFunctionResults[0].Auth = result.Auth
 
 		return SimulateTransactionResponse{
 			Results:         hostFunctionResults,
+			Events:          result.Events,
 			TransactionData: result.TransactionData,
 			MinResourceFee:  result.MinFee,
 			Cost: SimulateTransactionCost{

--- a/cmd/soroban-rpc/internal/methods/simulate_transaction.go
+++ b/cmd/soroban-rpc/internal/methods/simulate_transaction.go
@@ -113,9 +113,7 @@ func NewSimulateTransactionHandler(logger *log.Entry, ledgerEntryReader db.Ledge
 		return SimulateTransactionResponse{
 			Results:         hostFunctionResults,
 			TransactionData: result.TransactionData,
-			// FIXME: this cast shouldn't be necessary
-			//       find out why it doesn't work without it
-			MinFee: int64(result.MinFee),
+			MinFee:          result.MinFee,
 			Cost: SimulateTransactionCost{
 				CPUInstructions: result.CPUInstructions,
 				MemoryBytes:     result.MemoryBytes,

--- a/cmd/soroban-rpc/internal/methods/simulate_transaction.go
+++ b/cmd/soroban-rpc/internal/methods/simulate_transaction.go
@@ -21,7 +21,7 @@ type SimulateTransactionCost struct {
 	MemoryBytes     uint64 `json:"memBytes,string"`
 }
 
-// SimulateHostFunctionResult contains the simulation result of each HostFunction within each InvokeHostFunctionOp
+// SimulateHostFunctionResult contains the simulation result of each HostFunction within the single InvokeHostFunctionOp allowed in a Transaction
 type SimulateHostFunctionResult struct {
 	Auth []string `json:"auth"`
 	XDR  string   `json:"xdr"`

--- a/cmd/soroban-rpc/internal/methods/simulate_transaction.go
+++ b/cmd/soroban-rpc/internal/methods/simulate_transaction.go
@@ -32,7 +32,7 @@ type SimulateTransactionResponse struct {
 	Error string `json:"error,omitempty"`
 	// TODO: update documentation and review field name
 	TransactionData string                       `json:"transaction_data"` // SorobanTransactionData XDR in base64
-	MinFee          int64                        `json:"minFee,string"`
+	MinResourceFee  int64                        `json:"minResourceFee,string"`
 	Results         []SimulateHostFunctionResult `json:"results,omitempty"`
 	Cost            SimulateTransactionCost      `json:"cost"`
 	LatestLedger    int64                        `json:"latestLedger,string"`
@@ -113,7 +113,7 @@ func NewSimulateTransactionHandler(logger *log.Entry, ledgerEntryReader db.Ledge
 		return SimulateTransactionResponse{
 			Results:         hostFunctionResults,
 			TransactionData: result.TransactionData,
-			MinFee:          result.MinFee,
+			MinResourceFee:  result.MinFee,
 			Cost: SimulateTransactionCost{
 				CPUInstructions: result.CPUInstructions,
 				MemoryBytes:     result.MemoryBytes,

--- a/cmd/soroban-rpc/internal/preflight/preflight.go
+++ b/cmd/soroban-rpc/internal/preflight/preflight.go
@@ -168,7 +168,7 @@ func GetPreflight(ctx context.Context, params PreflightParameters) (Preflight, e
 		Auth:            GoNullTerminatedStringSlice(res.auth),
 		Events:          GoNullTerminatedStringSlice(res.events),
 		TransactionData: C.GoString(res.transaction_data),
-		MinFee:          res.min_fee,
+		MinFee:          int64(res.min_fee),
 		Results:         GoNullTerminatedStringSlice(res.results),
 		CPUInstructions: uint64(res.cpu_instructions),
 		MemoryBytes:     uint64(res.memory_bytes),

--- a/cmd/soroban-rpc/internal/preflight/preflight.go
+++ b/cmd/soroban-rpc/internal/preflight/preflight.go
@@ -95,12 +95,16 @@ type PreflightParameters struct {
 	LedgerEntryReadTx  db.LedgerEntryReadTx
 }
 
+type HostFunctionPreflight struct {
+	Result string   // XDR SCVal in base64
+	Auth   []string // ContractAuths XDR in base64
+}
+
 type Preflight struct {
-	Auth            []string // ContractAuths XDR in base64
 	Events          []string // DiagnosticEvents XDR in base64
 	TransactionData string   // SorobanTransactionData XDR in base64
 	MinFee          int64
-	Results         []string // SCVal XDRs in base64
+	Results         []HostFunctionPreflight
 	CPUInstructions uint64
 	MemoryBytes     uint64
 }
@@ -164,12 +168,20 @@ func GetPreflight(ctx context.Context, params PreflightParameters) (Preflight, e
 		return Preflight{}, errors.New(C.GoString(res.error))
 	}
 
+	cHostFunctionPreflights := (*[1 << 20]C.CHostFunctionPreflight)(unsafe.Pointer(res.results))[:res.results_size:res.results_size]
+	hostFunctionPreflights := make([]HostFunctionPreflight, len(cHostFunctionPreflights))
+	for i, cHostFunctionPreflight := range cHostFunctionPreflights {
+		hostFunctionPreflights[i] = HostFunctionPreflight{
+			Result: C.GoString(cHostFunctionPreflight.result),
+			Auth:   GoNullTerminatedStringSlice(cHostFunctionPreflight.auth),
+		}
+	}
+
 	preflight := Preflight{
-		Auth:            GoNullTerminatedStringSlice(res.auth),
 		Events:          GoNullTerminatedStringSlice(res.events),
 		TransactionData: C.GoString(res.transaction_data),
 		MinFee:          int64(res.min_fee),
-		Results:         GoNullTerminatedStringSlice(res.results),
+		Results:         hostFunctionPreflights,
 		CPUInstructions: uint64(res.cpu_instructions),
 		MemoryBytes:     uint64(res.memory_bytes),
 	}

--- a/cmd/soroban-rpc/internal/preflight/preflight.go
+++ b/cmd/soroban-rpc/internal/preflight/preflight.go
@@ -98,7 +98,7 @@ type PreflightParameters struct {
 type Preflight struct {
 	Auth            []string // ContractAuths XDR in base64
 	Events          []string // DiagnosticEvents XDR in base64
-	Footprint       string   // LedgerFootprint XDR in base64
+	TransactionData string   // SorobanTransactionData XDR in base64
 	Results         []string // SCVal XDRs in base64
 	CPUInstructions uint64
 	MemoryBytes     uint64
@@ -149,7 +149,7 @@ func GetPreflight(ctx context.Context, params PreflightParameters) (Preflight, e
 	sourceAccountCString := C.CString(sourceAccountB64)
 	handle := cgo.NewHandle(snapshotSourceHandle{params.LedgerEntryReadTx, params.Logger})
 	defer handle.Delete()
-	res := C.preflight_host_function(
+	res := C.preflight_invoke_hf_op(
 		C.uintptr_t(handle),
 		invokeHostFunctionCString,
 		sourceAccountCString,
@@ -166,7 +166,7 @@ func GetPreflight(ctx context.Context, params PreflightParameters) (Preflight, e
 	preflight := Preflight{
 		Auth:            GoNullTerminatedStringSlice(res.auth),
 		Events:          GoNullTerminatedStringSlice(res.events),
-		Footprint:       C.GoString(res.preflight),
+		TransactionData: C.GoString(res.transaction_data),
 		Results:         GoNullTerminatedStringSlice(res.results),
 		CPUInstructions: uint64(res.cpu_instructions),
 		MemoryBytes:     uint64(res.memory_bytes),

--- a/cmd/soroban-rpc/internal/preflight/preflight.go
+++ b/cmd/soroban-rpc/internal/preflight/preflight.go
@@ -99,6 +99,7 @@ type Preflight struct {
 	Auth            []string // ContractAuths XDR in base64
 	Events          []string // DiagnosticEvents XDR in base64
 	TransactionData string   // SorobanTransactionData XDR in base64
+	MinFee          int64
 	Results         []string // SCVal XDRs in base64
 	CPUInstructions uint64
 	MemoryBytes     uint64
@@ -167,6 +168,7 @@ func GetPreflight(ctx context.Context, params PreflightParameters) (Preflight, e
 		Auth:            GoNullTerminatedStringSlice(res.auth),
 		Events:          GoNullTerminatedStringSlice(res.events),
 		TransactionData: C.GoString(res.transaction_data),
+		MinFee:          res.min_fee,
 		Results:         GoNullTerminatedStringSlice(res.results),
 		CPUInstructions: uint64(res.cpu_instructions),
 		MemoryBytes:     uint64(res.memory_bytes),

--- a/cmd/soroban-rpc/internal/preflight/preflight.go
+++ b/cmd/soroban-rpc/internal/preflight/preflight.go
@@ -128,7 +128,6 @@ func GoNullTerminatedStringSlice(str **C.char) []string {
 }
 
 func GetPreflight(ctx context.Context, params PreflightParameters) (Preflight, error) {
-	// TODO: this will be broken until the Go XDR is updated
 	invokeHostFunctionB64, err := xdr.MarshalBase64(params.InvokeHostFunction)
 	if err != nil {
 		return Preflight{}, err

--- a/cmd/soroban-rpc/internal/test/get_ledger_entries_test.go
+++ b/cmd/soroban-rpc/internal/test/get_ledger_entries_test.go
@@ -79,17 +79,18 @@ func TestGetLedgerEntriesSucceeds(t *testing.T) {
 	kp := keypair.Root(StandaloneNetworkPassphrase)
 	account := txnbuild.NewSimpleAccount(kp.Address(), 0)
 
-	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
+	params := preflightTransactionParams(t, client, txnbuild.TransactionParams{
 		SourceAccount:        &account,
 		IncrementSequenceNum: true,
 		Operations: []txnbuild.Operation{
-			createInstallContractCodeOperation(t, account.AccountID, testContract, true),
+			createInstallContractCodeOperation(account.AccountID, testContract),
 		},
 		BaseFee: txnbuild.MinBaseFee,
 		Preconditions: txnbuild.Preconditions{
 			TimeBounds: txnbuild.NewInfiniteTimeout(),
 		},
 	})
+	tx, err := txnbuild.NewTransaction(params)
 	require.NoError(t, err)
 	tx, err = tx.Sign(StandaloneNetworkPassphrase, kp)
 	require.NoError(t, err)

--- a/cmd/soroban-rpc/internal/test/get_ledger_entry_test.go
+++ b/cmd/soroban-rpc/internal/test/get_ledger_entry_test.go
@@ -72,17 +72,18 @@ func TestGetLedgerEntrySucceeds(t *testing.T) {
 	kp := keypair.Root(StandaloneNetworkPassphrase)
 	account := txnbuild.NewSimpleAccount(kp.Address(), 0)
 
-	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
+	params := preflightTransactionParams(t, client, txnbuild.TransactionParams{
 		SourceAccount:        &account,
 		IncrementSequenceNum: true,
 		Operations: []txnbuild.Operation{
-			createInstallContractCodeOperation(t, account.AccountID, testContract, true),
+			createInstallContractCodeOperation(account.AccountID, testContract),
 		},
 		BaseFee: txnbuild.MinBaseFee,
 		Preconditions: txnbuild.Preconditions{
 			TimeBounds: txnbuild.NewInfiniteTimeout(),
 		},
 	})
+	tx, err := txnbuild.NewTransaction(params)
 	assert.NoError(t, err)
 	tx, err = tx.Sign(StandaloneNetworkPassphrase, kp)
 	assert.NoError(t, err)

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -544,9 +544,9 @@ func TestSimulateInvokeContractTransactionSucceeds(t *testing.T) {
 	assert.Equal(t, xdr.ScString("auth"), *event.Event.Body.V0.Topics[0].Str)
 
 	metrics := getMetrics(test)
-	require.Contains(t, metrics, "soroban_rpc_json_rpc_request_duration_seconds_count{endpoint=\"simulateTransaction\",status=\"ok\"} 1")
-	require.Contains(t, metrics, "soroban_rpc_preflight_pool_request_ledger_get_duration_seconds_count{status=\"ok\",type=\"db\"} 1")
-	require.Contains(t, metrics, "soroban_rpc_preflight_pool_request_ledger_get_duration_seconds_count{status=\"ok\",type=\"all\"} 1")
+	require.Contains(t, metrics, "soroban_rpc_json_rpc_request_duration_seconds_count{endpoint=\"simulateTransaction\",status=\"ok\"} 3")
+	require.Contains(t, metrics, "soroban_rpc_preflight_pool_request_ledger_get_duration_seconds_count{status=\"ok\",type=\"db\"} 3")
+	require.Contains(t, metrics, "soroban_rpc_preflight_pool_request_ledger_get_duration_seconds_count{status=\"ok\",type=\"all\"} 3")
 	require.Contains(t, metrics, "soroban_rpc_preflight_pool_request_ledger_entries_fetched_sum 4")
 }
 

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -468,6 +468,7 @@ func TestSimulateInvokeContractTransactionSucceeds(t *testing.T) {
 	require.Contains(t, metrics, "soroban_rpc_preflight_pool_request_ledger_get_duration_seconds_count{status=\"ok\",type=\"db\"} 3")
 	require.Contains(t, metrics, "soroban_rpc_preflight_pool_request_ledger_get_duration_seconds_count{status=\"ok\",type=\"all\"} 3")
 	require.Contains(t, metrics, "soroban_rpc_preflight_pool_request_ledger_entries_fetched_sum 14")
+
 }
 
 func TestSimulateTransactionError(t *testing.T) {

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -349,7 +349,8 @@ func TestSimulateInvokeContractTransactionSucceeds(t *testing.T) {
 		Operations: []txnbuild.Operation{
 			createInstallContractCodeOperation(t, account.AccountID, helloWorldContract, true),
 		},
-		BaseFee: txnbuild.MinBaseFee,
+		// TODO: replace this will the preflight min value?
+		BaseFee: txnbuild.MinBaseFee * 10000,
 		Preconditions: txnbuild.Preconditions{
 			TimeBounds: txnbuild.NewInfiniteTimeout(),
 		},
@@ -363,7 +364,8 @@ func TestSimulateInvokeContractTransactionSucceeds(t *testing.T) {
 		Operations: []txnbuild.Operation{
 			createCreateContractOperation(t, address, helloWorldContract, StandaloneNetworkPassphrase, true),
 		},
-		BaseFee: txnbuild.MinBaseFee,
+		// TODO: replace this will the preflight min value?
+		BaseFee: txnbuild.MinBaseFee * 1000,
 		Preconditions: txnbuild.Preconditions{
 			TimeBounds: txnbuild.NewInfiniteTimeout(),
 		},
@@ -416,7 +418,8 @@ func TestSimulateInvokeContractTransactionSucceeds(t *testing.T) {
 				},
 			),
 		},
-		BaseFee: txnbuild.MinBaseFee,
+		// TODO: replace this will the preflight min value?
+		BaseFee: txnbuild.MinBaseFee * 1000,
 		Preconditions: txnbuild.Preconditions{
 			TimeBounds: txnbuild.NewInfiniteTimeout(),
 		},

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -442,8 +442,6 @@ func TestSimulateInvokeContractTransactionSucceeds(t *testing.T) {
 		Operations: []txnbuild.Operation{
 			createInvokeHostOperation(
 				address,
-				// TODO: fill in this data properly
-				//       we will most likely need to invoke the preflight endpoint
 				xdr.TransactionExt{},
 				contractID,
 				"auth",
@@ -460,8 +458,7 @@ func TestSimulateInvokeContractTransactionSucceeds(t *testing.T) {
 				},
 			),
 		},
-		// TODO: replace this will the preflight min value?
-		BaseFee: txnbuild.MinBaseFee * 1000,
+		BaseFee: txnbuild.MinBaseFee,
 		Preconditions: txnbuild.Preconditions{
 			TimeBounds: txnbuild.NewInfiniteTimeout(),
 		},
@@ -547,7 +544,7 @@ func TestSimulateInvokeContractTransactionSucceeds(t *testing.T) {
 	require.Contains(t, metrics, "soroban_rpc_json_rpc_request_duration_seconds_count{endpoint=\"simulateTransaction\",status=\"ok\"} 3")
 	require.Contains(t, metrics, "soroban_rpc_preflight_pool_request_ledger_get_duration_seconds_count{status=\"ok\",type=\"db\"} 3")
 	require.Contains(t, metrics, "soroban_rpc_preflight_pool_request_ledger_get_duration_seconds_count{status=\"ok\",type=\"all\"} 3")
-	require.Contains(t, metrics, "soroban_rpc_preflight_pool_request_ledger_entries_fetched_sum 4")
+	require.Contains(t, metrics, "soroban_rpc_preflight_pool_request_ledger_entries_fetched_sum 14")
 }
 
 func TestSimulateTransactionError(t *testing.T) {

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -427,7 +427,11 @@ func TestSimulateInvokeContractTransactionSucceeds(t *testing.T) {
 	assert.Equal(t, xdr.Hash(contractHash), ro2.ContractCode.Hash)
 	assert.NoError(t, err)
 
-	// TODO: check the other transactiondata fields
+	assert.NotZero(t, obtainedTransactionData.RefundableFee)
+	assert.NotZero(t, obtainedTransactionData.Resources.ExtendedMetaDataSizeBytes)
+	assert.NotZero(t, obtainedTransactionData.Resources.Instructions)
+	assert.NotZero(t, obtainedTransactionData.Resources.ReadBytes)
+	assert.NotZero(t, obtainedTransactionData.Resources.WriteBytes)
 
 	// check the auth
 	assert.Len(t, response.Results[0].Auth, 1)

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -260,10 +260,11 @@ func TestSimulateTransactionSucceeds(t *testing.T) {
 				CPUInstructions: result.Cost.CPUInstructions,
 				MemoryBytes:     result.Cost.MemoryBytes,
 			},
+			// TODO: place actual string
+			TransactionData: "",
 			Results: []methods.SimulateHostFunctionResult{
 				{
-					Footprint: "AAAAAAAAAAEAAAAH6p/Lga5Uop9rO/KThH0/1+mjaf0cgKyv7Gq9VxMX4MI=",
-					XDR:       expectedXdr,
+					XDR: expectedXdr,
 				},
 			},
 			LatestLedger: result.LatestLedger,
@@ -434,8 +435,9 @@ func TestSimulateInvokeContractTransactionSucceeds(t *testing.T) {
 	assert.Equal(t, authAccountIDArg, obtainedResult.Address.MustAccountId())
 
 	// check the footprint
-	var obtainedFootprint xdr.LedgerFootprint
-	err = xdr.SafeUnmarshalBase64(response.Results[0].Footprint, &obtainedFootprint)
+	var obtainedTransactionData xdr.SorobanTransactionData
+	err = xdr.SafeUnmarshalBase64(response.TransactionData, &obtainedTransactionData)
+	obtainedFootprint := obtainedTransactionData.Resources.Footprint
 	assert.NoError(t, err)
 	assert.Len(t, obtainedFootprint.ReadWrite, 1)
 	assert.Len(t, obtainedFootprint.ReadOnly, 3)
@@ -453,6 +455,8 @@ func TestSimulateInvokeContractTransactionSucceeds(t *testing.T) {
 	contractHash := sha256.Sum256(uploadContractCodeArgs)
 	assert.Equal(t, xdr.Hash(contractHash), ro2.ContractCode.Hash)
 	assert.NoError(t, err)
+
+	// TODO: check the other transactiondata fields
 
 	// check the auth
 	assert.Len(t, response.Results[0].Auth, 1)

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -292,6 +292,9 @@ func TestSimulateTransactionSucceeds(t *testing.T) {
 	assert.Equal(t, result, resultForRequestWithDifferentTxSource)
 }
 
+// TODO: we should add a test preflighting an InvokeHostFunctionOp with multiple host functions
+//       we can probably just modify TestSimulateInvokeContractTransactionSucceeds
+
 func TestSimulateInvokeContractTransactionSucceeds(t *testing.T) {
 	test := NewTest(t)
 

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -260,8 +260,8 @@ func TestSimulateTransactionSucceeds(t *testing.T) {
 				CPUInstructions: result.Cost.CPUInstructions,
 				MemoryBytes:     result.Cost.MemoryBytes,
 			},
-			// TODO: place actual string
-			TransactionData: "",
+			TransactionData: "AAAAAAAAAAEAAAAH6p/Lga5Uop9rO/KThH0/1+mjaf0cgKyv7Gq9VxMX4MIAAGWMAAAAAAAAAGQAAABkAAAAAAAAABQAAAAA",
+			MinResourceFee:  result.MinResourceFee,
 			Results: []methods.SimulateHostFunctionResult{
 				{
 					XDR: expectedXdr,

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -157,6 +157,7 @@ func preflightTransactionParams(t *testing.T, client *jrpc2.Client, params txnbu
 	}
 	var transactionData xdr.SorobanTransactionData
 	err = xdr.SafeUnmarshalBase64(response.TransactionData, &transactionData)
+	assert.NoError(t, err)
 	op.Ext = xdr.TransactionExt{
 		V:           1,
 		SorobanData: &transactionData,

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -468,7 +468,6 @@ func TestSimulateInvokeContractTransactionSucceeds(t *testing.T) {
 	require.Contains(t, metrics, "soroban_rpc_preflight_pool_request_ledger_get_duration_seconds_count{status=\"ok\",type=\"db\"} 3")
 	require.Contains(t, metrics, "soroban_rpc_preflight_pool_request_ledger_get_duration_seconds_count{status=\"ok\",type=\"all\"} 3")
 	require.Contains(t, metrics, "soroban_rpc_preflight_pool_request_ledger_entries_fetched_sum 14")
-
 }
 
 func TestSimulateTransactionError(t *testing.T) {

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -484,9 +484,9 @@ func TestSimulateInvokeContractTransactionSucceeds(t *testing.T) {
 	assert.Nil(t, obtainedAuth.RootInvocation.SubInvocations)
 
 	// check the events
-	assert.Len(t, response.Results[0].Events, 1)
+	assert.Len(t, response.Events, 1)
 	var event xdr.DiagnosticEvent
-	err = xdr.SafeUnmarshalBase64(response.Results[0].Events[0], &event)
+	err = xdr.SafeUnmarshalBase64(response.Events[0], &event)
 	assert.NoError(t, err)
 	assert.True(t, event.InSuccessfulContractCall)
 	assert.Equal(t, xdr.Hash(contractID), *event.Event.ContractId)

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -225,7 +225,7 @@ func TestSimulateTransactionSucceeds(t *testing.T) {
 				CPUInstructions: result.Cost.CPUInstructions,
 				MemoryBytes:     result.Cost.MemoryBytes,
 			},
-			TransactionData: "AAAAAAAAAAEAAAAH6p/Lga5Uop9rO/KThH0/1+mjaf0cgKyv7Gq9VxMX4MIAAHLLAAAAJAAAAGQAAACIAAAAAAAAABsAAAAA",
+			TransactionData: "AAAAAAAAAAEAAAAH6p/Lga5Uop9rO/KThH0/1+mjaf0cgKyv7Gq9VxMX4MIAARueAAAAJAAAAGQAAACIAAAAAAAAABsAAAAA",
 			MinResourceFee:  result.MinResourceFee,
 			Results: []methods.SimulateHostFunctionResult{
 				{

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -260,7 +260,7 @@ func TestSimulateTransactionSucceeds(t *testing.T) {
 				CPUInstructions: result.Cost.CPUInstructions,
 				MemoryBytes:     result.Cost.MemoryBytes,
 			},
-			Results: []methods.SimulateTransactionResult{
+			Results: []methods.SimulateHostFunctionResult{
 				{
 					Footprint: "AAAAAAAAAAEAAAAH6p/Lga5Uop9rO/KThH0/1+mjaf0cgKyv7Gq9VxMX4MI=",
 					XDR:       expectedXdr,

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -87,6 +87,8 @@ func createInstallContractCodeOperation(t *testing.T, sourceAccount string, cont
 				},
 			},
 		}
+		// TODO: fill in this data properly
+		//       we will most likely need to invoke the preflight endpoint
 		ext = xdr.TransactionExt{
 			V: 1,
 			SorobanData: &xdr.SorobanTransactionData{
@@ -149,6 +151,8 @@ func createCreateContractOperation(t *testing.T, sourceAccount string, contractC
 				},
 			},
 		}
+		// TODO: fill in this data properly
+		//       we will most likely need to invoke the preflight endpoint
 		ext = xdr.TransactionExt{
 			V: 1,
 			SorobanData: &xdr.SorobanTransactionData{
@@ -394,6 +398,8 @@ func TestSimulateInvokeContractTransactionSucceeds(t *testing.T) {
 		Operations: []txnbuild.Operation{
 			createInvokeHostOperation(
 				address,
+				// TODO: fill in this data properly
+				//       we will most likely need to invoke the preflight endpoint
 				xdr.TransactionExt{},
 				contractID,
 				"auth",

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -220,6 +220,7 @@ func getContractID(t *testing.T, sourceAccount string, salt [32]byte, networkPas
 
 func preflightTransactionParams(t *testing.T, client *jrpc2.Client, params txnbuild.TransactionParams) (txnbuild.TransactionParams, methods.SimulateTransactionResponse) {
 	savedAutoIncrement := params.IncrementSequenceNum
+
 	params.IncrementSequenceNum = false
 	tx, err := txnbuild.NewTransaction(params)
 	params.IncrementSequenceNum = savedAutoIncrement
@@ -391,7 +392,7 @@ func TestSimulateInvokeContractTransactionSucceeds(t *testing.T) {
 		Operations: []txnbuild.Operation{
 			createInstallContractCodeOperation(t, account.AccountID, helloWorldContract, false),
 		},
-		BaseFee: txnbuild.MinBaseFee * 100,
+		BaseFee: 2992,
 		Preconditions: txnbuild.Preconditions{
 			TimeBounds: txnbuild.NewInfiniteTimeout(),
 		},

--- a/cmd/soroban-rpc/internal/test/transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/transaction_test.go
@@ -55,17 +55,18 @@ func TestSendTransactionSucceedsWithResults(t *testing.T) {
 	address := kp.Address()
 	account := txnbuild.NewSimpleAccount(address, 0)
 
-	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
+	params := preflightTransactionParams(t, client, txnbuild.TransactionParams{
 		SourceAccount:        &account,
 		IncrementSequenceNum: true,
 		Operations: []txnbuild.Operation{
-			createInstallContractCodeOperation(t, account.AccountID, testContract, true),
+			createInstallContractCodeOperation(account.AccountID, testContract),
 		},
 		BaseFee: txnbuild.MinBaseFee,
 		Preconditions: txnbuild.Preconditions{
 			TimeBounds: txnbuild.NewInfiniteTimeout(),
 		},
 	})
+	tx, err := txnbuild.NewTransaction(params)
 	assert.NoError(t, err)
 	response := sendSuccessfulTransaction(t, client, kp, tx)
 
@@ -107,6 +108,8 @@ func TestSendTransactionSucceedsWithResults(t *testing.T) {
 	}
 	var resultXdr xdr.TransactionResult
 	assert.NoError(t, xdr.SafeUnmarshalBase64(response.ResultXdr, &resultXdr))
+	// We cannot really predict the charged fee
+	expectedResult.FeeCharged = resultXdr.FeeCharged
 	assert.Equal(t, expectedResult, resultXdr)
 }
 
@@ -162,14 +165,19 @@ func TestSendTransactionFailedInLedger(t *testing.T) {
 	address := kp.Address()
 	account := txnbuild.NewSimpleAccount(address, 0)
 
+	op := createInstallContractCodeOperation(account.AccountID, testContract)
+	// without the presources the tx will fail
+	op.Ext = xdr.TransactionExt{
+		V:           1,
+		SorobanData: &xdr.SorobanTransactionData{},
+	}
 	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
 		SourceAccount:        &account,
 		IncrementSequenceNum: true,
 		Operations: []txnbuild.Operation{
-			// without the footprint the tx will fail
-			createInstallContractCodeOperation(t, account.AccountID, testContract, false),
+			op,
 		},
-		BaseFee: txnbuild.MinBaseFee,
+		BaseFee: txnbuild.MinBaseFee * 1000,
 		Preconditions: txnbuild.Preconditions{
 			TimeBounds: txnbuild.NewInfiniteTimeout(),
 		},
@@ -189,7 +197,12 @@ func TestSendTransactionFailedInLedger(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, expectedHashHex, result.Hash)
-	assert.Equal(t, proto.TXStatusPending, result.Status)
+	if !assert.Equal(t, proto.TXStatusPending, result.Status) {
+		var txResult xdr.TransactionResult
+		err := xdr.SafeUnmarshalBase64(result.ErrorResultXDR, &txResult)
+		assert.NoError(t, err)
+		fmt.Printf("error: %#v\n", txResult)
+	}
 	assert.NotZero(t, result.LatestLedger)
 	assert.NotZero(t, result.LatestLedgerCloseTime)
 

--- a/cmd/soroban-rpc/lib/preflight.h
+++ b/cmd/soroban-rpc/lib/preflight.h
@@ -15,6 +15,7 @@ typedef struct CPreflightResult {
     char *error; // Error string in case of error, otherwise null
     char **results; // NULL terminated array of XDR SCVals in base64
     char *transaction_data; // SorobanTransactionData XDR in base64
+    int64_t min_fee; // Minimum recommended resource fee
     char **auth; // NULL terminated array of XDR ContractAuths in base64
     char **events; // NULL terminated array of XDR DiagnosticEvents in base64
     uint64_t cpu_instructions;

--- a/cmd/soroban-rpc/lib/preflight.h
+++ b/cmd/soroban-rpc/lib/preflight.h
@@ -11,12 +11,17 @@ typedef struct CLedgerInfo {
   uint32_t base_reserve;
 } CLedgerInfo;
 
+typedef struct CHostFunctionPreflight {
+    char **auth; // NULL terminated array of XDR ContractAuths in base64
+    char *result; // XDR SCVal in base64
+} CHostFunctionPreflight;
+
 typedef struct CPreflightResult {
     char *error; // Error string in case of error, otherwise null
-    char **results; // NULL terminated array of XDR SCVals in base64
+    CHostFunctionPreflight *results; // array of CHostFunctionPreflight
+    size_t results_size;
     char *transaction_data; // SorobanTransactionData XDR in base64
     int64_t min_fee; // Minimum recommended resource fee
-    char **auth; // NULL terminated array of XDR ContractAuths in base64
     char **events; // NULL terminated array of XDR DiagnosticEvents in base64
     uint64_t cpu_instructions;
     uint64_t memory_bytes;

--- a/cmd/soroban-rpc/lib/preflight.h
+++ b/cmd/soroban-rpc/lib/preflight.h
@@ -14,17 +14,17 @@ typedef struct CLedgerInfo {
 typedef struct CPreflightResult {
     char *error; // Error string in case of error, otherwise null
     char **results; // NULL terminated array of XDR SCVals in base64
-    char *preflight; // LedgerFootprint XDR in base64
+    char *transaction_data; // SorobanTransactionData XDR in base64
     char **auth; // NULL terminated array of XDR ContractAuths in base64
     char **events; // NULL terminated array of XDR DiagnosticEvents in base64
     uint64_t cpu_instructions;
     uint64_t memory_bytes;
 } CPreflightResult;
 
-CPreflightResult *preflight_host_function(uintptr_t handle, // Go Handle to forward to SnapshotSourceGet and SnapshotSourceHasconst
-                                          char *invoke_hf_op, // InvokeHostFunctionOp XDR in base64
-                                          const char *source_account, // AccountId XDR in base64
-                                          const struct CLedgerInfo ledger_info);
+CPreflightResult *preflight_invoke_hf_op(uintptr_t handle, // Go Handle to forward to SnapshotSourceGet and SnapshotSourceHasconst
+                                         char *invoke_hf_op, // InvokeHostFunctionOp XDR in base64
+                                         const char *source_account, // AccountId XDR in base64
+                                         const struct CLedgerInfo ledger_info);
 
 // LedgerKey XDR in base64 string to LedgerEntry XDR in base64 string
 extern char *SnapshotSourceGet(uintptr_t handle, char *ledger_key);

--- a/cmd/soroban-rpc/lib/preflight/Cargo.toml
+++ b/cmd/soroban-rpc/lib/preflight/Cargo.toml
@@ -7,6 +7,10 @@ publish = false
 crate-type = ["staticlib"]
 
 [dependencies]
+# TODO: base64 and thiserror are also used by the CLI,
+#       should we make them workspace dependencies?
+base64 = "0.13.0"
+thiserror = "1.0.31"
 libc = "0.2.2"
 sha2 = "0.10.6"
 soroban-env-host = { workspace = true, features = ["vm"] }

--- a/cmd/soroban-rpc/lib/preflight/src/fees.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/fees.rs
@@ -1,0 +1,238 @@
+use ledger_storage;
+use soroban_env_host::budget::Budget;
+use soroban_env_host::fees::{
+    compute_transaction_resource_fee, FeeConfiguration, TransactionResources,
+};
+use soroban_env_host::storage::{AccessType, Footprint, Storage, StorageMap};
+use soroban_env_host::xdr;
+use soroban_env_host::xdr::{
+    DecoratedSignature, DiagnosticEvent, ExtensionPoint, InvokeHostFunctionOp, LedgerFootprint,
+    LedgerKey, Memo, MuxedAccount, MuxedAccountMed25519, Operation, OperationBody, Preconditions,
+    SequenceNumber, SignatureHint, SorobanResources, SorobanTransactionData, Transaction,
+    TransactionExt, TransactionV1Envelope, Uint256, WriteXdr,
+};
+use std::cmp::max;
+use std::convert::TryInto;
+use std::error;
+
+pub(crate) fn compute_transaction_data_and_min_fee(
+    invoke_hf_op: &InvokeHostFunctionOp,
+    snapshot_source: &ledger_storage::LedgerStorage,
+    storage: &Storage,
+    budget: &Budget,
+    events: &Vec<DiagnosticEvent>,
+) -> Result<(SorobanTransactionData, i64), Box<dyn error::Error>> {
+    let soroban_resources = calculate_soroban_resources(snapshot_source, storage, budget, events)?;
+    let fee_configuration = get_fee_configuration(snapshot_source)?;
+
+    let read_write_entries = soroban_resources.footprint.read_write.as_vec().len() as u32;
+
+    let transaction_resources = TransactionResources {
+        instructions: soroban_resources.instructions,
+        read_entries: soroban_resources.footprint.read_only.as_vec().len() as u32
+            + read_write_entries,
+        write_entries: read_write_entries,
+        read_bytes: soroban_resources.read_bytes,
+        write_bytes: soroban_resources.write_bytes,
+        metadata_size_bytes: soroban_resources.extended_meta_data_size_bytes,
+        // Note: we could get a better transaction size if the full transaction was passed down to libpreflight
+        transaction_size_bytes: estimate_max_transaction_size(
+            invoke_hf_op,
+            &soroban_resources.footprint,
+        )?,
+    };
+    let (min_fee, ref_fee) =
+        compute_transaction_resource_fee(&transaction_resources, &fee_configuration);
+    let transaction_data = SorobanTransactionData {
+        resources: soroban_resources,
+        refundable_fee: ref_fee,
+        ext: ExtensionPoint::V0,
+    };
+    Ok((transaction_data, min_fee))
+}
+
+fn estimate_max_transaction_size(
+    invoke_hf_op: &InvokeHostFunctionOp,
+    fp: &LedgerFootprint,
+) -> Result<u32, Box<dyn error::Error>> {
+    let source = MuxedAccount::MuxedEd25519(MuxedAccountMed25519 {
+        id: 0,
+        ed25519: Uint256([0; 32]),
+    });
+    // generate the maximum memo size and signature size
+    // TODO: is this being too conservative?
+    let memo_text: Vec<u8> = [0; 28].into();
+    // TODO: find a better way to do this:
+    let mut signatures: Vec<DecoratedSignature> = vec![];
+    let mut signatures_left = 20;
+    while signatures_left > 0 {
+        signatures.push(DecoratedSignature {
+            hint: SignatureHint([0; 4]),
+            signature: Default::default(),
+        });
+        signatures_left -= 1;
+    }
+    let envelope = TransactionV1Envelope {
+        tx: Transaction {
+            source_account: source.clone(),
+            fee: 0,
+            seq_num: SequenceNumber(0),
+            cond: Preconditions::None,
+            memo: Memo::Text(memo_text.try_into()?),
+            operations: vec![Operation {
+                source_account: Some(source),
+                body: OperationBody::InvokeHostFunction(invoke_hf_op.clone()),
+            }]
+            .try_into()?,
+            ext: TransactionExt::V1(SorobanTransactionData {
+                resources: SorobanResources {
+                    footprint: fp.clone(),
+                    instructions: 0,
+                    read_bytes: 0,
+                    write_bytes: 0,
+                    extended_meta_data_size_bytes: 0,
+                },
+                refundable_fee: 0,
+                ext: ExtensionPoint::V0,
+            }),
+        },
+        signatures: signatures.try_into()?,
+    };
+
+    let envelope_xdr = envelope.to_xdr()?;
+    let envelope_size = envelope_xdr.len();
+
+    // Add a 15% leeway
+    let envelope_size = envelope_size * 115 / 100;
+    Ok(envelope_size as u32)
+}
+
+fn calculate_soroban_resources(
+    snapshot_source: &ledger_storage::LedgerStorage,
+    storage: &Storage,
+    budget: &Budget,
+    events: &Vec<DiagnosticEvent>,
+) -> Result<SorobanResources, Box<dyn error::Error>> {
+    let fp = storage_footprint_to_ledger_footprint(&storage.footprint)?;
+    /*
+      readBytes = size(footprint.readOnly) + size(footprint.readWrite)
+      writeBytes = size(storage.map[rw entries])
+      metadataSize = readBytes(footprint.readWrite) + writeBytes + eventsSize
+    */
+    let original_write_ledger_entry_bytes =
+        calculate_unmodified_ledger_entry_bytes(&fp.read_write.as_vec(), snapshot_source)?;
+    let read_bytes =
+        calculate_unmodified_ledger_entry_bytes(&fp.read_only.as_vec(), snapshot_source)?
+            + original_write_ledger_entry_bytes;
+    let write_bytes =
+        calculate_modified_read_write_ledger_entry_bytes(&storage.footprint, &storage.map, budget)?;
+    let meta_data_size_bytes =
+        original_write_ledger_entry_bytes + write_bytes + calculate_event_size_bytes(events)?;
+
+    // Add a 15% leeway with a minimum of 50k instructions
+    let instructions = max(
+        budget.get_cpu_insns_count() + 50000,
+        budget.get_cpu_insns_count() * 115 / 100,
+    );
+    Ok(SorobanResources {
+        footprint: fp,
+        instructions: instructions as u32,
+        read_bytes: read_bytes,
+        write_bytes: write_bytes,
+        extended_meta_data_size_bytes: meta_data_size_bytes,
+    })
+}
+
+fn get_fee_configuration(
+    _snapshot_source: &ledger_storage::LedgerStorage,
+) -> Result<FeeConfiguration, Box<dyn error::Error>> {
+    // TODO: (at least part of) these values should be obtained from the network's ConfigSetting LedgerEntries
+    //       (instead of hardcoding them to the initial values in the network)
+
+    // Taken from Stellar Core's InitialSorobanNetworkConfig in NetworkConfig.h
+    Ok(FeeConfiguration {
+        fee_per_instruction_increment: 100,
+        fee_per_read_entry: 5000,
+        fee_per_write_entry: 20000,
+        fee_per_read_1kb: 1000,
+        fee_per_write_1kb: 4000,
+        fee_per_historical_1kb: 100,
+        fee_per_metadata_1kb: 200,
+        fee_per_propagate_1kb: 2000,
+    })
+}
+
+fn calculate_modified_read_write_ledger_entry_bytes(
+    footprint: &Footprint,
+    storage_map: &StorageMap,
+    budget: &Budget,
+) -> Result<u32, Box<dyn error::Error>> {
+    let mut res: u32 = 0;
+    for (lk, ole) in storage_map {
+        match footprint.0.get::<LedgerKey>(lk, budget)? {
+            Some(AccessType::ReadOnly) => (),
+            Some(AccessType::ReadWrite) => {
+                if let Some(le) = ole {
+                    let entry_bytes = le.to_xdr()?;
+                    let key_bytes = lk.to_xdr()?;
+                    res += (entry_bytes.len() + key_bytes.len()) as u32;
+                }
+            }
+            // TODO: turn this panic into an error
+            None => panic!("ledger entry not in footprint"),
+        }
+    }
+    Ok(res)
+}
+
+fn calculate_unmodified_ledger_entry_bytes(
+    ledger_entries: &Vec<LedgerKey>,
+    snapshot_source: &ledger_storage::LedgerStorage,
+) -> Result<u32, Box<dyn error::Error>> {
+    let mut res: u32 = 0;
+    for lk in ledger_entries {
+        res += lk.to_xdr()?.len() as u32;
+        match snapshot_source.get_xdr(lk) {
+            Ok(entry_bytes) => {
+                res += entry_bytes.len() as u32;
+            }
+            Err(e) => {
+                match e {
+                    ledger_storage::Error::NotFound =>
+                    // The entry is not present in the unmodified ledger storage.
+                    // We assume it to be due to the entry being created by a host function invocation.
+                    // Thus, we shouldn't count it in as unmodified.
+                    {
+                        continue;
+                    }
+                    _ => return Err(e)?,
+                }
+            }
+        };
+    }
+    Ok(res)
+}
+
+fn calculate_event_size_bytes(events: &Vec<DiagnosticEvent>) -> Result<u32, xdr::Error> {
+    let mut res: u32 = 0;
+    for e in events {
+        let event_xdr = e.to_xdr()?;
+        res += event_xdr.len() as u32;
+    }
+    Ok(res)
+}
+
+fn storage_footprint_to_ledger_footprint(foot: &Footprint) -> Result<LedgerFootprint, xdr::Error> {
+    let mut read_only: Vec<LedgerKey> = Vec::new();
+    let mut read_write: Vec<LedgerKey> = Vec::new();
+    for (k, v) in &foot.0 {
+        match v {
+            AccessType::ReadOnly => read_only.push((**k).clone()),
+            AccessType::ReadWrite => read_write.push((**k).clone()),
+        }
+    }
+    Ok(LedgerFootprint {
+        read_only: read_only.try_into()?,
+        read_write: read_write.try_into()?,
+    })
+}

--- a/cmd/soroban-rpc/lib/preflight/src/fees.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/fees.rs
@@ -143,6 +143,8 @@ fn calculate_soroban_resources(
 fn get_fee_configuration(_snapshot_source: &ledger_storage::LedgerStorage) -> FeeConfiguration {
     // TODO: (at least part of) these values should be obtained from the network's ConfigSetting LedgerEntries
     //       (instead of hardcoding them to the initial values in the network)
+    //       Specifically, we need to derive it from ConfigSettingContractComputeV0 which can
+    //       be retrieved using the ConfigSetting/CONFIG_SETTING_CONTRACT_COMPUTE_V0.
 
     // Taken from Stellar Core's InitialSorobanNetworkConfig in NetworkConfig.h
     FeeConfiguration {

--- a/cmd/soroban-rpc/lib/preflight/src/fees.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/fees.rs
@@ -62,16 +62,13 @@ fn estimate_max_transaction_size(
     // generate the maximum memo size and signature size
     // TODO: is this being too conservative?
     let memo_text: Vec<u8> = [0; 28].into();
-    // TODO: find a better way to do this:
-    let mut signatures: Vec<DecoratedSignature> = vec![];
-    let mut signatures_left = 20;
-    while signatures_left > 0 {
-        signatures.push(DecoratedSignature {
+    let signatures: Vec<DecoratedSignature> = vec![
+        DecoratedSignature {
             hint: SignatureHint([0; 4]),
             signature: Default::default(),
-        });
-        signatures_left -= 1;
-    }
+        };
+        20
+    ];
     let envelope = TransactionV1Envelope {
         tx: Transaction {
             source_account: source.clone(),

--- a/cmd/soroban-rpc/lib/preflight/src/fees.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/fees.rs
@@ -178,8 +178,7 @@ fn calculate_modified_read_write_ledger_entry_bytes(
                     res += (entry_bytes.len() + key_bytes.len()) as u32;
                 }
             }
-            // TODO: turn this panic into an error
-            None => panic!("ledger entry not in footprint"),
+            None => return Err("storage ledger entry not found in footprint".into()),
         }
     }
     Ok(res)

--- a/cmd/soroban-rpc/lib/preflight/src/ledger_storage.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/ledger_storage.rs
@@ -1,0 +1,94 @@
+use base64::DecodeError;
+use soroban_env_host::storage::SnapshotSource;
+use soroban_env_host::xdr::ScUnknownErrorCode::{General, Xdr};
+use soroban_env_host::xdr::{
+    Error as XdrError, LedgerEntry, LedgerKey, ReadXdr, ScHostStorageErrorCode, ScStatus, WriteXdr,
+};
+use soroban_env_host::HostError;
+use std::ffi::{CStr, CString, NulError};
+use std::rc::Rc;
+use std::str::Utf8Error;
+
+// Functions imported from Golang
+extern "C" {
+    // Free Strings returned from Go functions
+    fn FreeGoCString(str: *const libc::c_char);
+    // LedgerKey XDR in base64 string to LedgerEntry XDR in base64 string
+    fn SnapshotSourceGet(
+        handle: libc::uintptr_t,
+        ledger_key: *const libc::c_char,
+    ) -> *const libc::c_char;
+    // TODO: this function is unnecessary, we can just look for null in SnapshotSourceGet
+    // LedgerKey XDR in base64 string to bool
+    fn SnapshotSourceHas(handle: libc::uintptr_t, ledger_key: *const libc::c_char) -> libc::c_int;
+}
+
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum Error {
+    #[error("not found")]
+    NotFound,
+    #[error("xdr processing error: {0}")]
+    Xdr(#[from] XdrError),
+    #[error("nul error: {0}")]
+    NulError(#[from] NulError),
+    #[error("decode error: {0}")]
+    DecodeError(#[from] DecodeError),
+    #[error("utf8 error: {0}")]
+    Utf8Error(#[from] Utf8Error),
+}
+
+impl Error {
+    fn to_host_error(self) -> HostError {
+        match self {
+            Error::NotFound => HostError::from(ScHostStorageErrorCode::AccessToUnknownEntry),
+            Error::Xdr(_) => ScStatus::UnknownError(Xdr).into(),
+            _ => ScStatus::UnknownError(General).into(),
+        }
+    }
+}
+
+pub(crate) struct LedgerStorage {
+    pub(crate) golang_handle: libc::uintptr_t,
+}
+
+impl LedgerStorage {
+    fn get_xdr_base64(&self, key: &LedgerKey) -> Result<String, Error> {
+        let key_xdr = key.to_xdr_base64()?;
+        let key_cstr = CString::new(key_xdr)?;
+        let res = unsafe { SnapshotSourceGet(self.golang_handle, key_cstr.as_ptr()) };
+        if res.is_null() {
+            return Err(Error::NotFound);
+        }
+        let res_cstr = unsafe { CStr::from_ptr(res) };
+        // Make a safe copy of the string before freeing it
+        // Note: If we wanted more performance we should create an unsafe version of get_xdr_base64() which
+        //       returned a view of the C buffer as follows:
+        // return Ok((res, res_cstr.to_bytes())); // we would later need to call FreeGoCString(res)
+        let res_str = String::from_utf8_lossy(res_cstr.to_bytes()).to_string();
+        unsafe { FreeGoCString(res) };
+        Ok(res_str)
+    }
+
+    pub fn get_xdr(&self, key: &LedgerKey) -> Result<Vec<u8>, Error> {
+        let base64_str = self.get_xdr_base64(key)?;
+        Ok(base64::decode(base64_str)?)
+    }
+}
+
+impl SnapshotSource for LedgerStorage {
+    fn get(&self, key: &Rc<LedgerKey>) -> Result<Rc<LedgerEntry>, HostError> {
+        let base64_str = self.get_xdr_base64(&*key).map_err(Error::to_host_error)?;
+        let entry =
+            LedgerEntry::from_xdr_base64(base64_str).map_err(|_| ScStatus::UnknownError(Xdr))?;
+        Ok(entry.into())
+    }
+
+    fn has(&self, key: &Rc<LedgerKey>) -> Result<bool, HostError> {
+        let key_xdr = key
+            .to_xdr_base64()
+            .map_err(|_| ScStatus::UnknownError(Xdr))?;
+        let key_cstr = CString::new(key_xdr).map_err(|_| ScStatus::UnknownError(Xdr))?;
+        let res = unsafe { SnapshotSourceHas(self.golang_handle, key_cstr.as_ptr()) };
+        Ok(res != 0)
+    }
+}

--- a/cmd/soroban-rpc/lib/preflight/src/lib.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/lib.rs
@@ -309,7 +309,6 @@ fn estimate_max_transaction_size(
 
     // Add a 15% leeway
     let envelope_size = envelope_size * 115 / 100;
-    println!("envelope_size: {}", envelope_size);
     Ok(envelope_size as u32)
 }
 

--- a/cmd/soroban-rpc/lib/preflight/src/lib.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/lib.rs
@@ -230,10 +230,13 @@ fn compute_transaction_data_and_min_fee(
     let soroban_resources = calculate_soroban_resources(snapshot_source, storage, budget, events)?;
     let fee_configuration = get_fee_configuration(snapshot_source)?;
 
+    let read_write_entries = soroban_resources.footprint.read_write.as_vec().len() as u32;
+
     let transaction_resources = TransactionResources {
         instructions: soroban_resources.instructions,
-        read_entries: soroban_resources.footprint.read_only.as_vec().len() as u32,
-        write_entries: soroban_resources.footprint.read_write.as_vec().len() as u32,
+        read_entries: soroban_resources.footprint.read_only.as_vec().len() as u32
+            + read_write_entries,
+        write_entries: read_write_entries,
         read_bytes: soroban_resources.read_bytes,
         write_bytes: soroban_resources.write_bytes,
         metadata_size_bytes: soroban_resources.extended_meta_data_size_bytes,
@@ -306,6 +309,7 @@ fn estimate_max_transaction_size(
 
     // Add a 15% leeway
     let envelope_size = envelope_size * 115 / 100;
+    println!("envelope_size: {}", envelope_size);
     Ok(envelope_size as u32)
 }
 

--- a/cmd/soroban-rpc/lib/preflight/src/lib.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/lib.rs
@@ -390,12 +390,12 @@ fn calculate_unmodified_ledger_entry_bytes(
 ) -> Result<u32, Box<dyn error::Error>> {
     let mut res: u32 = 0;
     for lk in ledger_entries {
+        res += lk.to_xdr()?.len() as u32;
         // TODO: remove unnecessary Rc
         match snapshot_source.get(&Rc::new(lk.clone())) {
             Ok(le) => {
                 let entry_bytes = le.to_xdr()?;
-                let key_bytes = lk.to_xdr()?;
-                res += (entry_bytes.len() + key_bytes.len()) as u32;
+                res += entry_bytes.len() as u32;
             }
             Err(e) => {
                 if e.status == ScHostStorageErrorCode::AccessToUnknownEntry.into() {

--- a/cmd/soroban-rpc/lib/preflight/src/lib.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/lib.rs
@@ -6,8 +6,19 @@ use sha2::{Digest, Sha256};
 use soroban_env_host::auth::RecordedAuthPayload;
 use soroban_env_host::budget::Budget;
 use soroban_env_host::events::{Event, Events};
-use soroban_env_host::storage::{self, AccessType, SnapshotSource, Storage};
-use soroban_env_host::xdr::{self, AccountId, AddressWithNonce, ContractAuth, DiagnosticEvent, ExtensionPoint, InvokeHostFunctionOp, LedgerEntry, LedgerKey, ReadXdr, ScHostStorageErrorCode, ScStatus, ScUnknownErrorCode::{General, Xdr}, ScVal, SorobanResources, SorobanTransactionData, WriteXdr};
+use soroban_env_host::fees::{
+    compute_transaction_resource_fee, FeeConfiguration, TransactionResources,
+};
+use soroban_env_host::storage::{AccessType, Footprint, SnapshotSource, Storage, StorageMap};
+use soroban_env_host::xdr::{
+    self, AccountId, AddressWithNonce, ContractAuth, DecoratedSignature, DiagnosticEvent,
+    ExtensionPoint, InvokeHostFunctionOp, LedgerEntry, LedgerKey, Memo, MuxedAccount,
+    MuxedAccountMed25519, Operation, OperationBody, Preconditions, ReadXdr, ScHostStorageErrorCode,
+    ScStatus,
+    ScUnknownErrorCode::{General, Xdr},
+    ScVal, SequenceNumber, SignatureHint, SorobanResources, SorobanTransactionData, Transaction,
+    TransactionExt, TransactionV1Envelope, Uint256, WriteXdr,
+};
 use soroban_env_host::{Host, HostError, LedgerInfo};
 use std::convert::TryInto;
 use std::ffi::{CStr, CString};
@@ -87,9 +98,7 @@ impl From<CLedgerInfo> for LedgerInfo {
     }
 }
 
-fn storage_footprint_to_ledger_footprint(
-    foot: &storage::Footprint,
-) -> Result<LedgerFootprint, xdr::Error> {
+fn storage_footprint_to_ledger_footprint(foot: &Footprint) -> Result<LedgerFootprint, xdr::Error> {
     let mut read_only: Vec<LedgerKey> = Vec::new();
     let mut read_write: Vec<LedgerKey> = Vec::new();
     for (k, v) in &foot.0 {
@@ -109,6 +118,7 @@ pub struct CPreflightResult {
     pub error: *mut libc::c_char, // Error string in case of error, otherwise null
     pub results: *mut *mut libc::c_char, // NULL terminated array of XDR SCVals in base64
     pub transaction_data: *mut libc::c_char, // SorobanTransactionData XDR in base64
+    pub min_fee: i64,             // Minimum recommended resource fee
     pub auth: *mut *mut libc::c_char, // NULL terminated array of XDR ContractAuths in base64
     pub events: *mut *mut libc::c_char, // NULL terminated array of XDR ContractEvents in base64
     pub cpu_instructions: u64,
@@ -123,6 +133,7 @@ fn preflight_error(str: String) -> *mut CPreflightResult {
         error: c_str.into_raw(),
         results: null_mut(),
         transaction_data: null_mut(),
+        min_fee: 0,
         auth: null_mut(),
         events: null_mut(),
         cpu_instructions: 0,
@@ -180,40 +191,219 @@ fn preflight_invoke_hf_op_or_maybe_panic(
     host.set_ledger_info(ledger_info.into());
 
     // Run the preflight.
-    let results = host.invoke_functions(invoke_hf_op.functions.into())?;
+    let results = host.invoke_functions(invoke_hf_op.clone().functions.into())?;
     let auth_payloads = host.get_recorded_auth_payloads()?;
 
     // Recover, convert and return the storage footprint and other values to C.
     let (storage, budget, events) = host.try_finish().unwrap();
 
-    let fp = storage_footprint_to_ledger_footprint(&storage.footprint)?;
-    let transaction_data = calculate_soroban_transaction_data(fp)?;
-    let transaction_data = CString::new(transaction_data.to_xdr_base64()?)?;
+    let diagnostic_events = host_events_to_diagnostic_events(&events)?;
+    let (transaction_data, min_fee) = compute_transaction_data_and_min_fee(
+        &invoke_hf_op,
+        &CSnapshotSource { handle },
+        &storage,
+        &budget,
+        &diagnostic_events,
+    )?;
+    let transaction_data_cstr = CString::new(transaction_data.to_xdr_base64()?)?;
     Ok(CPreflightResult {
         error: null_mut(),
         results: scvals_to_c(results)?,
-        transaction_data: transaction_data.into_raw(),
+        transaction_data: transaction_data_cstr.into_raw(),
+        min_fee: min_fee,
         auth: recorded_auth_payloads_to_c(auth_payloads)?,
-        events: host_events_to_c(events)?,
+        events: diagnostic_events_to_c(diagnostic_events)?,
         cpu_instructions: budget.get_cpu_insns_count(),
         memory_bytes: budget.get_mem_bytes_count(),
     })
-
 }
 
-fn calculate_soroban_transaction_data(fp: LedgerFootprint)  -> Result<SorobanTransactionData, Box<dyn error::Error>> {
-    // TODO
-    Ok(SorobanTransactionData{
-        resources: SorobanResources {
-            footprint: fp,
-            instructions: 0,
-            read_bytes: 0,
-            write_bytes: 0,
-            extended_meta_data_size_bytes: 0,
-        },
-        refundable_fee: 0,
+fn compute_transaction_data_and_min_fee(
+    invoke_hf_op: &InvokeHostFunctionOp,
+    snapshot_source: &CSnapshotSource,
+    storage: &Storage,
+    budget: &Budget,
+    events: &Vec<DiagnosticEvent>,
+) -> Result<(SorobanTransactionData, i64), Box<dyn error::Error>> {
+    let soroban_resources = calculate_soroban_resources(snapshot_source, storage, budget, events)?;
+    let fee_configuration = get_fee_configuration(snapshot_source)?;
+
+    let transaction_resources = TransactionResources {
+        instructions: soroban_resources.instructions,
+        read_entries: soroban_resources.footprint.read_only.as_vec().len() as u32,
+        write_entries: soroban_resources.footprint.read_write.as_vec().len() as u32,
+        read_bytes: soroban_resources.read_bytes,
+        write_bytes: soroban_resources.write_bytes,
+        metadata_size_bytes: soroban_resources.extended_meta_data_size_bytes,
+        // Note: we could get a better transaction size if the full transaction was passed down to libpreflight
+        transaction_size_bytes: estimate_max_transaction_size(
+            invoke_hf_op,
+            &soroban_resources.footprint,
+        )?,
+    };
+    let (min_fee, ref_fee) =
+        compute_transaction_resource_fee(&transaction_resources, &fee_configuration);
+    let transaction_data = SorobanTransactionData {
+        resources: soroban_resources,
+        refundable_fee: ref_fee,
         ext: ExtensionPoint::V0,
+    };
+    Ok((transaction_data, min_fee))
+}
+
+fn estimate_max_transaction_size(
+    invoke_hf_op: &InvokeHostFunctionOp,
+    fp: &LedgerFootprint,
+) -> Result<u32, Box<dyn error::Error>> {
+    let source = MuxedAccount::MuxedEd25519(MuxedAccountMed25519 {
+        id: 0,
+        ed25519: Uint256([0; 32]),
+    });
+    // generate the maximum memo size and signature size
+    // TODO: is this being too conservative?
+    let memo_text: Vec<u8> = [0; 28].into();
+    // TODO: find a better way to do this:
+    let mut signatures: Vec<DecoratedSignature> = vec![];
+    let mut signatures_left = 20;
+    while signatures_left > 0 {
+        signatures.push(DecoratedSignature {
+            hint: SignatureHint([0; 4]),
+            signature: Default::default(),
+        });
+        signatures_left -= 1;
+    }
+    let envelope = TransactionV1Envelope {
+        tx: Transaction {
+            source_account: source.clone(),
+            fee: 0,
+            seq_num: SequenceNumber(0),
+            cond: Preconditions::None,
+            memo: Memo::Text(memo_text.try_into()?),
+            operations: vec![Operation {
+                source_account: Some(source),
+                body: OperationBody::InvokeHostFunction(invoke_hf_op.clone()),
+            }]
+            .try_into()?,
+            ext: TransactionExt::V1(SorobanTransactionData {
+                resources: SorobanResources {
+                    footprint: fp.clone(),
+                    instructions: 0,
+                    read_bytes: 0,
+                    write_bytes: 0,
+                    extended_meta_data_size_bytes: 0,
+                },
+                refundable_fee: 0,
+                ext: ExtensionPoint::V0,
+            }),
+        },
+        signatures: signatures.try_into()?,
+    };
+
+    let envelope_xdr = envelope.to_xdr()?;
+    let envelope_size = envelope_xdr.len();
+
+    // Add a 15% leeway
+    let envelope_size = envelope_size * 115 / 100;
+    Ok(envelope_size as u32)
+}
+
+fn calculate_soroban_resources(
+    snapshot_source: &CSnapshotSource,
+    storage: &Storage,
+    budget: &Budget,
+    events: &Vec<DiagnosticEvent>,
+) -> Result<SorobanResources, Box<dyn error::Error>> {
+    let fp = storage_footprint_to_ledger_footprint(&storage.footprint)?;
+    /*
+      readBytes = size(footprint.readOnly) + size(footprint.readWrite)
+      writeBytes = size(storage.map[rw entries])
+      metadataSize = readBytes(footprint.readWrite) + writeBytes + eventsSize
+    */
+    let original_write_ledger_entry_bytes =
+        calculate_unmodified_ledger_entry_bytes(&fp.read_write.as_vec(), snapshot_source)?;
+    let read_bytes =
+        calculate_unmodified_ledger_entry_bytes(&fp.read_only.as_vec(), snapshot_source)?
+            + original_write_ledger_entry_bytes;
+    let write_bytes =
+        calculate_modified_read_write_ledger_entry_bytes(&storage.footprint, &storage.map, budget)?;
+    let meta_data_size_bytes =
+        original_write_ledger_entry_bytes + write_bytes + calculate_event_size_bytes(events)?;
+
+    // Add a 15% leeway
+    let instructions = budget.get_cpu_insns_count() * 115 / 100;
+    Ok(SorobanResources {
+        footprint: fp,
+        instructions: instructions as u32,
+        read_bytes: read_bytes,
+        write_bytes: write_bytes,
+        extended_meta_data_size_bytes: meta_data_size_bytes,
     })
+}
+
+fn get_fee_configuration(
+    _snapshot_source: &CSnapshotSource,
+) -> Result<FeeConfiguration, Box<dyn error::Error>> {
+    // TODO: (at least part of) these values should be obtained from the network's ConfigSetting LedgerEntries
+    //       (instead of hardcoding them to the initial values in the network)
+
+    // Taken from Stellar Core's InitialSorobanNetworkConfig in NetworkConfig.h
+    Ok(FeeConfiguration {
+        fee_per_instruction_increment: 100,
+        fee_per_read_entry: 5000,
+        fee_per_write_entry: 20000,
+        fee_per_read_1kb: 1000,
+        fee_per_write_1kb: 4000,
+        fee_per_historical_1kb: 100,
+        fee_per_metadata_1kb: 200,
+        fee_per_propagate_1kb: 2000,
+    })
+}
+
+fn calculate_modified_read_write_ledger_entry_bytes(
+    footprint: &Footprint,
+    storage_map: &StorageMap,
+    budget: &Budget,
+) -> Result<u32, Box<dyn error::Error>> {
+    let mut res: u32 = 0;
+    for (lk, ole) in storage_map {
+        match footprint.0.get::<LedgerKey>(lk, budget)? {
+            Some(AccessType::ReadOnly) => (),
+            Some(AccessType::ReadWrite) => {
+                if let Some(le) = ole {
+                    let entry_bytes = le.to_xdr()?;
+                    let key_bytes = lk.to_xdr()?;
+                    res += (entry_bytes.len() + key_bytes.len()) as u32;
+                }
+            }
+            // TODO: turn this panic into an error
+            None => panic!("ledger entry not in footprint"),
+        }
+    }
+    Ok(res)
+}
+
+fn calculate_unmodified_ledger_entry_bytes(
+    ledger_entries: &Vec<LedgerKey>,
+    snapshot_source: &CSnapshotSource,
+) -> Result<u32, Box<dyn error::Error>> {
+    let mut res: u32 = 0;
+    for lk in ledger_entries {
+        // TODO: remove unnecessary Rc
+        let le = snapshot_source.get(&Rc::new(lk.clone()))?;
+        let entry_bytes = le.to_xdr()?;
+        let key_bytes = lk.to_xdr()?;
+        res += (entry_bytes.len() + key_bytes.len()) as u32;
+    }
+    Ok(res)
+}
+
+fn calculate_event_size_bytes(events: &Vec<DiagnosticEvent>) -> Result<u32, xdr::Error> {
+    let mut res: u32 = 0;
+    for e in events {
+        let event_xdr = e.to_xdr()?;
+        res += event_xdr.len() as u32;
+    }
+    Ok(res)
 }
 
 fn scvals_to_c(scvals: Vec<ScVal>) -> Result<*mut *mut libc::c_char, Box<dyn error::Error>> {
@@ -251,8 +441,10 @@ fn recorded_auth_payload_to_xdr(payload: &RecordedAuthPayload) -> ContractAuth {
     }
 }
 
-fn host_events_to_c(events: Events) -> Result<*mut *mut libc::c_char, Box<dyn error::Error>> {
-    let mut xdr_base64_vec: Vec<String> = Vec::new();
+fn host_events_to_diagnostic_events(
+    events: &Events,
+) -> Result<Vec<DiagnosticEvent>, Box<dyn error::Error>> {
+    let mut res: Vec<DiagnosticEvent> = Vec::new();
     for e in events.0.iter() {
         let maybe_contract_event = match &e.event {
             Event::Contract(e) => Some(e),
@@ -265,9 +457,19 @@ fn host_events_to_c(events: Events) -> Result<*mut *mut libc::c_char, Box<dyn er
                 in_successful_contract_call: !e.failed_call,
                 event: contract_event.clone(),
             };
-            xdr_base64_vec.push(diagnostic_event.to_xdr_base64()?);
+            res.push(diagnostic_event);
         }
     }
+    Ok(res)
+}
+
+fn diagnostic_events_to_c(
+    events: Vec<DiagnosticEvent>,
+) -> Result<*mut *mut libc::c_char, Box<dyn error::Error>> {
+    let xdr_base64_vec: Vec<String> = events
+        .iter()
+        .map(DiagnosticEvent::to_xdr_base64)
+        .collect::<Result<Vec<_>, _>>()?;
     string_vec_to_c_to_null_terminated_char_array(xdr_base64_vec)
 }
 

--- a/cmd/soroban-rpc/lib/preflight/src/lib.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/lib.rs
@@ -1,3 +1,7 @@
+mod fees;
+mod ledger_storage;
+
+extern crate base64;
 extern crate libc;
 extern crate sha2;
 extern crate soroban_env_host;
@@ -6,76 +10,18 @@ use sha2::{Digest, Sha256};
 use soroban_env_host::auth::RecordedAuthPayload;
 use soroban_env_host::budget::Budget;
 use soroban_env_host::events::{Event, Events};
-use soroban_env_host::fees::{
-    compute_transaction_resource_fee, FeeConfiguration, TransactionResources,
-};
-use soroban_env_host::storage::{AccessType, Footprint, SnapshotSource, Storage, StorageMap};
+use soroban_env_host::storage::Storage;
 use soroban_env_host::xdr::{
-    self, AccountId, AddressWithNonce, ContractAuth, DecoratedSignature, DiagnosticEvent,
-    ExtensionPoint, HostFunction, InvokeHostFunctionOp, LedgerEntry, LedgerKey, Memo, MuxedAccount,
-    MuxedAccountMed25519, Operation, OperationBody, Preconditions, ReadXdr, ScHostStorageErrorCode,
-    ScStatus,
-    ScUnknownErrorCode::{General, Xdr},
-    ScVal, SequenceNumber, SignatureHint, SorobanResources, SorobanTransactionData, Transaction,
-    TransactionExt, TransactionV1Envelope, Uint256, WriteXdr,
+    AccountId, AddressWithNonce, ContractAuth, DiagnosticEvent, HostFunction, InvokeHostFunctionOp,
+    ReadXdr, ScVal, WriteXdr,
 };
-use soroban_env_host::{Host, HostError, LedgerInfo};
-use std::cmp::max;
+use soroban_env_host::{Host, LedgerInfo};
 use std::convert::TryInto;
 use std::ffi::{CStr, CString};
 use std::panic;
 use std::ptr::null_mut;
 use std::rc::Rc;
 use std::{error, mem};
-use xdr::LedgerFootprint;
-
-extern "C" {
-    // LedgerKey XDR in base64 string to LedgerEntry XDR in base64 string
-    fn SnapshotSourceGet(
-        handle: libc::uintptr_t,
-        ledger_key: *const libc::c_char,
-    ) -> *const libc::c_char;
-    // LedgerKey XDR in base64 string to bool
-    fn SnapshotSourceHas(handle: libc::uintptr_t, ledger_key: *const libc::c_char) -> libc::c_int;
-    // Free Strings returned from Go functions
-    fn FreeGoCString(str: *const libc::c_char);
-}
-
-struct CSnapshotSource {
-    handle: libc::uintptr_t,
-}
-
-impl SnapshotSource for CSnapshotSource {
-    fn get(&self, key: &Rc<LedgerKey>) -> Result<Rc<LedgerEntry>, HostError> {
-        let key_xdr = key
-            .to_xdr_base64()
-            .map_err(|_| ScStatus::UnknownError(Xdr))?;
-        let key_cstr = CString::new(key_xdr).map_err(|_| ScStatus::UnknownError(General))?;
-        let res = unsafe { SnapshotSourceGet(self.handle, key_cstr.as_ptr()) };
-        if res.is_null() {
-            return Err(HostError::from(
-                ScHostStorageErrorCode::AccessToUnknownEntry,
-            ));
-        }
-        let res_cstr = unsafe { CStr::from_ptr(res) };
-        let res_str = res_cstr
-            .to_str()
-            .map_err(|_| ScStatus::UnknownError(General))?;
-        let entry =
-            LedgerEntry::from_xdr_base64(res_str).map_err(|_| ScStatus::UnknownError(Xdr))?;
-        unsafe { FreeGoCString(res) };
-        Ok(entry.into())
-    }
-
-    fn has(&self, key: &Rc<LedgerKey>) -> Result<bool, HostError> {
-        let key_xdr = key
-            .to_xdr_base64()
-            .map_err(|_| ScStatus::UnknownError(Xdr))?;
-        let key_cstr = CString::new(key_xdr).map_err(|_| ScStatus::UnknownError(Xdr))?;
-        let res = unsafe { SnapshotSourceHas(self.handle, key_cstr.as_ptr()) };
-        Ok(res != 0)
-    }
-}
 
 #[repr(C)]
 pub struct CLedgerInfo {
@@ -97,21 +43,6 @@ impl From<CLedgerInfo> for LedgerInfo {
             base_reserve: c.base_reserve,
         }
     }
-}
-
-fn storage_footprint_to_ledger_footprint(foot: &Footprint) -> Result<LedgerFootprint, xdr::Error> {
-    let mut read_only: Vec<LedgerKey> = Vec::new();
-    let mut read_write: Vec<LedgerKey> = Vec::new();
-    for (k, v) in &foot.0 {
-        match v {
-            AccessType::ReadOnly => read_only.push((**k).clone()),
-            AccessType::ReadWrite => read_write.push((**k).clone()),
-        }
-    }
-    Ok(LedgerFootprint {
-        read_only: read_only.try_into()?,
-        read_write: read_write.try_into()?,
-    })
 }
 
 #[repr(C)]
@@ -188,7 +119,9 @@ fn preflight_invoke_hf_op_or_maybe_panic(
     let invoke_hf_op = InvokeHostFunctionOp::from_xdr_base64(invoke_hf_op_cstr.to_str()?)?;
     let source_account_cstr = unsafe { CStr::from_ptr(source_account) };
     let source_account = AccountId::from_xdr_base64(source_account_cstr.to_str()?)?;
-    let src = Rc::new(CSnapshotSource { handle });
+    let src = Rc::new(ledger_storage::LedgerStorage {
+        golang_handle: handle,
+    });
     let storage = Storage::with_recording_footprint(src);
     let budget = Budget::default();
     let host = Host::with_storage_and_budget(storage, budget);
@@ -220,11 +153,13 @@ fn preflight_invoke_hf_op_or_maybe_panic(
     let (storage, budget, events) = host.try_finish().unwrap();
 
     let diagnostic_events = host_events_to_diagnostic_events(&events)?;
-    let (transaction_data, min_fee) = compute_transaction_data_and_min_fee(
+    let (transaction_data, min_fee) = fees::compute_transaction_data_and_min_fee(
         &InvokeHostFunctionOp {
             functions: functions_with_auths.try_into()?,
         },
-        &CSnapshotSource { handle },
+        &ledger_storage::LedgerStorage {
+            golang_handle: handle,
+        },
         &storage,
         &budget,
         &diagnostic_events,
@@ -241,212 +176,6 @@ fn preflight_invoke_hf_op_or_maybe_panic(
         cpu_instructions: budget.get_cpu_insns_count(),
         memory_bytes: budget.get_mem_bytes_count(),
     })
-}
-
-fn compute_transaction_data_and_min_fee(
-    invoke_hf_op: &InvokeHostFunctionOp,
-    snapshot_source: &CSnapshotSource,
-    storage: &Storage,
-    budget: &Budget,
-    events: &Vec<DiagnosticEvent>,
-) -> Result<(SorobanTransactionData, i64), Box<dyn error::Error>> {
-    let soroban_resources = calculate_soroban_resources(snapshot_source, storage, budget, events)?;
-    let fee_configuration = get_fee_configuration(snapshot_source)?;
-
-    let read_write_entries = soroban_resources.footprint.read_write.as_vec().len() as u32;
-
-    let transaction_resources = TransactionResources {
-        instructions: soroban_resources.instructions,
-        read_entries: soroban_resources.footprint.read_only.as_vec().len() as u32
-            + read_write_entries,
-        write_entries: read_write_entries,
-        read_bytes: soroban_resources.read_bytes,
-        write_bytes: soroban_resources.write_bytes,
-        metadata_size_bytes: soroban_resources.extended_meta_data_size_bytes,
-        // Note: we could get a better transaction size if the full transaction was passed down to libpreflight
-        transaction_size_bytes: estimate_max_transaction_size(
-            invoke_hf_op,
-            &soroban_resources.footprint,
-        )?,
-    };
-    let (min_fee, ref_fee) =
-        compute_transaction_resource_fee(&transaction_resources, &fee_configuration);
-    let transaction_data = SorobanTransactionData {
-        resources: soroban_resources,
-        refundable_fee: ref_fee,
-        ext: ExtensionPoint::V0,
-    };
-    Ok((transaction_data, min_fee))
-}
-
-fn estimate_max_transaction_size(
-    invoke_hf_op: &InvokeHostFunctionOp,
-    fp: &LedgerFootprint,
-) -> Result<u32, Box<dyn error::Error>> {
-    let source = MuxedAccount::MuxedEd25519(MuxedAccountMed25519 {
-        id: 0,
-        ed25519: Uint256([0; 32]),
-    });
-    // generate the maximum memo size and signature size
-    // TODO: is this being too conservative?
-    let memo_text: Vec<u8> = [0; 28].into();
-    // TODO: find a better way to do this:
-    let mut signatures: Vec<DecoratedSignature> = vec![];
-    let mut signatures_left = 20;
-    while signatures_left > 0 {
-        signatures.push(DecoratedSignature {
-            hint: SignatureHint([0; 4]),
-            signature: Default::default(),
-        });
-        signatures_left -= 1;
-    }
-    let envelope = TransactionV1Envelope {
-        tx: Transaction {
-            source_account: source.clone(),
-            fee: 0,
-            seq_num: SequenceNumber(0),
-            cond: Preconditions::None,
-            memo: Memo::Text(memo_text.try_into()?),
-            operations: vec![Operation {
-                source_account: Some(source),
-                body: OperationBody::InvokeHostFunction(invoke_hf_op.clone()),
-            }]
-            .try_into()?,
-            ext: TransactionExt::V1(SorobanTransactionData {
-                resources: SorobanResources {
-                    footprint: fp.clone(),
-                    instructions: 0,
-                    read_bytes: 0,
-                    write_bytes: 0,
-                    extended_meta_data_size_bytes: 0,
-                },
-                refundable_fee: 0,
-                ext: ExtensionPoint::V0,
-            }),
-        },
-        signatures: signatures.try_into()?,
-    };
-
-    let envelope_xdr = envelope.to_xdr()?;
-    let envelope_size = envelope_xdr.len();
-
-    // Add a 15% leeway
-    let envelope_size = envelope_size * 115 / 100;
-    Ok(envelope_size as u32)
-}
-
-fn calculate_soroban_resources(
-    snapshot_source: &CSnapshotSource,
-    storage: &Storage,
-    budget: &Budget,
-    events: &Vec<DiagnosticEvent>,
-) -> Result<SorobanResources, Box<dyn error::Error>> {
-    let fp = storage_footprint_to_ledger_footprint(&storage.footprint)?;
-    /*
-      readBytes = size(footprint.readOnly) + size(footprint.readWrite)
-      writeBytes = size(storage.map[rw entries])
-      metadataSize = readBytes(footprint.readWrite) + writeBytes + eventsSize
-    */
-    let original_write_ledger_entry_bytes =
-        calculate_unmodified_ledger_entry_bytes(&fp.read_write.as_vec(), snapshot_source)?;
-    let read_bytes =
-        calculate_unmodified_ledger_entry_bytes(&fp.read_only.as_vec(), snapshot_source)?
-            + original_write_ledger_entry_bytes;
-    let write_bytes =
-        calculate_modified_read_write_ledger_entry_bytes(&storage.footprint, &storage.map, budget)?;
-    let meta_data_size_bytes =
-        original_write_ledger_entry_bytes + write_bytes + calculate_event_size_bytes(events)?;
-
-    // Add a 15% leeway with a minimum of 50k instructions
-    let instructions = max(
-        budget.get_cpu_insns_count() + 50000,
-        budget.get_cpu_insns_count() * 115 / 100,
-    );
-    Ok(SorobanResources {
-        footprint: fp,
-        instructions: instructions as u32,
-        read_bytes: read_bytes,
-        write_bytes: write_bytes,
-        extended_meta_data_size_bytes: meta_data_size_bytes,
-    })
-}
-
-fn get_fee_configuration(
-    _snapshot_source: &CSnapshotSource,
-) -> Result<FeeConfiguration, Box<dyn error::Error>> {
-    // TODO: (at least part of) these values should be obtained from the network's ConfigSetting LedgerEntries
-    //       (instead of hardcoding them to the initial values in the network)
-
-    // Taken from Stellar Core's InitialSorobanNetworkConfig in NetworkConfig.h
-    Ok(FeeConfiguration {
-        fee_per_instruction_increment: 100,
-        fee_per_read_entry: 5000,
-        fee_per_write_entry: 20000,
-        fee_per_read_1kb: 1000,
-        fee_per_write_1kb: 4000,
-        fee_per_historical_1kb: 100,
-        fee_per_metadata_1kb: 200,
-        fee_per_propagate_1kb: 2000,
-    })
-}
-
-fn calculate_modified_read_write_ledger_entry_bytes(
-    footprint: &Footprint,
-    storage_map: &StorageMap,
-    budget: &Budget,
-) -> Result<u32, Box<dyn error::Error>> {
-    let mut res: u32 = 0;
-    for (lk, ole) in storage_map {
-        match footprint.0.get::<LedgerKey>(lk, budget)? {
-            Some(AccessType::ReadOnly) => (),
-            Some(AccessType::ReadWrite) => {
-                if let Some(le) = ole {
-                    let entry_bytes = le.to_xdr()?;
-                    let key_bytes = lk.to_xdr()?;
-                    res += (entry_bytes.len() + key_bytes.len()) as u32;
-                }
-            }
-            // TODO: turn this panic into an error
-            None => panic!("ledger entry not in footprint"),
-        }
-    }
-    Ok(res)
-}
-
-fn calculate_unmodified_ledger_entry_bytes(
-    ledger_entries: &Vec<LedgerKey>,
-    snapshot_source: &CSnapshotSource,
-) -> Result<u32, Box<dyn error::Error>> {
-    let mut res: u32 = 0;
-    for lk in ledger_entries {
-        res += lk.to_xdr()?.len() as u32;
-        // TODO: remove unnecessary Rc
-        match snapshot_source.get(&Rc::new(lk.clone())) {
-            Ok(le) => {
-                let entry_bytes = le.to_xdr()?;
-                res += entry_bytes.len() as u32;
-            }
-            Err(e) => {
-                if e.status == ScHostStorageErrorCode::AccessToUnknownEntry.into() {
-                    // The entry is not present in the unmodified ledger storage.
-                    // We assume it to be due to the entry being created by a host function invocation.
-                    // Thus, we shouldn't count it in as unmodified.
-                    continue;
-                }
-                return Err(e)?;
-            }
-        };
-    }
-    Ok(res)
-}
-
-fn calculate_event_size_bytes(events: &Vec<DiagnosticEvent>) -> Result<u32, xdr::Error> {
-    let mut res: u32 = 0;
-    for e in events {
-        let event_xdr = e.to_xdr()?;
-        res += event_xdr.len() as u32;
-    }
-    Ok(res)
 }
 
 fn recorded_auth_payloads_to_c(
@@ -605,7 +334,7 @@ fn free_c_null_terminated_char_array(array: *mut *mut libc::c_char) {
             if c_char_ptr.is_null() {
                 break;
             }
-            // deallocate each base64 string
+            // deallocate each string
             let _ = CString::from_raw(c_char_ptr);
             i += 1;
         }

--- a/cmd/soroban-rpc/lib/preflight/src/lib.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/lib.rs
@@ -20,6 +20,7 @@ use soroban_env_host::xdr::{
     TransactionExt, TransactionV1Envelope, Uint256, WriteXdr,
 };
 use soroban_env_host::{Host, HostError, LedgerInfo};
+use std::cmp::max;
 use std::convert::TryInto;
 use std::ffi::{CStr, CString};
 use std::panic;
@@ -334,8 +335,11 @@ fn calculate_soroban_resources(
     let meta_data_size_bytes =
         original_write_ledger_entry_bytes + write_bytes + calculate_event_size_bytes(events)?;
 
-    // Add a 30% leeway
-    let instructions = budget.get_cpu_insns_count() * 13 / 10;
+    // Add a 15% leeway with a minimum of 50k instructions
+    let instructions = max(
+        budget.get_cpu_insns_count() + 50000,
+        budget.get_cpu_insns_count() * 115 / 100,
+    );
     Ok(SorobanResources {
         footprint: fp,
         instructions: instructions as u32,

--- a/cmd/soroban-rpc/lib/preflight/src/lib.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/lib.rs
@@ -397,12 +397,11 @@ fn calculate_unmodified_ledger_entry_bytes(
             }
             Err(e) => {
                 if e.status == ScHostStorageErrorCode::AccessToUnknownEntry.into() {
-                    // If not present in the unmodified ledger storage, assume it to be due to the
-                    // entry being created by a host function invocation.
+                    // The entry is not present in the unmodified ledger storage.
+                    // We assume it to be due to the entry being created by a host function invocation.
                     // Thus, we shouldn't count it in as unmodified.
                     continue;
                 }
-                println!("{:?}", e);
                 return Err(e)?;
             }
         };

--- a/cmd/soroban-rpc/lib/preflight/src/lib.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/lib.rs
@@ -250,19 +250,8 @@ fn get_c_host_function_preflight_array(
             result: result_c_str,
         });
     }
-
-    // Make sure length and capacity are the same
-    // (this allows using the length as the capacity when deallocating the vector)
-    out_vec.shrink_to_fit();
-    assert_eq!(out_vec.len(), out_vec.capacity());
-
-    // Get the pointer to our vector, we will deallocate it in free_c_null_terminated_char_array()
-    // TODO: replace by `out_vec.into_raw_parts()` once the API stabilizes
-    let ptr = out_vec.as_mut_ptr();
     let size = out_vec.len();
-    mem::forget(out_vec);
-
-    Ok((ptr, size))
+    Ok((vec_to_c_array(out_vec), size))
 }
 
 fn string_vec_to_c_null_terminated_char_array(
@@ -277,17 +266,21 @@ fn string_vec_to_c_null_terminated_char_array(
     // Add the ending NULL
     out_vec.push(null_mut());
 
+    Ok(vec_to_c_array(out_vec))
+}
+
+fn vec_to_c_array<T>(mut v: Vec<T>) -> *mut T {
     // Make sure length and capacity are the same
     // (this allows using the length as the capacity when deallocating the vector)
-    out_vec.shrink_to_fit();
-    assert_eq!(out_vec.len(), out_vec.capacity());
+    v.shrink_to_fit();
+    assert_eq!(v.len(), v.capacity());
 
     // Get the pointer to our vector, we will deallocate it in free_c_null_terminated_char_array()
     // TODO: replace by `out_vec.into_raw_parts()` once the API stabilizes
-    let ptr = out_vec.as_mut_ptr();
-    mem::forget(out_vec);
+    let ptr = v.as_mut_ptr();
+    mem::forget(v);
 
-    Ok(ptr)
+    ptr
 }
 
 /// .

--- a/cmd/soroban-rpc/lib/preflight/src/lib.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/lib.rs
@@ -334,8 +334,8 @@ fn calculate_soroban_resources(
     let meta_data_size_bytes =
         original_write_ledger_entry_bytes + write_bytes + calculate_event_size_bytes(events)?;
 
-    // Add a 15% leeway
-    let instructions = budget.get_cpu_insns_count() * 115 / 100;
+    // Add a 30% leeway
+    let instructions = budget.get_cpu_insns_count() * 13 / 10;
     Ok(SorobanResources {
         footprint: fp,
         instructions: instructions as u32,

--- a/cmd/soroban-rpc/lib/preflight/src/lib.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/lib.rs
@@ -198,6 +198,8 @@ fn preflight_invoke_hf_op_or_maybe_panic(
     let (storage, budget, events) = host.try_finish().unwrap();
 
     let diagnostic_events = host_events_to_diagnostic_events(&events)?;
+    // TODO: add the auth info to invoke_hf_op so that it's taken into account when estimating the
+    //       transaction size
     let (transaction_data, min_fee) = compute_transaction_data_and_min_fee(
         &invoke_hf_op,
         &CSnapshotSource { handle },

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/sirupsen/logrus v1.4.1
 	github.com/spf13/cobra v0.0.0-20160830174925-9c28e4bbd74e
 	github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189
-	github.com/stellar/go v0.0.0-20230505191505-7e069e5de4fc
+	github.com/stellar/go v0.0.0-20230511213801-ca711a9dd13c
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/mod v0.6.0
 )

--- a/go.sum
+++ b/go.sum
@@ -169,8 +169,8 @@ github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475 h1:RtZIgreTwcayPTOw7G5
 github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189 h1:fvB1AFbBd6SfI9Rd0ooAJp8uLkZDbZaLFHi7ZnNP6uI=
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
-github.com/stellar/go v0.0.0-20230505191505-7e069e5de4fc h1:XSvw3azNialrtsj6Rig0i3bqxeHVQlUn00KImVePRFU=
-github.com/stellar/go v0.0.0-20230505191505-7e069e5de4fc/go.mod h1:DHmAo7QjGEJa0yef6NXOh+083h/S6OsdRhOwav6Om1A=
+github.com/stellar/go v0.0.0-20230511213801-ca711a9dd13c h1:gk0b32afbLO3THrK2F4XQJEAN7Ltddk6vXV/BzlaIlw=
+github.com/stellar/go v0.0.0-20230511213801-ca711a9dd13c/go.mod h1:DHmAo7QjGEJa0yef6NXOh+083h/S6OsdRhOwav6Om1A=
 github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee h1:fbVs0xmXpBvVS4GBeiRmAE3Le70ofAqFMch1GTiq/e8=
 github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
### What

Calculate soroban transaction data in libpreflight

This changes the API of `simulateTransaction`. `SimulateTransactionResponse` changes as follows:

* Instead of returning a footprint, we return the full soroban transaction data.
* The list of events is returned globally instead of per host function
* A new field, `minResourceFee`, is added to tell the user what fee should be used with respect to the resources consumed by the host function invocations.

### Why

Closes #622 

### Known limitations

N/A
