### PR TITLE
Do not publish soroban-hello test fixture

### DIFF
--- a/cmd/crates/soroban-test/tests/fixtures/hello/Cargo.toml
+++ b/cmd/crates/soroban-test/tests/fixtures/hello/Cargo.toml
@@ -2,6 +2,7 @@
 name = "soroban-hello"
 version = "0.8.0"
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
### What

Do not publish soroban-hello test fixture.

### Why

It is a test fixture. It isn't intended to be published. In the v0.8.0 release it was attempted published because cargo-workspace looks for all crates in the repo. Other test fixtures we configure with publish = false, and looks like we just missed it on this one.

### Known limitations

N/A

