### PR TITLE
soroban-cli: fix contract deploy

### DIFF
--- a/cmd/crates/soroban-test/src/wasm.rs
+++ b/cmd/crates/soroban-test/src/wasm.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Display, fs, path::PathBuf};
 
 use sha2::{Digest, Sha256};
-use soroban_env_host::xdr::{self, WriteXdr};
+use soroban_env_host::xdr;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -50,9 +50,7 @@ impl Wasm<'_> {
     /// # Errors
     ///
     pub fn hash(&self) -> Result<xdr::Hash, Error> {
-        let args_bytes: xdr::BytesM = self.bytes().try_into()?;
-        let args_xdr = args_bytes.to_xdr()?;
-        Ok(xdr::Hash(Sha256::digest(args_xdr).into()))
+        Ok(xdr::Hash(Sha256::digest(self.bytes()).into()))
     }
 }
 

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -286,7 +286,7 @@ impl Cmd {
             tracing::debug!(?events);
         }
 
-        let xdr::TransactionMeta::V3(xdr::TransactionMetaV3{soroban_meta: Some(xdr::SorobanTransactionMeta{return_value, ..}), ..}) = meta.tx_apply_processing else {
+        let xdr::TransactionMeta::V3(xdr::TransactionMetaV3{soroban_meta: Some(xdr::SorobanTransactionMeta{return_value, ..}), ..}) = meta else {
             return Err(Error::MissingOperationResult);
         };
 

--- a/cmd/soroban-cli/src/rpc/mod.rs
+++ b/cmd/soroban-cli/src/rpc/mod.rs
@@ -11,8 +11,7 @@ use soroban_env_host::{
         self, AccountEntry, AccountId, ContractDataEntry, DiagnosticEvent, Error as XdrError,
         LedgerEntryData, LedgerFootprint, LedgerKey, LedgerKeyAccount, PublicKey, ReadXdr,
         SorobanAuthorizationEntry, Transaction, TransactionEnvelope, TransactionMeta,
-        TransactionMetaV3, TransactionResult, TransactionResultMeta, TransactionV1Envelope,
-        Uint256, VecM, WriteXdr,
+        TransactionMetaV3, TransactionResult, TransactionV1Envelope, Uint256, VecM, WriteXdr,
     },
 };
 use soroban_sdk::token;
