### PR TITLE
Add CODEOWNERS to keep contract committers automatically mentioned on changes to soroban contract build

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Involve the contract committer team when making changes to the soroban
+# contract build command.
+/cmd/soroban-cli/src/commands/contract/build.rs         @stellar/contract-committers


### PR DESCRIPTION
### What
Add CODEOWNERS with @stellar/contract-committers listed as owners of the soroban contract build command.

### Why
So that @stellar/contract-committers are mentioned automatically whenever the build command is being altered or changed. They're responsible for the developer experience developing contracts themselves, and will ensure they stay up to date with the build command if it evolves over time.

Note that this will not require them to approve changes, because the repos is configured not to require code owners approval, so it will have no impact on developer workflows and just serve as a way to knowledge share and keep the team in the loop. Although involving them in changes to the build command would probably be a good idea.