### PR TITLE
fix: make opt default; to opt-out `cargo install --no-default-features`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,7 @@ jobs:
         cd target/package
         tar xvfz soroban-cli-$VERSION.crate
         cd soroban-cli-$VERSION
-        cargo build --target-dir=../.. --features opt --release --target ${{ matrix.target }}
+        cargo build --target-dir=../.. --release --target ${{ matrix.target }}
     - name: Compress 
       run: |
           cd target/${{ matrix.target }}/release

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,7 +70,7 @@ jobs:
           cargo test --target ${{ matrix.target }} --manifest-path $I/Cargo.toml
         done
   publish-dry-run:
-    if: github.event_name == 'push' || startsWith(github.head_ref, 'release/')
+    # if: github.event_name == 'push' || startsWith(github.head_ref, 'release/')
     strategy:
       matrix:
         include:

--- a/cmd/soroban-cli/Cargo.toml
+++ b/cmd/soroban-cli/Cargo.toml
@@ -31,7 +31,7 @@ path = "src/lib.rs"
 doctest = false
 
 [features]
-default = []
+default = ["opt"]
 opt = ["dep:wasm-opt"]
 
 [dependencies]

--- a/cmd/soroban-cli/README.md
+++ b/cmd/soroban-cli/README.md
@@ -10,10 +10,10 @@ Soroban: https://soroban.stellar.org
 cargo install --locked soroban-cli
 ```
 
-To install with the `opt` feature, which includes a WASM optimization feature and wasm-opt built in:
+The `opt` feature, which includes a WASM optimization feature and wasm-opt built in is the default; to to build without it:
 
 ```
-cargo install --locked soroban-cli --features opt
+cargo install --locked soroban-cli --no-default-features
 ```
 
 ## Usage

--- a/cmd/soroban-cli/src/commands/contract/optimize.rs
+++ b/cmd/soroban-cli/src/commands/contract/optimize.rs
@@ -23,7 +23,9 @@ pub enum Error {
     #[error("optimization error: {0}")]
     OptimizationError(OptimizationError),
     #[cfg(not(feature = "opt"))]
-    #[error("Must install with \"opt\" feature, e.g. `cargo install soroban-cli --features opt")]
+    #[error(
+        "Must install with \"opt\" feature, which is the default, e.g. `cargo install soroban-cli"
+    )]
     Install,
 }
 


### PR DESCRIPTION
### What

When installing users must do `--no-default-features` to opt out of using wasm-opt.

### Why

Hopefully will fix https://github.com/stellar/soroban-tools/actions/runs/5260321197/jobs/9507078865?pr=694

### Known limitations

[TODO or N/A]