@@ -454,14 +453,7 @@ impl Client {
     pub async fn send_transaction(
         &self,
         tx: &TransactionEnvelope,
-    ) -> Result<
-        (
-            TransactionResult,
-            TransactionResultMeta,
-            Vec<DiagnosticEvent>,
-        ),
-        Error,
-    > {
+    ) -> Result<(TransactionResult, TransactionMeta, Vec<DiagnosticEvent>), Error> {
         let client = self.client()?;
         tracing::trace!(?tx);
         let SendTransactionResponse {
@@ -498,16 +490,13 @@ impl Client {
                     let result = TransactionResult::from_xdr_base64(
                         response.result_xdr.clone().ok_or(Error::MissingResult)?,
                     )?;
-                    let meta = TransactionResultMeta::from_xdr_base64(
+                    let meta = TransactionMeta::from_xdr_base64(
                         response
                             .result_meta_xdr
                             .clone()
                             .ok_or(Error::MissingResult)?,
                     )?;
-                    let events = match response.result_meta_xdr {
-                        None => Vec::new(),
-                        Some(m) => extract_events(TransactionMeta::from_xdr_base64(m)?),
-                    };
+                    let events = extract_events(&meta);
                     return Ok((result, meta, events));
                 }
                 "FAILED" => {
@@ -569,14 +558,7 @@ impl Client {
         key: &ed25519_dalek::Keypair,
         network_passphrase: &str,
         log_events: Option<LogEvents>,
-    ) -> Result<
-        (
-            TransactionResult,
-            TransactionResultMeta,
-            Vec<DiagnosticEvent>,
-        ),
-        Error,
-    > {
+    ) -> Result<(TransactionResult, TransactionMeta, Vec<DiagnosticEvent>), Error> {
         let unsigned_tx = self
             .prepare_transaction(tx_without_preflight, log_events)
             .await?;
@@ -735,7 +717,7 @@ impl Client {
     }
 }
 
-fn extract_events(tx_meta: TransactionMeta) -> Vec<DiagnosticEvent> {
+fn extract_events(tx_meta: &TransactionMeta) -> Vec<DiagnosticEvent> {
     match tx_meta {
         TransactionMeta::V3(TransactionMetaV3 {
             soroban_meta: Some(meta),
@@ -743,7 +725,7 @@ fn extract_events(tx_meta: TransactionMeta) -> Vec<DiagnosticEvent> {
         }) => {
             // NOTE: we assume there can only be one operation, since we only send one
             if meta.diagnostic_events.len() == 1 {
-                meta.diagnostic_events.into()
+                meta.diagnostic_events.clone().into()
             } else if meta.events.len() == 1 {
                 meta.events
                     .iter()

--- a/cmd/soroban-cli/src/utils.rs
+++ b/cmd/soroban-cli/src/utils.rs
@@ -8,14 +8,14 @@ use soroban_env_host::{
     expiration_ledger_bumps::ExpirationLedgerBumps,
     storage::{AccessType, Footprint, Storage},
     xdr::{
-        AccountEntry, AccountEntryExt, AccountId, Asset, BytesM, ContractCodeEntry,
-        ContractCodeEntryBody, ContractDataDurability, ContractDataEntry, ContractDataEntryBody,
-        ContractDataEntryData, ContractEntryBodyType, ContractExecutable, ContractIdPreimage,
-        DecoratedSignature, Error as XdrError, ExtensionPoint, Hash, HashIdPreimage,
-        HashIdPreimageContractId, LedgerEntry, LedgerEntryData, LedgerEntryExt, LedgerFootprint,
-        LedgerKey, LedgerKeyContractCode, LedgerKeyContractData, ScAddress, ScContractInstance,
-        ScSpecEntry, ScVal, SequenceNumber, Signature, SignatureHint, String32, Thresholds,
-        Transaction, TransactionEnvelope, TransactionSignaturePayload,
+        AccountEntry, AccountEntryExt, AccountId, Asset, ContractCodeEntry, ContractCodeEntryBody,
+        ContractDataDurability, ContractDataEntry, ContractDataEntryBody, ContractDataEntryData,
+        ContractEntryBodyType, ContractExecutable, ContractIdPreimage, DecoratedSignature,
+        Error as XdrError, ExtensionPoint, Hash, HashIdPreimage, HashIdPreimageContractId,
+        LedgerEntry, LedgerEntryData, LedgerEntryExt, LedgerFootprint, LedgerKey,
+        LedgerKeyContractCode, LedgerKeyContractData, ScAddress, ScContractInstance, ScSpecEntry,
+        ScVal, SequenceNumber, Signature, SignatureHint, String32, Thresholds, Transaction,
+        TransactionEnvelope, TransactionSignaturePayload,
         TransactionSignaturePayloadTaggedTransaction, TransactionV1Envelope, VecM, WriteXdr,
     },
 };
@@ -32,9 +32,7 @@ pub mod contract_spec;
 ///
 /// Might return an error
 pub fn contract_hash(contract: &[u8]) -> Result<Hash, XdrError> {
-    let args_bytes: BytesM = contract.try_into()?;
-    let args_xdr = args_bytes.to_xdr()?;
-    Ok(Hash(Sha256::digest(args_xdr).into()))
+    Ok(Hash(Sha256::digest(contract).into()))
 }
 
 /// # Errors


### PR DESCRIPTION
### What

Fix two bugs preventing contract deploy from working.
- When updating the xdr in this branch, I had used `TransactionResultMeta`, but it should be `TransactionMeta` from soroban-rpc.
- Contract code hashes are now just `hash(code)`, not a `hash(xdr(BytesM(code)))`
  - @dmkozh is this ^ true?
