### PR TITLE
Upload after publish of crates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,7 @@ jobs:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   upload:
+    needs: publish
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### What
Build and upload soroban-cli after publish is complete.

### Why
The package process we use for building for uploading is dependent on the publishing being complete. This is because of the same reason we had to make these changes:
- https://github.com/stellar/actions/pull/54
- https://github.com/stellar/soroban-tools/pull/709

Without this change the upload job will fail because it expects crates that are dependencies of soroban-cli are already published. If you wait till the publish job completes, and rerun the upload, the upload will succeed.

We could do some fancy things to make this work entirely locally, like how we do publish dry runs, but simply delaying upload until after publish is simpler.