### PR TITLE
fix: use correct url for cargo-binstall

### DIFF
--- a/cmd/soroban-cli/Cargo.toml
+++ b/cmd/soroban-cli/Cargo.toml
@@ -17,7 +17,7 @@ name = "soroban"
 path = "src/bin/main.rs"
 
 [package.metadata.binstall]
-pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.{ archive-suffix }"
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ version }-{ target }{ archive-suffix }"
 bin-dir = "{ bin }{ binary-ext }"
 
 [[bin]]


### PR DESCRIPTION
Currently the following works for installing from binary:
```
cargo binstall \
--pkg-url "{ repo }/releases/download/v{ version }/{ name }-{ version }-{ target }{ archive-suffix }" \
--force \
soroban-cli
```
