### PR TITLE
Remove unnecessary rustc options

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/build.rs
+++ b/cmd/soroban-cli/src/commands/contract/build.rs
@@ -101,14 +101,12 @@ impl Cmd {
             cmd.arg("rustc");
             let manifest_path = pathdiff::diff_paths(&p.manifest_path, &working_dir)
                 .unwrap_or(p.manifest_path.clone().into());
-            cmd.arg("--locked");
             cmd.arg(format!(
                 "--manifest-path={}",
                 manifest_path.to_string_lossy()
             ));
             cmd.arg("--crate-type=cdylib");
             cmd.arg("--target=wasm32-unknown-unknown");
-            cmd.arg(format!("--package={}", p.name)); // TODO: Is this line necessary? I think not.
             if self.profile == "release" {
                 cmd.arg("--release");
             } else {
@@ -128,8 +126,6 @@ impl Cmd {
                     cmd.arg(format!("--features={activate}"));
                 }
             }
-            // cmd.arg("--");
-            // cmd.arg(format!("-o={}.wasm", p.name));
             let cmd_str = format!(
                 "cargo {}",
                 cmd.get_args().map(OsStr::to_string_lossy).join(" ")


### PR DESCRIPTION
### What
Remove rustc options:
- `--locked`
- `--package`

### Why

The locked option prevents someone from having their Cargo.lock file updated, so it will be surprising / annoying to have in there. I had added it mistakenly thinking someone would only run the build command for final releasing, but likely it'll be used during development too, and it should update the file.

The package option is unnecessary, since each manifest the tool is passing to rustc is a single package.