### PR TITLE
soroban-rpc: Fix integration test phrasing

### DIFF
--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -599,7 +599,7 @@ func TestSimulateTransactionWithoutInvokeHostFunction(t *testing.T) {
 	assert.Equal(
 		t,
 		methods.SimulateTransactionResponse{
-			Error: "Transaction contains unsupported operation type: OperationTypeBumpSequenc",
+			Error: "Transaction contains unsupported operation type: OperationTypeBumpSequence",
 		},
 		result,
 	)

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -599,7 +599,7 @@ func TestSimulateTransactionWithoutInvokeHostFunction(t *testing.T) {
 	assert.Equal(
 		t,
 		methods.SimulateTransactionResponse{
-			Error: "Transaction does not contain invoke host function operation",
+			Error: "Transaction contains unsupported operation type: OperationTypeBumpSequenc",
 		},
 		result,
 	)


### PR DESCRIPTION
### What

Fix the expected phrase in a soroban-rpc integration test

### Why

Got missed in a #730, I assume because all the tests have been broken for so long that lone failures are hard to catch.

### Known limitations

[TODO or N/A]
