### PR TITLE
soroban-rpc: Obtain fee configuration from the ledger

### DIFF
--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -294,6 +294,7 @@ func TestSimulateTransactionSucceeds(t *testing.T) {
 }
 
 func TestSimulateInvokeContractTransactionSucceeds(t *testing.T) {
+
 	test := NewTest(t)
 
 	ch := jhttp.NewChannel(test.sorobanRPCURL(), nil)
@@ -477,7 +478,7 @@ func TestSimulateInvokeContractTransactionSucceeds(t *testing.T) {
 	require.Contains(t, metrics, "soroban_rpc_json_rpc_request_duration_seconds_count{endpoint=\"simulateTransaction\",status=\"ok\"} 3")
 	require.Contains(t, metrics, "soroban_rpc_preflight_pool_request_ledger_get_duration_seconds_count{status=\"ok\",type=\"db\"} 3")
 	require.Contains(t, metrics, "soroban_rpc_preflight_pool_request_ledger_get_duration_seconds_count{status=\"ok\",type=\"all\"} 3")
-	require.Contains(t, metrics, "soroban_rpc_preflight_pool_request_ledger_entries_fetched_sum 14")
+	require.Contains(t, metrics, "soroban_rpc_preflight_pool_request_ledger_entries_fetched_sum 29")
 }
 
 func TestSimulateTransactionError(t *testing.T) {

--- a/cmd/soroban-rpc/lib/preflight/src/fees.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/fees.rs
@@ -164,8 +164,11 @@ fn get_configuration_setting(
 fn get_fee_configuration(
     ledger_storage: &ledger_storage::LedgerStorage,
 ) -> Result<FeeConfiguration, Box<dyn error::Error>> {
-    // TODO: consider caching these entries. In theory, they can change at any given ledger
-    //       (making caching ineffective) but we can maybe relax that requirement?
+    // TODO: to improve the performance of this function (which is invoked every single preflight call) we can
+    //       1. modify ledger_storage.get() so that it can gather multiple entries at once
+    //       2. implement a write-through cache for the configuration ledger entries (i.e. the cache is written to at the
+    //          same time as the DB, ensuring they are always in memory).
+    //
 
     let ConfigSettingEntry::ComputeV0(compute) = get_configuration_setting(ledger_storage, ConfigSettingId::ComputeV0)? else {
             return Err(

--- a/cmd/soroban-rpc/lib/preflight/src/ledger_storage.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/ledger_storage.rs
@@ -69,6 +69,12 @@ impl LedgerStorage {
         Ok(str)
     }
 
+    pub fn get(&self, key: &LedgerKey) -> Result<LedgerEntry, Error> {
+        let base64_str = self.get_xdr_base64(key)?;
+        let entry = LedgerEntry::from_xdr_base64(base64_str)?;
+        Ok(entry)
+    }
+
     pub fn get_xdr(&self, key: &LedgerKey) -> Result<Vec<u8>, Error> {
         let base64_str = self.get_xdr_base64(key)?;
         Ok(base64::decode(base64_str)?)
@@ -77,11 +83,7 @@ impl LedgerStorage {
 
 impl SnapshotSource for LedgerStorage {
     fn get(&self, key: &Rc<LedgerKey>) -> Result<Rc<LedgerEntry>, HostError> {
-        let base64_str = self
-            .get_xdr_base64(key)
-            .map_err(|e| Error::to_host_error(&e))?;
-        let entry =
-            LedgerEntry::from_xdr_base64(base64_str).map_err(|_| ScStatus::UnknownError(Xdr))?;
+        let entry = self.get(key).map_err(|e| Error::to_host_error(&e))?;
         Ok(entry.into())
     }
 


### PR DESCRIPTION
### What

Obtain the configuration for the fee estimation of `simulateTransaction` from the ledger instead of hardcoding it.

### Why

Close #665 

### Known limitations

Obtaining 4 ledger entries for each `simulateTransaction` call will reduce performance. We need a benchmark to measure the impact.


