### PR TITLE
Add command for building contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1883,6 +1915,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sep5"
 version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2061,6 +2102,7 @@ dependencies = [
  "assert_cmd",
  "assert_fs",
  "base64 0.13.1",
+ "cargo_metadata",
  "chrono",
  "clap",
  "clap-markdown",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1463,6 +1463,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+
+[[package]]
 name = "pbkdf2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2119,6 +2125,7 @@ dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-http-client",
  "num-bigint",
+ "pathdiff",
  "predicates 2.1.5",
  "rand 0.8.5",
  "regex",

--- a/cmd/soroban-cli/Cargo.toml
+++ b/cmd/soroban-cli/Cargo.toml
@@ -90,6 +90,7 @@ tracing = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 cargo_metadata = "0.15.4"
+pathdiff = "0.2.1"
 
 [build-dependencies]
 crate-git-revision = "0.0.4"

--- a/cmd/soroban-cli/Cargo.toml
+++ b/cmd/soroban-cli/Cargo.toml
@@ -89,6 +89,7 @@ heck = "0.4.1"
 tracing = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+cargo_metadata = "0.15.4"
 
 [build-dependencies]
 crate-git-revision = "0.0.4"

--- a/cmd/soroban-cli/src/commands/contract/build.rs
+++ b/cmd/soroban-cli/src/commands/contract/build.rs
@@ -1,0 +1,118 @@
+use clap::Parser;
+use itertools::Itertools;
+use std::{
+    collections::HashSet,
+    ffi::OsStr,
+    fmt::Debug,
+    process::{Command, Stdio},
+};
+
+use cargo_metadata::{Metadata, MetadataCommand, Package};
+
+#[derive(Parser, Debug, Clone)]
+#[group(skip)]
+pub struct Cmd {
+    /// Path to Cargo.toml
+    #[arg(long)]
+    pub manifest_path: Option<std::path::PathBuf>,
+    /// Package to build
+    #[arg(long)]
+    pub package: Option<String>,
+    /// Build with the specified profile
+    #[arg(long, default_value = "release")]
+    pub profile: String,
+    /// Build with the list of features activated, space or comma separated
+    #[arg(
+        long,
+        conflicts_with = "all_features",
+        conflicts_with = "no_default_features"
+    )]
+    pub features: Option<String>,
+    /// Build with the all features activated, space or comma separated
+    #[arg(
+        long,
+        conflicts_with = "features",
+        conflicts_with = "no_default_features"
+    )]
+    pub all_features: bool,
+    /// Build with the default feature not activated
+    #[arg(long, conflicts_with = "features", conflicts_with = "all_features")]
+    pub no_default_features: bool,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Metadata(#[from] cargo_metadata::Error),
+}
+
+impl Cmd {
+    pub fn run(&self) -> Result<(), Error> {
+        let packages = self.packages()?;
+
+        for p in packages {
+            let mut cmd = Command::new("cargo");
+            cmd.stdout(Stdio::piped());
+            cmd.arg("rustc");
+            cmd.arg(format!("--manifest-path={}", p.manifest_path));
+            cmd.arg("--crate-type=cdylib");
+            cmd.arg("--target=wasm32-unknown-unknown");
+            cmd.arg(format!("--package={}", p.name));
+            cmd.arg(format!("--profile={}", self.profile));
+            if self.all_features {
+                cmd.arg("--all-features");
+            }
+            if self.no_default_features {
+                cmd.arg("--no-default-features");
+            }
+            if let Some(features) = self.features() {
+                let requested: HashSet<String> = features.iter().cloned().collect();
+                let available = p.features.iter().map(|f| f.0).cloned().collect();
+                let activate = requested.intersection(&available).join(",");
+                if !activate.is_empty() {
+                    cmd.arg(format!("--features={activate}"));
+                }
+            }
+            eprintln!(
+                "cargo {}",
+                cmd.get_args().map(OsStr::to_string_lossy).join(" ")
+            );
+            let _ = cmd.status();
+        }
+
+        Ok(())
+    }
+
+    fn features(&self) -> Option<Vec<String>> {
+        self.features
+            .as_ref()
+            .map(|f| f.split(&[',', ' ']).map(String::from).collect())
+    }
+
+    fn packages(&self) -> Result<Vec<Package>, cargo_metadata::Error> {
+        let metadata = self.metadata()?;
+        let iter = metadata
+            .packages
+            .iter()
+            .filter(|p| self.package.is_none() || Some(&p.name) == self.package.as_ref())
+            .filter(|p| {
+                p.targets
+                    .iter()
+                    .any(|t| t.crate_types.iter().any(|c| c == "cdylib"))
+            })
+            .cloned();
+        Ok(iter.collect())
+    }
+
+    fn metadata(&self) -> Result<Metadata, cargo_metadata::Error> {
+        let mut cmd = MetadataCommand::new();
+        cmd.no_deps();
+        if let Some(manifest_path) = &self.manifest_path {
+            cmd.manifest_path(manifest_path);
+        }
+        // Do not configure features on the metadata command, because we are
+        // only collecting non-dependency metadata, features have no impact on
+        // the output.
+        cmd.exec()
+    }
+}

