### PR TITLE
preflight: Resolve compilation issue rust 1.70 on windows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,7 +32,7 @@ jobs:
       SYSTEM_TEST_RUST_TOOLCHAIN_VERSION: stable
 
       # sets the version of soroban-js-client used by tests
-      SYSTEM_TEST_JS_SOROBAN_CLIENT_NPM_VERSION: "0.7.0"
+      SYSTEM_TEST_JS_SOROBAN_CLIENT_NPM_VERSION: "0.8.1"
      
       # system test will build quickstart image internally to use for running the service stack
       # configured in standalone network mode(core, rpc)

--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -68,6 +68,7 @@ jobs:
           cd cmd/soroban-rpc/lib/preflight
           rustup default stable-${{ matrix.rust_target }}
           cd ../../../..
+          echo "CC=c:\msys2\mingw64\bin\gcc.exe" >> $GITHUB_ENV
 
       # Use cross-compiler for linux aarch64
       - if: matrix.rust_target == 'aarch64-unknown-linux-gnu'

--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Build Soroban RPC reproducible build
         run: |
-          CGO_ENABLED=1 GOARCH=${{ matrix.go_arch }} go build -trimpath -buildvcs=false ./cmd/soroban-rpc
+          CGO_ENABLED=1 GOARCH=${{ matrix.go_arch }} go build -x -trimpath -buildvcs=false ./cmd/soroban-rpc
           ls -lh soroban-rpc
           file soroban-rpc
 

--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -68,8 +68,9 @@ jobs:
           cd cmd/soroban-rpc/lib/preflight
           rustup default stable-${{ matrix.rust_target }}
           cd ../../../..
-          c:\\msys64\\usr\\bin\\pacman.exe -S mingw-w64-x86_64-gcc --noconfirm
-          echo "CC=c:\\msys64\\mingw64\\bin\\gcc.exe" >> $GITHUB_ENV
+          C:\\msys64\\usr\\bin\\pacman.exe -S mingw-w64-x86_64-gcc --noconfirm
+          echo "CC=C:\\msys64\\mingw64\\bin\\gcc.exe" >> $GITHUB_ENV
+          echo "C:\\msys64\\mingw64\\bin" >> $GITHUB_PATH
 
       # Use cross-compiler for linux aarch64
       - if: matrix.rust_target == 'aarch64-unknown-linux-gnu'

--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -68,7 +68,8 @@ jobs:
           cd cmd/soroban-rpc/lib/preflight
           rustup default stable-${{ matrix.rust_target }}
           cd ../../../..
-          echo "CC=c:\msys2\mingw64\bin\gcc.exe" >> $GITHUB_ENV
+          c:\msys64\usr\bin\pacman -S mingw-w64-x86_64-gcc --noconfirm
+          echo "CC=c:\msys64\mingw64\bin\gcc.exe" >> $GITHUB_ENV
 
       # Use cross-compiler for linux aarch64
       - if: matrix.rust_target == 'aarch64-unknown-linux-gnu'

--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -62,12 +62,12 @@ jobs:
           go-version: 1.20.1
 
       - run: rustup target add ${{ matrix.rust_target }}
+
+      # On windows, make sure we have the same compiler (linker) used by rust.
+      # This is important since the symbols names won't match otherwise.
       - if: matrix.os == 'windows-latest'
-        name: Install the same mingw used by rust
+        name: Install the same mingw gcc compiler used by rust
         run: |
-          #cd cmd/soroban-rpc/lib/preflight
-          #rustup default stable-${{ matrix.rust_target }}
-          #cd ../../../..
           C:\\msys64\\usr\\bin\\pacman.exe -S mingw-w64-x86_64-gcc --noconfirm
           echo "CC=C:\\msys64\\mingw64\\bin\\gcc.exe" >> $GITHUB_ENV
           echo "C:\\msys64\\mingw64\\bin" >> $GITHUB_PATH

--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Build libpreflight
         run: make build-libpreflight
         env:
-          CARGO_BUILD_TARGET=${{ matrix.rust_target }}
+          CARGO_BUILD_TARGET: ${{ matrix.rust_target }}
 
       - name: Build Soroban RPC reproducible build
         run: |
@@ -91,8 +91,8 @@ jobs:
           ls -lh soroban-rpc
           file soroban-rpc
         env:
-          CGO_ENABLED=1
-          GOARCH=${{ matrix.go_arch }}
+          CGO_ENABLED: 1
+          GOARCH: ${{ matrix.go_arch }}
 
   integration:
     name: Integration tests

