### PR TITLE
fix: return contract Addresses and allow passing hex when used as an contract arg

### DIFF
--- a/cmd/crates/soroban-test/tests/it/invoke_sandbox.rs
+++ b/cmd/crates/soroban-test/tests/it/invoke_sandbox.rs
@@ -1,3 +1,5 @@
+use std::println;
+
 use soroban_cli::commands::{config::identity, contract};
 use soroban_test::TestEnv;
 
@@ -55,6 +57,7 @@ fn invoke_hello_world_with_deploy_first() {
         .success();
     let stdout = String::from_utf8(res.get_output().stdout.clone()).unwrap();
     let id = stdout.trim_end();
+    println!("{id}");
     sandbox
         .new_assert_cmd("contract")
         .arg("invoke")

--- a/cmd/crates/soroban-test/tests/it/invoke_sandbox.rs
+++ b/cmd/crates/soroban-test/tests/it/invoke_sandbox.rs
@@ -29,7 +29,7 @@ fn install_wasm_then_deploy_contract() {
         .arg("--id=1")
         .assert()
         .success()
-        .stdout("0000000000000000000000000000000000000000000000000000000000000001\n");
+        .stdout("CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM\n");
 }
 
 #[test]
@@ -42,7 +42,7 @@ fn deploy_contract_with_wasm_file() {
         .arg("--id=1")
         .assert()
         .success()
-        .stdout("0000000000000000000000000000000000000000000000000000000000000001\n");
+        .stdout("CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM\n");
 }
 
 #[test]

--- a/cmd/soroban-cli/src/bin/main.rs
+++ b/cmd/soroban-cli/src/bin/main.rs
@@ -5,7 +5,7 @@ use soroban_cli::{commands::plugin, Root};
 
 #[tokio::main]
 async fn main() {
-    let root = Root::try_parse().unwrap_or_else(|e| {
+    let mut root = Root::try_parse().unwrap_or_else(|e| {
         use clap::error::ErrorKind;
         match e.kind() {
             ErrorKind::InvalidSubcommand => {

--- a/cmd/soroban-cli/src/commands/contract/deploy.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy.rs
@@ -91,6 +91,8 @@ pub enum Error {
     Rpc(#[from] rpc::Error),
     #[error(transparent)]
     Config(#[from] config::Error),
+    #[error(transparent)]
+    StrKey(#[from] stellar_strkey::DecodeError),
 }
 
 impl Cmd {
@@ -145,7 +147,7 @@ impl Cmd {
         let mut state = self.config.get_state()?;
         utils::add_contract_to_ledger_entries(&mut state.ledger_entries, contract_id, wasm_hash.0);
         self.config.set_state(&mut state)?;
-        Ok(hex::encode(contract_id))
+        Ok(stellar_strkey::Contract(contract_id).to_string())
     }
 
     async fn run_against_rpc_server(&self, wasm_hash: Hash) -> Result<String, Error> {
@@ -177,8 +179,7 @@ impl Cmd {
         client
             .prepare_and_send_transaction(&tx, &key, &network.network_passphrase, None)
             .await?;
-
-        Ok(hex::encode(contract_id.0))
+        Ok(stellar_strkey::Contract(contract_id.0).to_string())
     }
 }
 

--- a/cmd/soroban-cli/src/commands/contract/install.rs
+++ b/cmd/soroban-cli/src/commands/contract/install.rs
@@ -44,7 +44,7 @@ pub enum Error {
 
 impl Cmd {
     pub async fn run(&self) -> Result<(), Error> {
-        let res_str = hex::encode(self.run_and_get_hash().await?);
+        let res_str = stellar_strkey::Contract(self.run_and_get_hash().await?.0).to_string();
         println!("{res_str}");
         Ok(())
     }

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -8,7 +8,6 @@ use std::{fmt::Debug, fs, io, rc::Rc};
 
 use clap::{arg, command, Parser};
 use heck::ToKebabCase;
-use hex::FromHexError;
 use soroban_env_host::{
     budget::Budget,
     events::HostEvent,
@@ -111,7 +110,7 @@ pub enum Error {
     #[error("cannot parse contract ID {contract_id}: {error}")]
     CannotParseContractId {
         contract_id: String,
-        error: FromHexError,
+        error: stellar_strkey::DecodeError,
     },
     #[error("function {0} was not found in the contract")]
     FunctionNotFoundInContractSpec(String),
@@ -445,7 +444,7 @@ impl Cmd {
 
 impl Cmd {
     fn contract_id(&self) -> Result<[u8; 32], Error> {
-        utils::id_from_str(&self.contract_id)
+        utils::contract_id_from_str(&self.contract_id)
             .map_err(|e| Error::CannotParseContractId {
                 contract_id: self.contract_id.clone(),
                 error: e,

--- a/cmd/soroban-cli/src/commands/contract/read.rs
+++ b/cmd/soroban-cli/src/commands/contract/read.rs
@@ -4,7 +4,6 @@ use std::{
 };
 
 use clap::{command, Parser, ValueEnum};
-use hex::FromHexError;
 use soroban_env_host::{
     xdr::{
         self, ContractDataEntry, Error as XdrError, LedgerEntryData, LedgerKey,
@@ -62,7 +61,7 @@ pub enum Error {
     #[error("cannot parse contract ID {contract_id}: {error}")]
     CannotParseContractId {
         contract_id: String,
-        error: FromHexError,
+        error: stellar_strkey::DecodeError,
     },
     #[error("cannot print result {result:?}: {error}")]
     CannotPrintResult { result: ScVal, error: strval::Error },
@@ -89,9 +88,11 @@ impl Cmd {
     #[allow(clippy::too_many_lines)]
     pub fn run(&self) -> Result<(), Error> {
         let contract_id: [u8; 32] =
-            utils::id_from_str(&self.contract_id).map_err(|e| Error::CannotParseContractId {
-                contract_id: self.contract_id.clone(),
-                error: e,
+            utils::contract_id_from_str(&self.contract_id).map_err(|e| {
+                Error::CannotParseContractId {
+                    contract_id: self.contract_id.clone(),
+                    error: e,
+                }
             })?;
         let key = if let Some(key) = &self.key {
             Some(

--- a/cmd/soroban-cli/src/commands/events.rs
+++ b/cmd/soroban-cli/src/commands/events.rs
@@ -112,7 +112,7 @@ pub enum Error {
     #[error("cannot parse contract ID {contract_id}: {error}")]
     InvalidContractId {
         contract_id: String,
-        error: hex::FromHexError,
+        error: stellar_strkey::DecodeError,
     },
 
     #[error("invalid JSON string: {error} ({debug})")]
@@ -226,7 +226,7 @@ impl Cmd {
             // We parse the contract IDs to ensure they're the correct format,
             // but since we'll be passing them as-is to the RPC server anyway,
             // we disregard the return value.
-            utils::id_from_str::<32>(raw_contract_id).map_err(|e| Error::InvalidContractId {
+            utils::contract_id_from_str(raw_contract_id).map_err(|e| Error::InvalidContractId {
                 contract_id: raw_contract_id.clone(),
                 error: e,
             })?;

--- a/cmd/soroban-cli/src/commands/events.rs
+++ b/cmd/soroban-cli/src/commands/events.rs
@@ -195,11 +195,11 @@ impl Cmd {
             // TODO: Once soroban-rpc supports passing these as a strkey, we should change to
             // formatting these as C-strkeys.
             *id = utils::contract_id_from_str(id)
-                .map(|key| hex::encode(key))
+                .map(hex::encode)
                 .map_err(|e| Error::InvalidContractId {
                     contract_id: id.clone(),
                     error: e,
-                })?
+                })?;
         }
 
         let response = if self.network.is_no_network() {

--- a/cmd/soroban-cli/src/commands/events.rs
+++ b/cmd/soroban-cli/src/commands/events.rs
@@ -165,7 +165,7 @@ pub enum OutputFormat {
 }
 
 impl Cmd {
-    pub async fn run(&self) -> Result<(), Error> {
+    pub async fn run(&mut self) -> Result<(), Error> {
         // Validate that topics are made up of segments.
         for topic in &self.topic_filters {
             for (i, segment) in topic.split(',').enumerate() {
@@ -185,6 +185,21 @@ impl Cmd {
                     }
                 }
             }
+        }
+
+        // Validate and normalize contract_ids
+        for id in &mut self.contract_ids {
+            // We parse the contract IDs to ensure they're the correct format, and padded out
+            // correctly.
+            //
+            // TODO: Once soroban-rpc supports passing these as a strkey, we should change to
+            // formatting these as C-strkeys.
+            *id = utils::contract_id_from_str(id)
+                .map(|key| hex::encode(key))
+                .map_err(|e| Error::InvalidContractId {
+                    contract_id: id.clone(),
+                    error: e,
+                })?
         }
 
         let response = if self.network.is_no_network() {
@@ -221,16 +236,6 @@ impl Cmd {
     async fn run_against_rpc_server(&self) -> Result<rpc::GetEventsResponse, Error> {
         let start = self.start()?;
         let Network { rpc_url, .. } = self.network.get(&self.locator)?;
-
-        for raw_contract_id in &self.contract_ids {
-            // We parse the contract IDs to ensure they're the correct format,
-            // but since we'll be passing them as-is to the RPC server anyway,
-            // we disregard the return value.
-            utils::contract_id_from_str(raw_contract_id).map_err(|e| Error::InvalidContractId {
-                contract_id: raw_contract_id.clone(),
-                error: e,
-            })?;
-        }
 
         let client = rpc::Client::new(&rpc_url)?;
         client

--- a/cmd/soroban-cli/src/commands/mod.rs
+++ b/cmd/soroban-cli/src/commands/mod.rs
@@ -71,8 +71,8 @@ impl Root {
     {
         Self::from_arg_matches_mut(&mut Self::command().get_matches_from(itr))
     }
-    pub async fn run(&self) -> Result<(), Error> {
-        match &self.cmd {
+    pub async fn run(&mut self) -> Result<(), Error> {
+        match &mut self.cmd {
             Cmd::Contract(contract) => contract.run().await?,
             Cmd::Events(events) => events.run().await?,
             Cmd::Lab(lab) => lab.run().await?,

--- a/cmd/soroban-cli/src/commands/plugin.rs
+++ b/cmd/soroban-cli/src/commands/plugin.rs
@@ -74,6 +74,6 @@ pub fn list() -> Result<Vec<String>, Error> {
         .collect())
 }
 
-fn is_hex_string(s: &str) -> bool {
+pub fn is_hex_string(s: &str) -> bool {
     s.chars().all(|s| s.is_ascii_hexdigit())
 }

--- a/cmd/soroban-cli/src/commands/plugin.rs
+++ b/cmd/soroban-cli/src/commands/plugin.rs
@@ -1,6 +1,8 @@
 use std::process::Command;
 use which::which;
 
+use crate::utils;
+
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("Plugin not provided. Should be `soroban plugin` for a binary `soroban-plugin`")]
@@ -69,11 +71,7 @@ pub fn list() -> Result<Vec<String>, Error> {
             let s = b.file_name()?.to_str()?;
             Some(s.strip_suffix(".exe").unwrap_or(s).to_string())
         })
-        .filter(|s| !(is_hex_string(s) && s.len() > MAX_HEX_LENGTH))
+        .filter(|s| !(utils::is_hex_string(s) && s.len() > MAX_HEX_LENGTH))
         .map(|s| s.replace("soroban-", ""))
         .collect())
-}
-
-pub fn is_hex_string(s: &str) -> bool {
-    s.chars().all(|s| s.is_ascii_hexdigit())
 }

--- a/cmd/soroban-cli/src/strval.rs
+++ b/cmd/soroban-cli/src/strval.rs
@@ -13,7 +13,7 @@ use soroban_env_host::xdr::{
     ScVec, StringM, UInt128Parts, UInt256Parts, Uint256, VecM,
 };
 
-use crate::utils;
+use crate::{commands::plugin::is_hex_string, utils};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -981,6 +981,12 @@ fn sc_address_to_json(v: &ScAddress) -> Value {
 }
 
 fn sc_address_from_json(s: &str, t: &ScType) -> Result<ScVal, Error> {
+    let s = &if is_hex_string(s) {
+        String::from_utf8(hex::decode(s).map_err(|_| Error::InvalidValue(Some(t.clone())))?)
+            .unwrap()
+    } else {
+        s.to_string()
+    };
     stellar_strkey::Strkey::from_string(s)
         .map_err(|_| Error::InvalidValue(Some(t.clone())))
         .map(|parsed| match parsed {

--- a/cmd/soroban-cli/src/strval.rs
+++ b/cmd/soroban-cli/src/strval.rs
@@ -1273,7 +1273,7 @@ mod tests {
         // All zero contract address
         match sc_address_from_json("CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4") {
             Ok(addr) => assert_eq!(addr, ScVal::Address(ScAddress::Contract(Hash([0; 32])))),
-            Err(e) => panic!("Unexpected error: {}", e),
+            Err(e) => panic!("Unexpected error: {e}"),
         }
 
         // Real contract address
@@ -1290,7 +1290,7 @@ mod tests {
                     .unwrap()
                 ))
             ),
-            Err(e) => panic!("Unexpected error: {}", e),
+            Err(e) => panic!("Unexpected error: {e}"),
         }
 
         // All zero user account address
@@ -1301,7 +1301,7 @@ mod tests {
                     PublicKey::PublicKeyTypeEd25519([0; 32].try_into().unwrap())
                 )))
             ),
-            Err(e) => panic!("Unexpected error: {}", e),
+            Err(e) => panic!("Unexpected error: {e}"),
         }
 
         // Real user account address
@@ -1320,7 +1320,7 @@ mod tests {
                     )
                 )))
             ),
-            Err(e) => panic!("Unexpected error: {}", e),
+            Err(e) => panic!("Unexpected error: {e}"),
         }
     }
 }

--- a/cmd/soroban-cli/src/utils.rs
+++ b/cmd/soroban-cli/src/utils.rs
@@ -221,21 +221,6 @@ pub fn get_contract_spec_from_storage(
     }
 }
 
-/// # Errors
-///
-/// Might return an error
-pub fn vec_to_hash(res: &ScVal) -> Result<String, XdrError> {
-    if let ScVal::Bytes(res_hash) = &res {
-        let mut hash_bytes: [u8; 32] = [0; 32];
-        for (i, b) in res_hash.iter().enumerate() {
-            hash_bytes[i] = *b;
-        }
-        Ok(hex::encode(hash_bytes))
-    } else {
-        Err(XdrError::Invalid)
-    }
-}
-
 /// # Panics
 ///
 /// May panic

--- a/cmd/soroban-cli/src/utils.rs
+++ b/cmd/soroban-cli/src/utils.rs
@@ -315,6 +315,10 @@ pub(crate) fn parse_secret_key(
     into_key_pair(&PrivateKey::from_string(s).unwrap())
 }
 
+pub fn is_hex_string(s: &str) -> bool {
+    s.chars().all(|s| s.is_ascii_hexdigit())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/cmd/soroban-cli/src/utils.rs
+++ b/cmd/soroban-cli/src/utils.rs
@@ -160,7 +160,7 @@ pub fn sign_transaction(
 ///
 /// Might return an error
 pub fn contract_id_from_str(contract_id: &str) -> Result<[u8; 32], stellar_strkey::DecodeError> {
-    stellar_strkey::Contract::from_string(&contract_id)
+    stellar_strkey::Contract::from_string(contract_id)
         .map(|strkey| strkey.0)
         .or_else(|_| {
             // strkey failed, try to parse it as a hex string, for backwards compatibility.
@@ -335,7 +335,7 @@ mod tests {
                     0x07, 0x3d, 0x05, 0xc7, 0xb1, 0x03,
                 ]
             ),
-            Err(err) => panic!("Failed to parse contract id: {}", err),
+            Err(err) => panic!("Failed to parse contract id: {err}"),
         }
 
         // hex
@@ -350,7 +350,7 @@ mod tests {
                     0x07, 0x3d, 0x05, 0xc7, 0xb1, 0x03,
                 ]
             ),
-            Err(err) => panic!("Failed to parse contract id: {}", err),
+            Err(err) => panic!("Failed to parse contract id: {err}"),
         }
 
         // unpadded-hex
@@ -363,7 +363,7 @@ mod tests {
                     0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
                 ]
             ),
-            Err(err) => panic!("Failed to parse contract id: {}", err),
+            Err(err) => panic!("Failed to parse contract id: {err}"),
         }
 
         // invalid hex


### PR DESCRIPTION
### What

fixes #661
fixes #662
fixes #403
replaces #663

### Why

https://github.com/stellar/soroban-tools/pull/663 missed a few other commands were we take contract IDs as args. Also, we cannot generically accept hex for `strval::scaddress_from_json`, because with just 32-byte hex, we cannot tell if it is a user address or a contract address.

Incidentally, making this more consistent also fixed a bug in `soroban events --id 1`, where the given contract id was not padded out to the full 32 bytes. Now, these are all equivalent:
```sh
soroban events --id 1
soroban events --id 0000000000000000000000000000000000000000000000000000000000000001
soroban events --id CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM
```
Those ids all also work for `invoke`, `deploy`, and `read`

### Known limitations

- We should also update soroban-rpc to take a contract strkey in it's params, wherever it currently accepts a contract hex (e.g. getEvents). Then we can update this to pass that in.