--- a/cmd/soroban-cli/src/commands/contract/build.rs
+++ b/cmd/soroban-cli/src/commands/contract/build.rs
@@ -44,7 +44,7 @@ pub struct Cmd {
     /// Build with the default feature not activated
     #[arg(long)]
     pub no_default_features: bool,
-    /// Print commands to build without executing them.
+    /// Print commands to build without executing them
     #[arg(long)]
     pub print_commands_only: bool,
 }

--- a/cmd/soroban-cli/src/commands/contract/build.rs
+++ b/cmd/soroban-cli/src/commands/contract/build.rs
@@ -35,17 +35,18 @@ pub struct Cmd {
     #[arg(long, default_value = "release")]
     pub profile: String,
     /// Build with the list of features activated, space or comma separated
-    #[arg(long)]
+    #[arg(long, help_heading = "Features")]
     pub features: Option<String>,
     /// Build with the all features activated
     #[arg(
         long,
         conflicts_with = "features",
-        conflicts_with = "no_default_features"
+        conflicts_with = "no_default_features",
+        help_heading = "Features"
     )]
     pub all_features: bool,
     /// Build with the default feature not activated
-    #[arg(long)]
+    #[arg(long, help_heading = "Features")]
     pub no_default_features: bool,
     /// Directory to copy wasm files to
     ///
@@ -56,7 +57,7 @@ pub struct Cmd {
     #[arg(long)]
     pub out_dir: Option<std::path::PathBuf>,
     /// Print commands to build without executing them
-    #[arg(long, conflicts_with = "out_dir")]
+    #[arg(long, conflicts_with = "out_dir", help_heading = "Other")]
     pub print_commands_only: bool,
 }
 

--- a/cmd/soroban-cli/src/commands/contract/build.rs
+++ b/cmd/soroban-cli/src/commands/contract/build.rs
@@ -54,6 +54,8 @@ impl Cmd {
             let mut cmd = Command::new("cargo");
             cmd.stdout(Stdio::piped());
             cmd.arg("rustc");
+            // TODO: Convert the manifest path into a relative path if possible,
+            // to improve the console output.
             cmd.arg(format!("--manifest-path={}", p.manifest_path));
             cmd.arg("--crate-type=cdylib");
             cmd.arg("--target=wasm32-unknown-unknown");

--- a/cmd/soroban-cli/src/commands/contract/build.rs
+++ b/cmd/soroban-cli/src/commands/contract/build.rs
@@ -28,7 +28,7 @@ pub struct Cmd {
         conflicts_with = "no_default_features"
     )]
     pub features: Option<String>,
-    /// Build with the all features activated, space or comma separated
+    /// Build with the all features activated
     #[arg(
         long,
         conflicts_with = "features",
