### PR TITLE
soroban-rpc: fix compilation on windows

### DIFF
--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -72,6 +72,13 @@ jobs:
           sudo apt-get install -y gcc-10-aarch64-linux-gnu
           echo 'CC=aarch64-linux-gnu-gcc-10' >> $GITHUB_ENV
 
+      - if: matrix.os == 'windows-2019'
+        name: Update MinGW version
+        uses: egor-tensin/setup-mingw@v2
+        with:
+          platform: x64
+          version: 12.2.0.03042023
+
       - name: Build libpreflight
         run: CARGO_BUILD_TARGET=${{ matrix.rust_target }} make build-libpreflight
 

--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -72,13 +72,6 @@ jobs:
           sudo apt-get install -y gcc-10-aarch64-linux-gnu
           echo 'CC=aarch64-linux-gnu-gcc-10' >> $GITHUB_ENV
 
-      - if: matrix.os == 'windows-2019'
-        name: Update MinGW version
-        uses: egor-tensin/setup-mingw@v2
-        with:
-          platform: x64
-          version: 12.2.0.03042023
-
       - name: Build libpreflight
         run: CARGO_BUILD_TARGET=${{ matrix.rust_target }} make build-libpreflight
 

--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -49,10 +49,10 @@ jobs:
           - os: macos-latest
             rust_target: aarch64-apple-darwin
             go_arch: arm64
-          - image-tag: [win22/20230508.3]
+          - os: windows-2019
             rust_target: x86_64-pc-windows-gnu
             go_arch: amd64
-    runs-on: ${{ matrix.os || matrix.image-tag }}
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       # we cannot use our own ./.github/actions/setup-go action

--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -61,7 +61,9 @@ jobs:
         with:
           go-version: 1.20.1
 
-      - run: rustup update
+      - run: }
+        RUST_VERSION=$(sed -n 's/.*rust-version = "\(.*\)"/\1/p' cmd/soroban-cli/Cargo.toml) rustup update ${RUST_VERSION}
+
       - run: rustup target add ${{ matrix.rust_target }}
 
       # Use cross-compiler for linux aarch64

--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -52,9 +52,7 @@ jobs:
           - image-tag: [win22/20230508.3]
             rust_target: x86_64-pc-windows-gnu
             go_arch: amd64
-    container:
-      image: ${{ matrix.image-tag }}
-    runs-on: container
+    runs-on: ${{ matrix.os || matrix.image-tag }}
     steps:
       - uses: actions/checkout@v3
       # we cannot use our own ./.github/actions/setup-go action

--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -84,7 +84,6 @@ jobs:
 
       - name: Build Soroban RPC reproducible build
         run: |
-          go version
           CGO_ENABLED=1 GOARCH=${{ matrix.go_arch }} go build -trimpath -buildvcs=false ./cmd/soroban-rpc
           ls -lh soroban-rpc
           file soroban-rpc

--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -82,6 +82,7 @@ jobs:
 
       - name: Build Soroban RPC reproducible build
         run: |
+          go version
           CGO_ENABLED=1 GOARCH=${{ matrix.go_arch }} go build -trimpath -buildvcs=false ./cmd/soroban-rpc
           ls -lh soroban-rpc
           file soroban-rpc

--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -61,8 +61,14 @@ jobs:
         with:
           go-version: 1.20.1
 
-      - run: |
-          RUST_VERSION=$(sed -n 's/.*rust-version = "\(.*\)"/\1/p' cmd/soroban-cli/Cargo.toml) rustup update 1.69.0
+      - if: matrix.os == 'windows-latest'
+        name: Find the minimal supported rust version on windows
+        run: |
+          preflight_rust_version=$(sed -n 's/.*rust-version = "\(.*\)"/\1/p' cmd/soroban-rpc/lib/preflight/Cargo.toml)
+          echo "PREFLIGHT_RUST_VERSION=$preflight_rust_version" >> $GITHUB_ENV
+      - name: Update rust toolchain as needed
+        run: |
+          rustup update $PREFLIGHT_RUST_VERSION
       - run: rustup target add ${{ matrix.rust_target }}
 
       # Use cross-compiler for linux aarch64

--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -49,7 +49,7 @@ jobs:
           - os: macos-latest
             rust_target: aarch64-apple-darwin
             go_arch: arm64
-          - os: windows-2019
+          - os: windows-latest
             rust_target: x86_64-pc-windows-gnu
             go_arch: amd64
     runs-on: ${{ matrix.os }}
@@ -71,6 +71,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc-10-aarch64-linux-gnu
           echo 'CC=aarch64-linux-gnu-gcc-10' >> $GITHUB_ENV
+
+      - if: matrix.os == 'windows-latest'
+        name: Rollback Microsoft Visual C++ Redistributable for Visual Studio 2015-2022 to v14.34.31938
+        run: |
+          choco install vcredist140 --version=14.34.31938
 
       - name: Build libpreflight
         run: CARGO_BUILD_TARGET=${{ matrix.rust_target }} make build-libpreflight

--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -62,7 +62,7 @@ jobs:
           go-version: 1.20.1
 
       - run: |
