### PR TITLE
fix: return contract Addresses and allow passing hex when used as an contract arg

### DIFF
--- a/cmd/crates/soroban-test/tests/it/invoke_sandbox.rs
+++ b/cmd/crates/soroban-test/tests/it/invoke_sandbox.rs
@@ -1,3 +1,5 @@
+use std::println;
+
 use soroban_cli::commands::{config::identity, contract};
 use soroban_test::TestEnv;
 
@@ -55,6 +57,7 @@ fn invoke_hello_world_with_deploy_first() {
         .success();
     let stdout = String::from_utf8(res.get_output().stdout.clone()).unwrap();
     let id = stdout.trim_end();
+    println!("{id}");
     sandbox
         .new_assert_cmd("contract")
         .arg("invoke")

--- a/cmd/crates/soroban-test/tests/it/invoke_sandbox.rs
+++ b/cmd/crates/soroban-test/tests/it/invoke_sandbox.rs
@@ -29,7 +29,7 @@ fn install_wasm_then_deploy_contract() {
         .arg("--id=1")
         .assert()
         .success()
-        .stdout("0000000000000000000000000000000000000000000000000000000000000001\n");
+        .stdout("CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM\n");
 }
 
 #[test]
@@ -42,7 +42,7 @@ fn deploy_contract_with_wasm_file() {
         .arg("--id=1")
         .assert()
         .success()
-        .stdout("0000000000000000000000000000000000000000000000000000000000000001\n");
+        .stdout("CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM\n");
 }
 
 #[test]

--- a/cmd/soroban-cli/src/commands/contract/deploy.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy.rs
@@ -91,6 +91,8 @@ pub enum Error {
     Rpc(#[from] rpc::Error),
     #[error(transparent)]
     Config(#[from] config::Error),
+    #[error(transparent)]
+    StrKey(#[from] stellar_strkey::DecodeError),
 }
 
 impl Cmd {
@@ -145,7 +147,7 @@ impl Cmd {
         let mut state = self.config.get_state()?;
         utils::add_contract_to_ledger_entries(&mut state.ledger_entries, contract_id, wasm_hash.0);
         self.config.set_state(&mut state)?;
-        Ok(hex::encode(contract_id))
+        Ok(stellar_strkey::Contract(contract_id).to_string())
     }
 
     async fn run_against_rpc_server(&self, wasm_hash: Hash) -> Result<String, Error> {
@@ -177,8 +179,7 @@ impl Cmd {
         client
             .prepare_and_send_transaction(&tx, &key, &network.network_passphrase, None)
             .await?;
-
-        Ok(hex::encode(contract_id.0))
+        Ok(stellar_strkey::Contract(contract_id.0).to_string())
     }
 }
 

--- a/cmd/soroban-cli/src/commands/plugin.rs
+++ b/cmd/soroban-cli/src/commands/plugin.rs
@@ -74,6 +74,6 @@ pub fn list() -> Result<Vec<String>, Error> {
         .collect())
 }
 
-fn is_hex_string(s: &str) -> bool {
+pub fn is_hex_string(s: &str) -> bool {
     s.chars().all(|s| s.is_ascii_hexdigit())
 }

--- a/cmd/soroban-cli/src/strval.rs
+++ b/cmd/soroban-cli/src/strval.rs
@@ -13,7 +13,7 @@ use soroban_env_host::xdr::{
     ScVec, StringM, UInt128Parts, UInt256Parts, Uint256, VecM,
 };
 
-use crate::utils;
+use crate::{commands::plugin::is_hex_string, utils};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -981,6 +981,12 @@ fn sc_address_to_json(v: &ScAddress) -> Value {
 }
 
 fn sc_address_from_json(s: &str, t: &ScType) -> Result<ScVal, Error> {
+    let s = &if is_hex_string(s) {
+        String::from_utf8(hex::decode(s).map_err(|_| Error::InvalidValue(Some(t.clone())))?)
+            .unwrap()
+    } else {
+        s.to_string()
+    };
     stellar_strkey::Strkey::from_string(s)
         .map_err(|_| Error::InvalidValue(Some(t.clone())))
         .map(|parsed| match parsed {


### PR DESCRIPTION
### What

fixes #661 
fixes #662

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