@@ -60,7 +60,11 @@ impl Cmd {
             cmd.arg("--crate-type=cdylib");
             cmd.arg("--target=wasm32-unknown-unknown");
             cmd.arg(format!("--package={}", p.name));
-            cmd.arg(format!("--profile={}", self.profile));
+            if self.profile == "release" {
+                cmd.arg("--release");
+            } else {
+                cmd.arg(format!("--profile={}", self.profile));
+            }
             if self.all_features {
                 cmd.arg("--all-features");
             }

--- a/cmd/soroban-cli/src/commands/contract/build.rs
+++ b/cmd/soroban-cli/src/commands/contract/build.rs
@@ -79,6 +79,7 @@ impl Cmd {
             cmd.arg("rustc");
             // TODO: Convert the manifest path into a relative path if possible,
             // to improve the console output.
+            cmd.arg("--locked");
             cmd.arg(format!("--manifest-path={}", p.manifest_path));
             cmd.arg("--crate-type=cdylib");
             cmd.arg("--target=wasm32-unknown-unknown");

--- a/cmd/soroban-cli/src/commands/contract/build.rs
+++ b/cmd/soroban-cli/src/commands/contract/build.rs
@@ -83,6 +83,7 @@ impl Cmd {
                 "cargo {}",
                 cmd.get_args().map(OsStr::to_string_lossy).join(" ")
             );
+            // TODO: Pass-through non-zero exit status and break.
             let _ = cmd.status();
         }
 

--- a/cmd/soroban-cli/src/commands/contract/build.rs
+++ b/cmd/soroban-cli/src/commands/contract/build.rs
@@ -84,6 +84,7 @@ impl Cmd {
             cmd.arg("--crate-type=cdylib");
             cmd.arg("--target=wasm32-unknown-unknown");
             cmd.arg(format!("--package={}", p.name));
+            cmd.arg(format!("-o={}.wasm", p.name));
             if self.profile == "release" {
                 cmd.arg("--release");
             } else {

--- a/cmd/soroban-cli/src/commands/contract/mod.rs
+++ b/cmd/soroban-cli/src/commands/contract/mod.rs
@@ -10,7 +10,6 @@ pub mod read;
 
 #[derive(Debug, clap::Subcommand)]
 pub enum Cmd {
-    /// Build a contract from source
     Build(build::Cmd),
 
     /// Generate code client bindings for a contract

--- a/cmd/soroban-cli/src/commands/contract/mod.rs
+++ b/cmd/soroban-cli/src/commands/contract/mod.rs
@@ -1,4 +1,5 @@
 pub mod bindings;
+pub mod build;
 pub mod deploy;
 pub mod fetch;
 pub mod inspect;
@@ -9,6 +10,9 @@ pub mod read;
 
 #[derive(Debug, clap::Subcommand)]
 pub enum Cmd {
+    /// Build a contract from source
+    Build(build::Cmd),
+
     /// Generate code client bindings for a contract
     #[command(subcommand)]
     Bindings(bindings::Cmd),
@@ -45,6 +49,9 @@ pub enum Cmd {
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error(transparent)]
+    Build(#[from] build::Error),
+
+    #[error(transparent)]
     Bindings(#[from] bindings::Error),
 
     #[error(transparent)]
@@ -72,6 +79,7 @@ pub enum Error {
 impl Cmd {
     pub async fn run(&self) -> Result<(), Error> {
         match &self {
+            Cmd::Build(build) => build.run()?,
             Cmd::Bindings(bindings) => bindings.run()?,
             Cmd::Deploy(deploy) => deploy.run().await?,
             Cmd::Inspect(inspect) => inspect.run()?,

--- a/docs/soroban-cli-full-docs.md
+++ b/docs/soroban-cli-full-docs.md
@@ -6,6 +6,7 @@ This document contains the help content for the `soroban` command-line program.
 
 * [`soroban`↴](#soroban)
 * [`soroban contract`↴](#soroban-contract)
+* [`soroban contract build`↴](#soroban-contract-build)
 * [`soroban contract bindings`↴](#soroban-contract-bindings)
 * [`soroban contract bindings json`↴](#soroban-contract-bindings-json)
 * [`soroban contract bindings rust`↴](#soroban-contract-bindings-rust)
@@ -96,6 +97,7 @@ Tools for smart contract developers
 
 ###### **Subcommands:**
 
+* `build` — Build a contract from source
 * `bindings` — Generate code client bindings for a contract
 * `deploy` — Deploy a contract
 * `fetch` — Fetch a contract's Wasm binary from a network or local sandbox
@@ -104,6 +106,25 @@ Tools for smart contract developers
 * `invoke` — Invoke a contract function
 * `optimize` — Optimize a WASM file
 * `read` — Print the current value of a contract-data ledger entry
+
+
+
+## `soroban contract build`
+
+Build a contract from source
+
+**Usage:** `soroban contract build [OPTIONS]`
+
+###### **Options:**
+
+* `--manifest-path <MANIFEST_PATH>` — Path to Cargo.toml
+* `--package <PACKAGE>` — Package to build
+* `--profile <PROFILE>` — Build with the specified profile
+
+  Default value: `release`
+* `--features <FEATURES>` — Build with the list of features activated, space or comma separated
+* `--all-features` — Build with the all features activated, space or comma separated
+* `--no-default-features` — Build with the default feature not activated
 
 
 

--- a/docs/soroban-cli-full-docs.md
+++ b/docs/soroban-cli-full-docs.md
@@ -113,18 +113,26 @@ Tools for smart contract developers
 
 Build a contract from source
 
+Builds all crates that are referenced by the cargo manifest (Cargo.toml) that have cdylib as their crate-type. Crates are built for the wasm32 target. Unless configured otherwise, crates are built with their default features and with their release profile.
+
+To view the commands that will be executed, without executing them, use the --print-commands-only option.
+
 **Usage:** `soroban contract build [OPTIONS]`
 
 ###### **Options:**
 
 * `--manifest-path <MANIFEST_PATH>` — Path to Cargo.toml
+
+  Default value: `Cargo.toml`
 * `--package <PACKAGE>` — Package to build
 * `--profile <PROFILE>` — Build with the specified profile
 
   Default value: `release`
 * `--features <FEATURES>` — Build with the list of features activated, space or comma separated
-* `--all-features` — Build with the all features activated, space or comma separated
+* `--all-features` — Build with the all features activated
 * `--no-default-features` — Build with the default feature not activated
+* `--out-dir <OUT_DIR>` — Directory to copy wasm files to
+* `--print-commands-only` — Print commands to build without executing them
 
 
 


### PR DESCRIPTION
### What
Add command for building contracts:

```
soroban contract build
```

```
❯ soroban contract build -h
Build a contract from source

Usage: soroban contract build [OPTIONS]

Options:
      --manifest-path <MANIFEST_PATH>  Path to Cargo.toml [default: Cargo.toml]
      --package <PACKAGE>              Package to build
      --profile <PROFILE>              Build with the specified profile [default: release]
      --out-dir <OUT_DIR>              Directory to copy wasm files to
  -h, --help                           Print help (see more with '--help')

Features:
      --features <FEATURES>  Build with the list of features activated, space or comma separated
      --all-features         Build with the all features activated
      --no-default-features  Build with the default feature not activated

Other:
      --print-commands-only  Print commands to build without executing them
```

```
❯ soroban contract build --help
Build a contract from source

Builds all crates that are referenced by the cargo manifest (Cargo.toml) that have cdylib as their crate-type. Crates are built for the wasm32 target. Unless configured otherwise, crates are built with their default features and with their release profile.

To view the commands that will be executed, without executing them, use the --print-commands-only option.

Usage: soroban contract build [OPTIONS]

Options:
      --manifest-path <MANIFEST_PATH>
          Path to Cargo.toml
          
          [default: Cargo.toml]

      --package <PACKAGE>
          Package to build
          
          If omitted, all packages that build for crate-type cdylib are built.

      --profile <PROFILE>
          Build with the specified profile
          
          [default: release]

      --out-dir <OUT_DIR>
          Directory to copy wasm files to
          
          If provided, wasm files can be found in the cargo target directory, and the specified directory.
          
          If ommitted, wasm files are written only to the cargo target directory.

  -h, --help
          Print help (see a summary with '-h')

Features:
      --features <FEATURES>
          Build with the list of features activated, space or comma separated

      --all-features
          Build with the all features activated

      --no-default-features
          Build with the default feature not activated

Other:
      --print-commands-only
          Print commands to build without executing them
```

### Why

The commands for building contracts are getting increasingly complex, e.g.:
```
cargo rustc --crate-type cdylib --target wasm32-unknown-unknown --release
```

A build command on soroban-cli has been requested many times. Most recently at: https://discord.com/channels/897514728459468821/1121218101489447054/1121219305133064284

Related to https://github.com/stellar/soroban-docs/pull/476