### PR TITLE
Fix bug in cli lab xdr decode --type parsing

### DIFF
--- a/cmd/soroban-cli/src/commands/lab/xdr/decode.rs
+++ b/cmd/soroban-cli/src/commands/lab/xdr/decode.rs
@@ -1,11 +1,21 @@
-use clap::{arg, Parser, ValueEnum};
+use clap::{
+    arg,
+    builder::{PossibleValuesParser, TypedValueParser},
+    Parser, ValueEnum,
+};
+use core::str::FromStr;
 use soroban_env_host::xdr;
 
 #[derive(Parser, Debug, Clone)]
 #[group(skip)]
 pub struct Cmd {
     /// XDR type to decode to
-    #[arg(long, value_parser(xdr::TypeVariant::VARIANTS_STR))]
+    #[arg(
+        long,
+        value_parser =
+            PossibleValuesParser::new(xdr::TypeVariant::VARIANTS_STR)
+                .try_map(|s| xdr::TypeVariant::from_str(&s))
+    )]
     r#type: xdr::TypeVariant,
     /// XDR (base64 encoded) to decode
     #[arg(long)]


### PR DESCRIPTION
### What

Fix `--type` flag parsing in `soroban xdr lab decode` subcommand.

### Why

I was hitting it when trying to debug other failing transactions. Turns out we need a `try_map` to tell clap how to convert the string into a `TypeVariant`. No idea how it ever worked tbh. Maybe some subtle xdr upgrade change broke it.

Previously you would get:
```
thread 'main' panicked at 'Mismatch between definition and access of `type`. Could not downcast to stellar_xdr::next::generated::TypeVariant, need to downcast to alloc::string::String
', cmd/soroban-cli/src/commands/lab/xdr/decode.rs:9:13
```

### Known limitations

[TODO or N/A]