--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -66,6 +66,7 @@ jobs:
         run: |
           preflight_rust_version=$(sed -n 's/.*rust-version = "\(.*\)"/\1/p' cmd/soroban-rpc/lib/preflight/Cargo.toml)
           echo "PREFLIGHT_RUST_VERSION=$preflight_rust_version" >> $GITHUB_ENV
+          echo "CC=c:\\msys2\\mingw64\\bin\\gcc.exe"
       - name: Update rust toolchain as needed
         run: |
           rustup update $PREFLIGHT_RUST_VERSION

--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -61,21 +61,12 @@ jobs:
         with:
           go-version: 1.20.1
 
-      - if: matrix.os == 'windows-latest'
-        name: Find the minimal supported rust version on windows
-        run: |
-          preflight_rust_version=$(sed -n 's/.*rust-version = "\(.*\)"/\1/p' cmd/soroban-rpc/lib/preflight/Cargo.toml)
-          echo "PREFLIGHT_RUST_VERSION=$preflight_rust_version" >> $GITHUB_ENV
-          echo "CC=c:\\msys2\\mingw64\\bin\\gcc.exe"
-      - name: Update rust toolchain as needed
-        run: |
-          rustup update $PREFLIGHT_RUST_VERSION
       - run: rustup target add ${{ matrix.rust_target }}
       - if: matrix.os == 'windows-latest'
         name: Configure preflight library to use explicit rust version
         run: |
           cd cmd/soroban-rpc/lib/preflight
-          rustup override set $PREFLIGHT_RUST_VERSION-${{ matrix.rust_target }}
+          rustup default stable-${{ matrix.rust_target }}
           cd ../../../..
 
       # Use cross-compiler for linux aarch64

--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -63,11 +63,11 @@ jobs:
 
       - run: rustup target add ${{ matrix.rust_target }}
       - if: matrix.os == 'windows-latest'
-        name: Configure preflight library to use explicit rust version
+        name: Install the same mingw used by rust
         run: |
-          cd cmd/soroban-rpc/lib/preflight
-          rustup default stable-${{ matrix.rust_target }}
-          cd ../../../..
+          #cd cmd/soroban-rpc/lib/preflight
+          #rustup default stable-${{ matrix.rust_target }}
+          #cd ../../../..
           C:\\msys64\\usr\\bin\\pacman.exe -S mingw-w64-x86_64-gcc --noconfirm
           echo "CC=C:\\msys64\\mingw64\\bin\\gcc.exe" >> $GITHUB_ENV
           echo "C:\\msys64\\mingw64\\bin" >> $GITHUB_PATH
@@ -85,7 +85,7 @@ jobs:
 
       - name: Build Soroban RPC reproducible build
         run: |
-          CGO_ENABLED=1 GOARCH=${{ matrix.go_arch }} go build -x -trimpath -buildvcs=false ./cmd/soroban-rpc
+          CGO_ENABLED=1 GOARCH=${{ matrix.go_arch }} go build -trimpath -buildvcs=false ./cmd/soroban-rpc
           ls -lh soroban-rpc
           file soroban-rpc
 

--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -68,8 +68,8 @@ jobs:
           cd cmd/soroban-rpc/lib/preflight
           rustup default stable-${{ matrix.rust_target }}
           cd ../../../..
-          c:\msys64\usr\bin\pacman -S mingw-w64-x86_64-gcc --noconfirm
-          echo "CC=c:\msys64\mingw64\bin\gcc.exe" >> $GITHUB_ENV
+          c:\\msys64\\usr\\bin\\pacman.exe -S mingw-w64-x86_64-gcc --noconfirm
+          echo "CC=c:\\msys64\\mingw64\\bin\\gcc.exe" >> $GITHUB_ENV
 
       # Use cross-compiler for linux aarch64
       - if: matrix.rust_target == 'aarch64-unknown-linux-gnu'

--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -81,13 +81,18 @@ jobs:
           echo 'CC=aarch64-linux-gnu-gcc-10' >> $GITHUB_ENV
 
       - name: Build libpreflight
-        run: CARGO_BUILD_TARGET=${{ matrix.rust_target }} make build-libpreflight
+        run: make build-libpreflight
+        env:
+          CARGO_BUILD_TARGET=${{ matrix.rust_target }}
 
       - name: Build Soroban RPC reproducible build
         run: |
