### PR TITLE
Disable fail-fast on soroban-cli builds and publishes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,7 @@ jobs:
 
   upload:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-20.04 # Use 20.04 to get an older version of glibc for increased compat

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,6 +40,7 @@ jobs:
 
   build-and-test:
     strategy:
+      fail-fast: false
       matrix:
         include:
         - os: ubuntu-latest
@@ -72,6 +73,7 @@ jobs:
   publish-dry-run:
     if: github.event_name == 'push' || startsWith(github.head_ref, 'release/')
     strategy:
+      fail-fast: false
       matrix:
         include:
         - os: ubuntu-latest


### PR DESCRIPTION
### What
Disable fail-fast on soroban-cli builds and publishes.

### Why
The fail-fast feature is enabled by default on matrix builds of GitHub Action jobs. When enabled, if any run in the matrix fails, all running variations will be canceled and any yet to run won't run.

Disabling fail-fast will cause all matrix builds to start and run to completion, regardless of whether another run in the matrix succeeds or fails.

It is enabled by default because it makes builds more efficient. Normally if a run fails there's enough information to go on to fix and then run again.

For the soroban-cli it is beneficial if builds that are matrix based on platforms are run without fail-fast because we will get broad signal if a problem is only related to one platform or multiple.

Recently we've had trouble with Windows builds failing due to environmental issues. This gives us the ability to make a decision to move ahead with a build without Windows support if we urgently need to do so.