### PR TITLE
feat: upgrade freighter-api to 1.5.0 & soroban-client to 0.8.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ install: install_rust build-libpreflight
 build_rust: Cargo.lock
 	cargo build
 
+# regenerate the example lib in `cmd/crates/soroban-spec-typsecript/fixtures/ts`
 build-snapshot:
 	cargo test --package soroban-spec-typescript --lib -- boilerplate::test::build_package --exact --nocapture --ignored
 

--- a/cmd/crates/soroban-spec-typescript/fixtures/ts/package.json
+++ b/cmd/crates/soroban-spec-typescript/fixtures/ts/package.json
@@ -4,9 +4,8 @@
     "dependencies": {
         "@stellar/freighter-api": "1.5.0",
         "buffer": "6.0.3",
-        "soroban-client": "0.8.0",
-        "bigint-conversion": "2.4.1",
-        "stellar-base": "9.0.0-soroban.3"
+        "soroban-client": "0.8.1",
+        "bigint-conversion": "2.4.1"
     },
     "scripts": {
         "build": "node ./scripts/build.mjs"

--- a/cmd/crates/soroban-spec-typescript/fixtures/ts/package.json
+++ b/cmd/crates/soroban-spec-typescript/fixtures/ts/package.json
@@ -2,7 +2,7 @@
     "version": "0.0.0",
     "name": "contract-data-example",
     "dependencies": {
-        "@stellar/freighter-api": "1.4.0",
+        "@stellar/freighter-api": "1.5.0",
         "buffer": "6.0.3",
         "soroban-client": "0.8.0",
         "bigint-conversion": "2.4.1",

--- a/cmd/crates/soroban-spec-typescript/src/project_template/package.json
+++ b/cmd/crates/soroban-spec-typescript/src/project_template/package.json
@@ -2,7 +2,7 @@
     "version": "0.0.0",
     "name": "INSERT_CONTRACT_NAME_HERE",
     "dependencies": {
-        "@stellar/freighter-api": "1.4.0",
+        "@stellar/freighter-api": "1.5.0",
         "buffer": "6.0.3",
         "soroban-client": "0.8.0",
         "bigint-conversion": "2.4.1",

--- a/cmd/crates/soroban-spec-typescript/src/project_template/package.json
+++ b/cmd/crates/soroban-spec-typescript/src/project_template/package.json
@@ -4,9 +4,8 @@
     "dependencies": {
         "@stellar/freighter-api": "1.5.0",
         "buffer": "6.0.3",
-        "soroban-client": "0.8.0",
-        "bigint-conversion": "2.4.1",
-        "stellar-base": "9.0.0-soroban.3"
+        "soroban-client": "0.8.1",
+        "bigint-conversion": "2.4.1"
     },
     "scripts": {
         "build": "node ./scripts/build.mjs"


### PR DESCRIPTION
### TODO

- [x] wait for #702 to merge, then rebase on `main` to remove all but the last commit here

### What

For JS libraries generated with `soroban contract bindings typescript`:

- upgrade to freighter-api 1.5.0

- use the new methods from `freighter-api@1.5.0` to avoid popping
  pop-ups over and over every time a view call is invoked

- if the transaction only needs to be simulated, then the user doesn't
  need to have Freighter connected. This now uses a default/dummy
  account for such calls, but throws an error if the app author tries to
  `signAndSend` such calls.

- upgrade `soroban-client` to 0.8.1, which allows removing the pinned version of `stellar-base`

### Why

This greatly improves the devx & ux of apps that use these generated libraries.

### Known limitations

N/A