### PR TITLE
rust: fix rust-analyzer testing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,7 +36,7 @@ jobs:
     - run: rustup update
     - run: rustup +nightly component add rust-analyzer
     - name: Check if rust-analyzer encounters any errors parsing project
-      run: rustup run nightly rust-analyzer analysis-stats . 2>&1 | (! grep ERROR)
+      run: rustup run nightly rust-analyzer analysis-stats . 2>&1 >/dev/null | (! grep ERROR)
 
   build-and-test:
     strategy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,7 +36,7 @@ jobs:
     - run: rustup update
     - run: rustup +nightly component add rust-analyzer
     - name: Check if rust-analyzer encounters any errors parsing project
-      run: rustup run nightly rust-analyzer analysis-stats . 2>&1 >/dev/null | (! grep ERROR)
+      run: rustup run nightly rust-analyzer analysis-stats . 2>&1 | (! grep '^\[ERROR')
 
   build-and-test:
     strategy:


### PR DESCRIPTION
### What

Following a recent dependency update, the `rust-analyzer` started failing when executing the following:
```sh
rustup run nightly rust-analyzer analysis-stats . 2>&1 | (! grep ERROR)
```

### Why

One of the dependencies was including the text "ERROR", which caused this test to fail. This is a false-positive,
since there is no actual failure here. The solution here is to omit the stdout and use the stderr only when scanning for the "ERROR" text.

### Known limitations

N/A
