### PR TITLE
soroban-cli: Verify the network passphrase provided matches the server

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/deploy.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy.rs
@@ -166,6 +166,9 @@ impl Cmd {
         };
 
         let client = Client::new(&network.rpc_url)?;
+        client
+            .verify_network_passphrase(Some(&network.network_passphrase))
+            .await?;
         let key = self.config.key_pair()?;
 
         // Get the account sequence number

--- a/cmd/soroban-cli/src/commands/contract/fetch.rs
+++ b/cmd/soroban-cli/src/commands/contract/fetch.rs
@@ -138,6 +138,9 @@ impl Cmd {
         tracing::trace!(?network);
         let contract_id = self.contract_id()?;
         let client = Client::new(&network.rpc_url)?;
+        client
+            .verify_network_passphrase(Some(&network.network_passphrase))
+            .await?;
         // async closures are not yet stable
         Ok(client.get_remote_wasm(&contract_id).await?)
     }

--- a/cmd/soroban-cli/src/commands/contract/install.rs
+++ b/cmd/soroban-cli/src/commands/contract/install.rs
@@ -73,6 +73,9 @@ impl Cmd {
     async fn run_against_rpc_server(&self, contract: Vec<u8>) -> Result<Hash, Error> {
         let network = self.config.get_network()?;
         let client = Client::new(&network.rpc_url)?;
+        client
+            .verify_network_passphrase(Some(&network.network_passphrase))
+            .await?;
         let key = self.config.key_pair()?;
 
         // Get the account sequence number

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -251,8 +251,10 @@ impl Cmd {
         let network = self.config.get_network()?;
         tracing::trace!(?network);
         let contract_id = self.contract_id()?;
-        let network = &self.config.get_network()?;
         let client = Client::new(&network.rpc_url)?;
+        client
+            .verify_network_passphrase(Some(&network.network_passphrase))
+            .await?;
         let key = self.config.key_pair()?;
 
         // Get the account sequence number

--- a/cmd/soroban-cli/src/commands/events.rs
+++ b/cmd/soroban-cli/src/commands/events.rs
@@ -4,7 +4,6 @@ use std::io;
 use soroban_env_host::xdr::{self, ReadXdr};
 
 use super::config::{events_file, locator, network};
-use crate::commands::config::network::Network;
 use crate::{rpc, toid, utils};
 
 #[derive(Parser, Debug, Clone)]
@@ -235,9 +234,12 @@ impl Cmd {
 
     async fn run_against_rpc_server(&self) -> Result<rpc::GetEventsResponse, Error> {
         let start = self.start()?;
-        let Network { rpc_url, .. } = self.network.get(&self.locator)?;
+        let network = self.network.get(&self.locator)?;
 
-        let client = rpc::Client::new(&rpc_url)?;
+        let client = rpc::Client::new(&network.rpc_url)?;
+        client
+            .verify_network_passphrase(Some(&network.network_passphrase))
+            .await?;
         client
             .get_events(
                 start,

--- a/cmd/soroban-cli/src/commands/lab/token/wrap.rs
+++ b/cmd/soroban-cli/src/commands/lab/token/wrap.rs
@@ -104,6 +104,9 @@ impl Cmd {
     async fn run_against_rpc_server(&self, asset: Asset) -> Result<String, Error> {
         let network = self.config.get_network()?;
         let client = Client::new(&network.rpc_url)?;
+        client
+            .verify_network_passphrase(Some(&network.network_passphrase))
+            .await?;
         let key = self.config.key_pair()?;
 
         // Get the account sequence number


### PR DESCRIPTION
### What

Before we try to talk to the server, check the network_passphrase configured locally matches what the server reports.

For example, the error if you had configured to talk to futurenet, but the server you were talking to is on standalone would look like:
```
error: provided network passphrase "Test SDF Future Network ; October 2022" does not match the server: "Standalone Network ; February 2017"
```

### Why

This can prevent confusing and difficult-to-debug errors.

### Known limitations

I had debated doing it in-line as part of the `Client::new` call, but that is currently not async. And I thought there might be cases where we want to use the client, but know the network passphrase doesn't matter. So, for now, there is a bit of boilerplate when we create a new client.