### PR TITLE
fix(bindings-ts): don't delete existing dirs

### DIFF
--- a/docs/soroban-cli-full-docs.md
+++ b/docs/soroban-cli-full-docs.md
@@ -179,12 +179,12 @@ Generate Rust bindings
 
 Generate a TypeScript / JavaScript package
 
-**Usage:** `soroban contract bindings typescript [OPTIONS] --wasm <WASM> --root-dir <ROOT_DIR> --contract-name <CONTRACT_NAME> --contract-id <CONTRACT_ID>`
+**Usage:** `soroban contract bindings typescript [OPTIONS] --wasm <WASM> --output-dir <OUTPUT_DIR> --contract-name <CONTRACT_NAME> --contract-id <CONTRACT_ID>`
 
 ###### **Options:**
 
 * `--wasm <WASM>` — Path to wasm binary
-* `--root-dir <ROOT_DIR>` — where to place generated project
+* `--output-dir <OUTPUT_DIR>` — where to place generated project
 * `--contract-name <CONTRACT_NAME>`
 * `--contract-id <CONTRACT_ID>`
 * `--global` — Use global config


### PR DESCRIPTION
### What

- Rename `root-dir` to `output-dir` to clarify the intent
- If `output-dir` already exists, use `output-dir/contract-name` instead

### Why

The old argument name and behavior made it too easy to accidentally
delete your entire project

### Known limitations

N/A