### PR TITLE
soroban-rpc: print xdr version in dev compilation

### DIFF
--- a/cmd/soroban-rpc/main.go
+++ b/cmd/soroban-rpc/main.go
@@ -36,6 +36,7 @@ func main() {
 		Run: func(_ *cobra.Command, _ []string) {
 			if config.CommitHash == "" {
 				fmt.Printf("soroban-rpc dev\n")
+				fmt.Printf("stellar-xdr %s\n", goxdr.CommitHash)
 			} else {
 				// avoid printing the branch for the main branch
 				// ( since that's what the end-user would typically have )

--- a/cmd/soroban-rpc/main.go
+++ b/cmd/soroban-rpc/main.go
@@ -36,7 +36,6 @@ func main() {
 		Run: func(_ *cobra.Command, _ []string) {
 			if config.CommitHash == "" {
 				fmt.Printf("soroban-rpc dev\n")
-				fmt.Printf("stellar-xdr %s\n", goxdr.CommitHash)
 			} else {
 				// avoid printing the branch for the main branch
 				// ( since that's what the end-user would typically have )
@@ -47,8 +46,8 @@ func main() {
 					branch = ""
 				}
 				fmt.Printf("soroban-rpc %s (%s) %s\n", config.Version, config.CommitHash, branch)
-				fmt.Printf("stellar-xdr %s\n", goxdr.CommitHash)
 			}
+			fmt.Printf("stellar-xdr %s\n", goxdr.CommitHash)
 		},
 	}
 


### PR DESCRIPTION
### What

Print the compiled xdr version during `soroban-rpc version` : 
```
$ soroban-rpc version
soroban-rpc dev
stellar-xdr 2f16687fdf6f4bcfb56805e2035f69997f4b34c4
```

### Why

Could help us with debug efforts.

### Known limitations

n/a