-          RUST_VERSION=$(sed -n 's/.*rust-version = "\(.*\)"/\1/p' cmd/soroban-cli/Cargo.toml) rustup update ${RUST_VERSION}
+          RUST_VERSION=$(sed -n 's/.*rust-version = "\(.*\)"/\1/p' cmd/soroban-cli/Cargo.toml) rustup update 1.69.0
       - run: rustup target add ${{ matrix.rust_target }}
 
       # Use cross-compiler for linux aarch64

--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           go-version: 1.20.1
 
-      - run: }
+      - run: |
         RUST_VERSION=$(sed -n 's/.*rust-version = "\(.*\)"/\1/p' cmd/soroban-cli/Cargo.toml) rustup update ${RUST_VERSION}
 
       - run: rustup target add ${{ matrix.rust_target }}

--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -79,11 +79,6 @@ jobs:
           sudo apt-get install -y gcc-10-aarch64-linux-gnu
           echo 'CC=aarch64-linux-gnu-gcc-10' >> $GITHUB_ENV
 
-      - if: matrix.os == 'windows-latest'
-        name: Rollback Microsoft Visual C++ Redistributable for Visual Studio 2015-2022 to v14.34.31938
-        run: |
-          choco install vcredist140 --version=14.34.31938 --allow-downgrade
-
       - name: Build libpreflight
         run: CARGO_BUILD_TARGET=${{ matrix.rust_target }} make build-libpreflight
 

--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -62,8 +62,7 @@ jobs:
           go-version: 1.20.1
 
       - run: |
-        RUST_VERSION=$(sed -n 's/.*rust-version = "\(.*\)"/\1/p' cmd/soroban-cli/Cargo.toml) rustup update ${RUST_VERSION}
-
+          RUST_VERSION=$(sed -n 's/.*rust-version = "\(.*\)"/\1/p' cmd/soroban-cli/Cargo.toml) rustup update ${RUST_VERSION}
       - run: rustup target add ${{ matrix.rust_target }}
 
       # Use cross-compiler for linux aarch64

--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -49,10 +49,12 @@ jobs:
           - os: macos-latest
             rust_target: aarch64-apple-darwin
             go_arch: arm64
-          - os: windows-latest
+          - image-tag: [win22/20230508.3]
             rust_target: x86_64-pc-windows-gnu
             go_arch: amd64
-    runs-on: ${{ matrix.os }}
+    container:
+      image: ${{ matrix.image-tag }}
+    runs-on: container
     steps:
       - uses: actions/checkout@v3
       # we cannot use our own ./.github/actions/setup-go action

--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -75,7 +75,7 @@ jobs:
       - if: matrix.os == 'windows-latest'
         name: Rollback Microsoft Visual C++ Redistributable for Visual Studio 2015-2022 to v14.34.31938
         run: |
-          choco install vcredist140 --version=14.34.31938
+          choco install vcredist140 --version=14.34.31938 --allow-downgrade
 
       - name: Build libpreflight
         run: CARGO_BUILD_TARGET=${{ matrix.rust_target }} make build-libpreflight

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repo is home to the suite of Soroban development tools.
 Soroban: https://soroban.stellar.org
 
 # linting
- 
+
 Before submitting a PR for review, please run
 
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repo is home to the suite of Soroban development tools.
 Soroban: https://soroban.stellar.org
 
 # linting
-
+ 
 Before submitting a PR for review, please run
 
 ```

--- a/cmd/soroban-rpc/internal/preflight/preflight.go
+++ b/cmd/soroban-rpc/internal/preflight/preflight.go
@@ -18,7 +18,7 @@ import (
 #include <stdlib.h>
 // This assumes that the Rust compiler should be using a -gnu target (i.e. MinGW compiler) in Windows
 // (I (fons) am not even sure if CGo supports MSVC, see https://github.com/golang/go/issues/20982)
-#cgo windows,amd64 LDFLAGS: -L${SRCDIR}/../../../../target/x86_64-pc-windows-gnu/release-with-panic-unwind/ -lpreflight -ldl -lm -static -lws2_32 -lbcrypt -luserenv
+#cgo windows,amd64 LDFLAGS: -L${SRCDIR}/../../../../target/x86_64-pc-windows-gnu/release-with-panic-unwind/ -lpreflight -lm -static -lws2_32 -lbcrypt -luserenv
 // You cannot compile with -static in macOS (and it's not worth it in Linux, at least with glibc)
 #cgo darwin,amd64 LDFLAGS: -L${SRCDIR}/../../../../target/x86_64-apple-darwin/release-with-panic-unwind/ -lpreflight -ldl -lm
 #cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/../../../../target/aarch64-apple-darwin/release-with-panic-unwind/ -lpreflight -ldl -lm

--- a/cmd/soroban-rpc/lib/preflight/Cargo.toml
+++ b/cmd/soroban-rpc/lib/preflight/Cargo.toml
@@ -2,6 +2,7 @@
 name = "preflight"
 version = "0.8.0"
 publish = false
+rust-version = "1.69"
 
 [lib]
 crate-type = ["staticlib"]


### PR DESCRIPTION
### What

Compiling under windows got broken by the internet.

### Why

The rust compiler was modified between release 1.69 and 1.70; the suspected culprit is the upgrade for rust to be using LLVM 16.

### Known limitations

The solution here is to use the minimal supported version and to use a rust compiler of that version ( 1.69 ). This is a good temporary solution until we can fix the issue properly.
