### PR TITLE
fix: allow generated JS libs to use localhost

### DIFF
--- a/cmd/crates/soroban-spec-typescript/fixtures/ts/src/server.ts
+++ b/cmd/crates/soroban-spec-typescript/fixtures/ts/src/server.ts
@@ -5,4 +5,4 @@ import { RPC_URL } from './constants.js'
  * SorobanClient.Server instance, initialized using {@link RPC_URL} used to
  * initialize this library.
  */
-export const Server = new SorobanClient.Server(RPC_URL);
+export const Server = new SorobanClient.Server(RPC_URL, { allowHttp: RPC_URL.startsWith('http://') });

--- a/cmd/crates/soroban-spec-typescript/src/project_template/src/server.ts
+++ b/cmd/crates/soroban-spec-typescript/src/project_template/src/server.ts
@@ -5,4 +5,4 @@ import { RPC_URL } from './constants.js'
  * SorobanClient.Server instance, initialized using {@link RPC_URL} used to
  * initialize this library.
  */
-export const Server = new SorobanClient.Server(RPC_URL);
+export const Server = new SorobanClient.Server(RPC_URL, { allowHttp: RPC_URL.startsWith('http://') });


### PR DESCRIPTION
### What

Set `allowHttp` to `true` if the RPC_URL starts with `http:` rather than `https`.

### Why

This allows people to use the exported `Server` instance correctly when using a local node.

### Known limitations

N/A