### PR TITLE
soroban-rpc: ensure building with proper commit hash version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,10 @@ all: check build test
 
 export RUSTFLAGS=-Dwarnings -Dclippy::all -Dclippy::pedantic
 
-REPOSITORY_COMMIT_HASH := "$(if $(shell git rev-parse HEAD),,$(error failed to retrieve git head commit hash))"
+REPOSITORY_COMMIT_HASH := "$(shell git rev-parse HEAD)"
+ifeq (${REPOSITORY_COMMIT_HASH},"")
+	$(error failed to retrieve git head commit hash)
+endif
 # Want to treat empty assignment, `REPOSITORY_VERSION=` the same as absence or unset.
 # By default make `?=` operator will treat empty assignment as a set value and will not use the default value.
 # Both cases should fallback to default of getting the version from git tag.

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,15 @@ all: check build test
 
 export RUSTFLAGS=-Dwarnings -Dclippy::all -Dclippy::pedantic
 
+REPOSITORY_COMMIT_HASH := "$(if $(shell git rev-parse HEAD),,$(error failed to retrieve git head commit hash))"
 # Want to treat empty assignment, `REPOSITORY_VERSION=` the same as absence or unset.
 # By default make `?=` operator will treat empty assignment as a set value and will not use the default value.
 # Both cases should fallback to default of getting the version from git tag.
 ifeq ($(strip $(REPOSITORY_VERSION)),)
 	override REPOSITORY_VERSION = "$(shell git describe --tags --always --abbrev=0 --match='v[0-9]*.[0-9]*.[0-9]*' 2> /dev/null | sed 's/^.//')"
 endif  
-REPOSITORY_COMMIT_HASH := "$(shell git rev-parse HEAD)"
 REPOSITORY_BRANCH := "$(shell git rev-parse --abbrev-ref HEAD)"
+
 BUILD_TIMESTAMP ?= $(shell date '+%Y-%m-%dT%H:%M:%S')
 GOLDFLAGS :=	-X 'github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/config.Version=${REPOSITORY_VERSION}' \
 				-X 'github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/config.CommitHash=${REPOSITORY_COMMIT_HASH}' \

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ ifeq ($(strip $(REPOSITORY_VERSION)),)
 	override REPOSITORY_VERSION = "$(shell git describe --tags --always --abbrev=0 --match='v[0-9]*.[0-9]*.[0-9]*' 2> /dev/null | sed 's/^.//')"
 endif  
 REPOSITORY_BRANCH := "$(shell git rev-parse --abbrev-ref HEAD)"
-
 BUILD_TIMESTAMP ?= $(shell date '+%Y-%m-%dT%H:%M:%S')
 GOLDFLAGS :=	-X 'github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/config.Version=${REPOSITORY_VERSION}' \
 				-X 'github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/config.CommitHash=${REPOSITORY_COMMIT_HASH}' \


### PR DESCRIPTION
ensure that failed builds would not result in corrupted soroban-rpc binaries being built without a commit hash.

### What

The makefile wasn't verifying that the `git` command was executed successfully.

### Why

It wasn't an issue before; however, during build the .git directory was omitted in https://github.com/stellar/quickstart/pull/449. This PR would ensure that such a case would be caught early.

### Known limitations

n/a