### PR TITLE
Enable diagnostic debug level in sandbox

### DIFF
--- a/cmd/soroban-cli/Cargo.toml
+++ b/cmd/soroban-cli/Cargo.toml
@@ -35,11 +35,7 @@ default = []
 opt = ["dep:wasm-opt"]
 
 [dependencies]
-soroban-env-host = { workspace = true, features = [
-    "vm",
-    "serde",
-    "hostfn_log_fmt_values",
-] }
+soroban-env-host = { workspace = true, features = ["vm", "serde"] }
 soroban-spec = { workspace = true }
 soroban-spec-tools = { workspace = true }
 soroban-spec-typescript = { workspace = true }

--- a/cmd/soroban-cli/src/commands/lab/token/wrap.rs
+++ b/cmd/soroban-cli/src/commands/lab/token/wrap.rs
@@ -12,7 +12,7 @@ use soroban_env_host::{
         PublicKey, ScContractExecutable, ScVal, SequenceNumber, Transaction, TransactionExt,
         Uint256, VecM, WriteXdr,
     },
-    Host, HostError,
+    DiagnosticLevel, Host, HostError,
 };
 use std::convert::Infallible;
 use std::{array::TryFromSliceError, fmt::Debug, num::ParseIntError, rc::Rc};
@@ -89,6 +89,8 @@ impl Cmd {
             Storage::with_recording_footprint(snap),
             Budget::default(),
         );
+
+        h.set_diagnostic_level(DiagnosticLevel::Debug);
 
         let mut ledger_info = state.ledger_info();
         ledger_info.sequence_number += 1;


### PR DESCRIPTION
### What
Enable diagnostic debug level in sandbox

### Why
They used to be enabled via a crate feature, but that functionality was converted to a function that gets called.

This needs enabling so that when running in sandbox mode debug events are outputted by a contract that is built with debug assertions enabled.