### PR TITLE
build: update slash direction for windows RPC builds

### DIFF
--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -68,9 +68,9 @@ jobs:
       - if: matrix.os == 'windows-latest'
         name: Install the same mingw gcc compiler used by rust
         run: |
-          C:\\msys64\\usr\\bin\\pacman.exe -S mingw-w64-x86_64-gcc --noconfirm
-          echo "CC=C:\\msys64\\mingw64\\bin\\gcc.exe" >> $GITHUB_ENV
-          echo "C:\\msys64\\mingw64\\bin" >> $GITHUB_PATH
+          C:/msys64/usr/bin/pacman.exe -S mingw-w64-x86_64-gcc --noconfirm
+          echo "CC=C:/msys64/mingw64/bin/gcc.exe" >> $GITHUB_ENV
+          echo "C:/msys64/mingw64/bin" >> $GITHUB_PATH
 
       # Use cross-compiler for linux aarch64
       - if: matrix.rust_target == 'aarch64-unknown-linux-gnu'


### PR DESCRIPTION
### What

In the Github testing, I used \\ ( double slash ) to specify path on windows platform.
In a previous code review, it was suggested to replace these with /, since windows understands both.

### Why

It's sightly more aligned with the rest of the yml file content.

### Known limitations

N/A. If it works, it works.