-          CGO_ENABLED=1 GOARCH=${{ matrix.go_arch }} go build -trimpath -buildvcs=false ./cmd/soroban-rpc
+          go build -trimpath -buildvcs=false ./cmd/soroban-rpc
           ls -lh soroban-rpc
           file soroban-rpc
+        env:
+          CGO_ENABLED=1
+          GOARCH=${{ matrix.go_arch }}
 
   integration:
     name: Integration tests

--- a/cmd/soroban-rpc/internal/preflight/preflight.go
+++ b/cmd/soroban-rpc/internal/preflight/preflight.go
@@ -18,7 +18,7 @@ import (
 #include <stdlib.h>
 // This assumes that the Rust compiler should be using a -gnu target (i.e. MinGW compiler) in Windows
 // (I (fons) am not even sure if CGo supports MSVC, see https://github.com/golang/go/issues/20982)
-#cgo windows,amd64 LDFLAGS: -L${SRCDIR}/../../../../target/x86_64-pc-windows-gnu/release-with-panic-unwind/ -lpreflight -lntdll -lm -static -lws2_32 -lbcrypt -luserenv
+#cgo windows,amd64 LDFLAGS: -L${SRCDIR}/../../../../target/x86_64-pc-windows-gnu/release-with-panic-unwind/ -lpreflight -lntdll -static -lws2_32 -lbcrypt -luserenv
 // You cannot compile with -static in macOS (and it's not worth it in Linux, at least with glibc)
 #cgo darwin,amd64 LDFLAGS: -L${SRCDIR}/../../../../target/x86_64-apple-darwin/release-with-panic-unwind/ -lpreflight -ldl -lm
 #cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/../../../../target/aarch64-apple-darwin/release-with-panic-unwind/ -lpreflight -ldl -lm

--- a/cmd/soroban-rpc/internal/preflight/preflight.go
+++ b/cmd/soroban-rpc/internal/preflight/preflight.go
@@ -18,7 +18,7 @@ import (
 #include <stdlib.h>
 // This assumes that the Rust compiler should be using a -gnu target (i.e. MinGW compiler) in Windows
 // (I (fons) am not even sure if CGo supports MSVC, see https://github.com/golang/go/issues/20982)
-#cgo windows,amd64 LDFLAGS: -L${SRCDIR}/../../../../target/x86_64-pc-windows-gnu/release-with-panic-unwind/ -lpreflight -lm -static -lws2_32 -lbcrypt -luserenv
+#cgo windows,amd64 LDFLAGS: -L${SRCDIR}/../../../../target/x86_64-pc-windows-gnu/release-with-panic-unwind/ -lpreflight -lntdll -lm -static -lws2_32 -lbcrypt -luserenv
 // You cannot compile with -static in macOS (and it's not worth it in Linux, at least with glibc)
 #cgo darwin,amd64 LDFLAGS: -L${SRCDIR}/../../../../target/x86_64-apple-darwin/release-with-panic-unwind/ -lpreflight -ldl -lm
 #cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/../../../../target/aarch64-apple-darwin/release-with-panic-unwind/ -lpreflight -ldl -lm

--- a/cmd/soroban-rpc/lib/preflight/Cargo.toml
+++ b/cmd/soroban-rpc/lib/preflight/Cargo.toml
@@ -2,7 +2,6 @@
 name = "preflight"
 version = "0.8.0"
 publish = false
-rust-version = "1.70"
 
 [lib]
 crate-type = ["staticlib"]

--- a/cmd/soroban-rpc/lib/preflight/Cargo.toml
+++ b/cmd/soroban-rpc/lib/preflight/Cargo.toml
@@ -2,7 +2,7 @@
 name = "preflight"
 version = "0.8.0"
 publish = false
-rust-version = "1.69"
+rust-version = "1.70"
 
 [lib]
 crate-type = ["staticlib"]


### PR DESCRIPTION
### What

Fix compilation issue with soroban-rpc & updated rust compiler.

### Why

We previously pinned the rust compiler to 1.69, since the transition to 1.70 included an upgrade to llvm 16.
That upgrade broke binary compatibility between the preflight library and the soroban-rpc.

To overcome these limitations, this PR switches to use the msys2 version of mingw's gcc compiler. This is the same compiler that the gnu implementation of rust is using, and therefore produces the same library symbols.

With this change in place, we can continue upgrading the rust compiler version as needed.

### Known limitations

N/A
