### PR TITLE
feat: long listing for identities

### DIFF
--- a/cmd/soroban-cli/src/commands/config/identity/ls.rs
+++ b/cmd/soroban-cli/src/commands/config/identity/ls.rs
@@ -12,11 +12,23 @@ pub enum Error {
 pub struct Cmd {
     #[command(flatten)]
     pub config_locator: locator::Args,
+    /// Get more info about the identities
+    #[arg(long, short = 'l')]
+    pub long: bool,
 }
 
 impl Cmd {
     pub fn run(&self) -> Result<(), Error> {
-        println!("{}", self.config_locator.list_identities()?.join("\n"));
+        let res = if self.long { self.ls_l() } else { self.ls() }?.join("\n");
+        println!("{res}");
         Ok(())
+    }
+
+    pub fn ls(&self) -> Result<Vec<String>, Error> {
+        Ok(self.config_locator.list_identities()?)
+    }
+
+    pub fn ls_l(&self) -> Result<Vec<String>, Error> {
+        Ok(self.config_locator.list_identities_long()?)
     }
 }

--- a/cmd/soroban-cli/src/commands/config/identity/mod.rs
+++ b/cmd/soroban-cli/src/commands/config/identity/mod.rs
@@ -16,6 +16,7 @@ pub enum Cmd {
     /// Generate a new identity with a seed phrase, currently 12 words
     Generate(generate::Cmd),
     /// List identities
+    #[command(aliases = ["list"])]
     Ls(ls::Cmd),
     /// Remove an identity
     Rm(rm::Cmd),

--- a/cmd/soroban-cli/src/commands/config/locator.rs
+++ b/cmd/soroban-cli/src/commands/config/locator.rs
@@ -152,6 +152,20 @@ impl Args {
             .collect())
     }
 
+    pub fn list_identities_long(&self) -> Result<Vec<String>, Error> {
+        Ok(KeyType::Identity
+            .list_paths(&self.local_and_global()?)
+            .into_iter()
+            .flatten()
+            .map(|(_, location)| {
+                let path = match location {
+                    Location::Local(path) | Location::Global(path) => path,
+                };
+                format!("{}", path.display())
+            })
+            .collect())
+    }
+
     pub fn list_networks(&self) -> Result<Vec<String>, Error> {
         Ok(KeyType::Network
             .list_paths(&self.local_and_global()?)

--- a/docs/soroban-cli-full-docs.md
+++ b/docs/soroban-cli-full-docs.md
@@ -452,6 +452,7 @@ List identities
 
 * `--global` — Use global config
 * `--config-dir <CONFIG_DIR>`
+* `-l`, `--long` — Get more info about the identities
 
 
 


### PR DESCRIPTION
### What

`soroban config identity ls -l`, inspired by `soroban config network ls -l`.

Also add a `soroban config identity list` alias.

### Why

I originally expected it at `list`, hence the alias.

The long-listing just shows full path to identity file. I was trying to figure
out where some defined identities were coming from while troubleshooting.

### Known limitations

This is a bit simpler in implementation than the networks long-list. The
important information for identities is, in my opinion, just the path where the
identity file lives. So this just lists those. Happy to discuss the
implementation specifics, though!

Example:

    $ soroban config identity ls -l
    /Users/chadoh/code/soroban/dapp/.soroban/identity/token-admin.toml
    /Users/chadoh/.config/soroban/identity/default.toml