### PR TITLE
pin os version of the rpc dockerfile build stage

### DIFF
--- a/cmd/soroban-rpc/docker/Dockerfile
+++ b/cmd/soroban-rpc/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 as build
+FROM golang:1.20-bullseye as build
 ARG RUST_TOOLCHAIN_VERSION=stable
 ARG REPOSITORY_VERSION
 


### PR DESCRIPTION
### What
pin the os version on the golang:x.x.x base image used for dockerfile build stage on rpc

### Why

without the O/S tag included on golang:x.x.x, the image can potentially change as new Debian OS's are released which may cause un-intended side effects for binaries built/linked within. recommendation from team overall is to pin to `bullseye`

### Known limitations

