### PR TITLE
Fix a bug parsing bytes args where the hex are all numbers

### DIFF
--- a/cmd/crates/soroban-test/tests/it/arg_parsing.rs
+++ b/cmd/crates/soroban-test/tests/it/arg_parsing.rs
@@ -1,7 +1,9 @@
 use crate::util::CUSTOM_TYPES;
 use serde_json::json;
 use soroban_cli::strval::{self, Spec};
-use soroban_env_host::xdr::{ScSpecTypeDef, ScSpecTypeOption, ScSpecTypeUdt, ScVal};
+use soroban_env_host::xdr::{
+    ScBytes, ScSpecTypeBytesN, ScSpecTypeDef, ScSpecTypeOption, ScSpecTypeUdt, ScVal,
+};
 
 #[test]
 fn parse_bool() {
@@ -84,6 +86,52 @@ fn parse_i256() {
         "{:#?}",
         strval::from_string_primitive(res, &ScSpecTypeDef::I256,).unwrap()
     );
+}
+
+#[test]
+fn parse_bytes() {
+    let b = strval::from_string_primitive(r#"beefface"#, &ScSpecTypeDef::Bytes).unwrap();
+    assert_eq!(
+        b,
+        ScVal::Bytes(ScBytes(vec![0xbe, 0xef, 0xfa, 0xce].try_into().unwrap()))
+    );
+    println!("{b:#?}");
+}
+
+#[test]
+fn parse_bytes_when_hex_is_all_numbers() {
+    let b = strval::from_string_primitive(r#"4554"#, &ScSpecTypeDef::Bytes).unwrap();
+    assert_eq!(
+        b,
+        ScVal::Bytes(ScBytes(vec![0x45, 0x54].try_into().unwrap()))
+    );
+    println!("{b:#?}");
+}
+
+#[test]
+fn parse_bytesn() {
+    let b = strval::from_string_primitive(
+        r#"beefface"#,
+        &ScSpecTypeDef::BytesN(ScSpecTypeBytesN { n: 4 }),
+    )
+    .unwrap();
+    assert_eq!(
+        b,
+        ScVal::Bytes(ScBytes(vec![0xbe, 0xef, 0xfa, 0xce].try_into().unwrap()))
+    );
+    println!("{b:#?}");
+}
+
+#[test]
+fn parse_bytesn_when_hex_is_all_numbers() {
+    let b =
+        strval::from_string_primitive(r#"4554"#, &ScSpecTypeDef::BytesN(ScSpecTypeBytesN { n: 2 }))
+            .unwrap();
+    assert_eq!(
+        b,
+        ScVal::Bytes(ScBytes(vec![0x45, 0x54].try_into().unwrap()))
+    );
+    println!("{b:#?}",);
 }
 
 #[test]

--- a/cmd/soroban-cli/src/strval.rs
+++ b/cmd/soroban-cli/src/strval.rs
@@ -798,7 +798,7 @@ pub fn from_json_primitives(v: &Value, t: &ScType) -> Result<ScVal, Error> {
         // Bytes parsing
         (bytes @ ScType::BytesN(_), Value::Number(n)) => from_json_primitives(
             &Value::String(format!("{n}")),
-            &ScType::BytesN(bytes.clone()),
+            &bytes,
         )?,
         (ScType::BytesN(bytes), Value::String(s)) => ScVal::Bytes(ScBytes({
             if let Ok(key) = stellar_strkey::ed25519::PublicKey::from_string(s) {

--- a/cmd/soroban-cli/src/strval.rs
+++ b/cmd/soroban-cli/src/strval.rs
@@ -796,7 +796,7 @@ pub fn from_json_primitives(v: &Value, t: &ScType) -> Result<ScVal, Error> {
         (ScType::Address, Value::String(s)) => sc_address_from_json(s, t)?,
 
         // Bytes parsing
-        (ScType::BytesN(bytes), Value::Number(n)) => from_json_primitives(
+        (bytes @ ScType::BytesN(_), Value::Number(n)) => from_json_primitives(
             &Value::String(format!("{n}")),
             &ScType::BytesN(bytes.clone()),
         )?,

--- a/cmd/soroban-cli/src/strval.rs
+++ b/cmd/soroban-cli/src/strval.rs
@@ -796,10 +796,9 @@ pub fn from_json_primitives(v: &Value, t: &ScType) -> Result<ScVal, Error> {
         (ScType::Address, Value::String(s)) => sc_address_from_json(s, t)?,
 
         // Bytes parsing
-        (bytes @ ScType::BytesN(_), Value::Number(n)) => from_json_primitives(
-            &Value::String(format!("{n}")),
-            &bytes,
-        )?,
+        (bytes @ ScType::BytesN(_), Value::Number(n)) => {
+            from_json_primitives(&Value::String(format!("{n}")), bytes)?
+        }
         (ScType::BytesN(bytes), Value::String(s)) => ScVal::Bytes(ScBytes({
             if let Ok(key) = stellar_strkey::ed25519::PublicKey::from_string(s) {
                 key.0

--- a/cmd/soroban-cli/src/strval.rs
+++ b/cmd/soroban-cli/src/strval.rs
@@ -796,6 +796,10 @@ pub fn from_json_primitives(v: &Value, t: &ScType) -> Result<ScVal, Error> {
         (ScType::Address, Value::String(s)) => sc_address_from_json(s, t)?,
 
         // Bytes parsing
+        (ScType::BytesN(bytes), Value::Number(n)) => from_json_primitives(
+            &Value::String(format!("{n}")),
+            &ScType::BytesN(bytes.clone()),
+        )?,
         (ScType::BytesN(bytes), Value::String(s)) => ScVal::Bytes(ScBytes({
             if let Ok(key) = stellar_strkey::ed25519::PublicKey::from_string(s) {
                 key.0
@@ -808,6 +812,9 @@ pub fn from_json_primitives(v: &Value, t: &ScType) -> Result<ScVal, Error> {
                     .map_err(|_| Error::InvalidValue(Some(t.clone())))?
             }
         })),
+        (ScType::Bytes, Value::Number(n)) => {
+            from_json_primitives(&Value::String(format!("{n}")), &ScType::Bytes)?
+        }
         (ScType::Bytes, Value::String(s)) => ScVal::Bytes(
             hex::decode(s)
                 .map_err(|_| Error::InvalidValue(Some(t.clone())))?
@@ -1258,5 +1265,59 @@ impl Spec {
             }
         };
         Some(res)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use soroban_env_host::xdr::ScSpecTypeBytesN;
+
+    #[test]
+    fn from_json_primitives_bytesn() {
+        // TODO: Add test for parsing addresses
+
+        // Check it parses hex-encoded bytes
+        let b = from_json_primitives(
+            &Value::String("beefface".to_string()),
+            &ScType::BytesN(ScSpecTypeBytesN { n: 4 }),
+        )
+        .unwrap();
+        assert_eq!(
+            b,
+            ScVal::Bytes(ScBytes(vec![0xbe, 0xef, 0xfa, 0xce].try_into().unwrap()))
+        );
+
+        // Check it parses hex-encoded bytes when they are all numbers. Normally the json would
+        // interpret the CLI arg as a number, so we need a special case there.
+        let b = from_json_primitives(
+            &Value::Number(4554.into()),
+            &ScType::BytesN(ScSpecTypeBytesN { n: 2 }),
+        )
+        .unwrap();
+        assert_eq!(
+            b,
+            ScVal::Bytes(ScBytes(vec![0x45, 0x54].try_into().unwrap()))
+        );
+    }
+
+    #[test]
+    fn from_json_primitives_bytes() {
+        // Check it parses hex-encoded bytes
+        let b =
+            from_json_primitives(&Value::String("beefface".to_string()), &ScType::Bytes).unwrap();
+        assert_eq!(
+            b,
+            ScVal::Bytes(ScBytes(vec![0xbe, 0xef, 0xfa, 0xce].try_into().unwrap()))
+        );
+
+        // Check it parses hex-encoded bytes when they are all numbers. Normally the json would
+        // interpret the CLI arg as a number, so we need a special case there.
+        let b = from_json_primitives(&Value::Number(4554.into()), &ScType::Bytes).unwrap();
+        assert_eq!(
+            b,
+            ScVal::Bytes(ScBytes(vec![0x45, 0x54].try_into().unwrap()))
+        );
     }
 }


### PR DESCRIPTION
### What

Fix a bug parsing "bytes" type args, where the value is all numbers.

### Why

Parsing a bytes array of the text "DT" would fail (bytes 0x45, 0x54). The CLI json arg parser would count it as a json number, not a string, so parsing would fail.

### Known limitations

[TODO or N/A]
