### PR TITLE
soroban-rpc: Restore footprint  preflighting fixes

### DIFF
--- a/cmd/soroban-rpc/internal/db/ledgerentry_test.go
+++ b/cmd/soroban-rpc/internal/db/ledgerentry_test.go
@@ -32,7 +32,7 @@ func getLedgerEntryAndLatestLedgerSequenceWithErr(db db.SessionInterface, key xd
 		return false, xdr.LedgerEntry{}, 0, err
 	}
 
-	present, entry, err := tx.GetLedgerEntry(key)
+	present, entry, err := tx.GetLedgerEntry(key, false)
 	if err != nil {
 		return false, xdr.LedgerEntry{}, 0, err
 	}
@@ -497,14 +497,14 @@ func TestReadTxsDuringWriteTx(t *testing.T) {
 
 	_, err = readTx1.GetLatestLedgerSequence()
 	assert.Equal(t, ErrEmptyDB, err)
-	present, _, err := readTx1.GetLedgerEntry(key)
+	present, _, err := readTx1.GetLedgerEntry(key, false)
 	assert.NoError(t, err)
 	assert.False(t, present)
 	assert.NoError(t, readTx1.Done())
 
 	_, err = readTx2.GetLatestLedgerSequence()
 	assert.Equal(t, ErrEmptyDB, err)
-	present, _, err = readTx2.GetLedgerEntry(key)
+	present, _, err = readTx2.GetLedgerEntry(key, false)
 	assert.NoError(t, err)
 	assert.False(t, present)
 	assert.NoError(t, readTx2.Done())
@@ -581,7 +581,7 @@ func TestWriteTxsDuringReadTxs(t *testing.T) {
 	for _, readTx := range []LedgerEntryReadTx{readTx1, readTx2, readTx3} {
 		_, err = readTx.GetLatestLedgerSequence()
 		assert.Equal(t, ErrEmptyDB, err)
-		present, _, err := readTx.GetLedgerEntry(key)
+		present, _, err := readTx.GetLedgerEntry(key, false)
 		assert.NoError(t, err)
 		assert.False(t, present)
 	}
@@ -593,7 +593,7 @@ func TestWriteTxsDuringReadTxs(t *testing.T) {
 	for _, readTx := range []LedgerEntryReadTx{readTx1, readTx2, readTx3} {
 		_, err = readTx.GetLatestLedgerSequence()
 		assert.Equal(t, ErrEmptyDB, err)
-		present, _, err := readTx.GetLedgerEntry(key)
+		present, _, err := readTx.GetLedgerEntry(key, false)
 		assert.NoError(t, err)
 		assert.False(t, present)
 	}

--- a/cmd/soroban-rpc/internal/methods/get_latest_ledger_test.go
+++ b/cmd/soroban-rpc/internal/methods/get_latest_ledger_test.go
@@ -6,8 +6,9 @@ import (
 
 	"github.com/creachadair/jrpc2"
 	"github.com/stellar/go/xdr"
-	"github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/db"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/db"
 )
 
 const (
@@ -37,7 +38,7 @@ func (entryReaderTx ConstantLedgerEntryReaderTx) GetLatestLedgerSequence() (uint
 	return expectedLatestLedgerSequence, nil
 }
 
-func (entryReaderTx ConstantLedgerEntryReaderTx) GetLedgerEntry(key xdr.LedgerKey) (bool, xdr.LedgerEntry, error) {
+func (entryReaderTx ConstantLedgerEntryReaderTx) GetLedgerEntry(key xdr.LedgerKey, includeExpired bool) (bool, xdr.LedgerEntry, error) {
 	return false, xdr.LedgerEntry{}, nil
 }
 

--- a/cmd/soroban-rpc/internal/methods/get_ledger_entries.go
+++ b/cmd/soroban-rpc/internal/methods/get_ledger_entries.go
@@ -72,7 +72,7 @@ func NewGetLedgerEntriesHandler(logger *log.Entry, ledgerEntryReader db.LedgerEn
 
 		var ledgerEntryResults []LedgerEntryResult
 		for i, ledgerKey := range ledgerKeys {
-			present, ledgerEntry, err := tx.GetLedgerEntry(ledgerKey)
+			present, ledgerEntry, err := tx.GetLedgerEntry(ledgerKey, false)
 			if err != nil {
 				logger.WithError(err).WithField("request", request).
 					Infof("could not obtain ledger entry %v at index %d from storage", ledgerKey, i)

--- a/cmd/soroban-rpc/internal/methods/get_ledger_entry.go
+++ b/cmd/soroban-rpc/internal/methods/get_ledger_entry.go
@@ -62,7 +62,7 @@ func NewGetLedgerEntryHandler(logger *log.Entry, ledgerEntryReader db.LedgerEntr
 			}
 		}
 
-		present, ledgerEntry, err := tx.GetLedgerEntry(key)
+		present, ledgerEntry, err := tx.GetLedgerEntry(key, false)
 		if err != nil {
 			logger.WithError(err).WithField("request", request).
 				Info("could not obtain ledger entry from storage")

--- a/cmd/soroban-rpc/internal/preflight/pool.go
+++ b/cmd/soroban-rpc/internal/preflight/pool.go
@@ -127,9 +127,9 @@ type metricsLedgerEntryWrapper struct {
 	ledgerEntriesFetched uint32
 }
 
-func (m *metricsLedgerEntryWrapper) GetLedgerEntry(key xdr.LedgerKey) (bool, xdr.LedgerEntry, error) {
+func (m *metricsLedgerEntryWrapper) GetLedgerEntry(key xdr.LedgerKey, includeExpired bool) (bool, xdr.LedgerEntry, error) {
 	startTime := time.Now()
-	ok, entry, err := m.LedgerEntryReadTx.GetLedgerEntry(key)
+	ok, entry, err := m.LedgerEntryReadTx.GetLedgerEntry(key, includeExpired)
 	atomic.AddUint64(&m.totalDurationMs, uint64(time.Since(startTime).Milliseconds()))
 	atomic.AddUint32(&m.ledgerEntriesFetched, 1)
 	return ok, entry, err

--- a/cmd/soroban-rpc/lib/preflight.h
+++ b/cmd/soroban-rpc/lib/preflight.h
@@ -35,7 +35,7 @@ CPreflightResult *preflight_footprint_expiration_op(uintptr_t handle, // Go Hand
                                                     const char *footprint); // LedgerFootprint XDR in base64
 
 // LedgerKey XDR in base64 string to LedgerEntry XDR in base64 string
-extern char *SnapshotSourceGet(uintptr_t handle, char *ledger_key);
+extern char *SnapshotSourceGet(uintptr_t handle, char *ledger_key, int include_expired);
 
 // LedgerKey XDR in base64 string to bool
 extern int SnapshotSourceHas(uintptr_t handle, char *ledger_key);

--- a/cmd/soroban-rpc/lib/preflight/src/fees.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/fees.rs
@@ -120,9 +120,9 @@ fn calculate_host_function_soroban_resources(
       metadataSize = readBytes(footprint.readWrite) + writeBytes + eventsSize
     */
     let original_write_ledger_entry_bytes =
-        calculate_unmodified_ledger_entry_bytes(fp.read_write.as_vec(), snapshot_source)?;
+        calculate_unmodified_ledger_entry_bytes(fp.read_write.as_vec(), snapshot_source, false)?;
     let read_bytes =
-        calculate_unmodified_ledger_entry_bytes(fp.read_only.as_vec(), snapshot_source)?
+        calculate_unmodified_ledger_entry_bytes(fp.read_only.as_vec(), snapshot_source, false)?
             + original_write_ledger_entry_bytes;
     let write_bytes =
         calculate_modified_read_write_ledger_entry_bytes(&storage.footprint, &storage.map, budget)?;
@@ -150,7 +150,7 @@ fn get_configuration_setting(
     let key = LedgerKey::ConfigSetting(LedgerKeyConfigSetting {
         config_setting_id: setting_id,
     });
-    match ledger_storage.get(&key)? {
+    match ledger_storage.get(&key, false)? {
         LedgerEntry {
             data: LedgerEntryData::ConfigSetting(cs),
             ..
@@ -241,11 +241,12 @@ fn calculate_modified_read_write_ledger_entry_bytes(
 fn calculate_unmodified_ledger_entry_bytes(
     ledger_entries: &Vec<LedgerKey>,
     snapshot_source: &ledger_storage::LedgerStorage,
+    include_expired: bool,
 ) -> Result<u32, Box<dyn error::Error>> {
     let mut res: u32 = 0;
     for lk in ledger_entries {
         res += u32::try_from(lk.to_xdr()?.len())?;
-        match snapshot_source.get_xdr(lk) {
+        match snapshot_source.get_xdr(lk, include_expired) {
             Ok(entry_bytes) => {
                 res += u32::try_from(entry_bytes.len())?;
             }
@@ -295,8 +296,11 @@ pub(crate) fn compute_bump_footprint_exp_transaction_data_and_min_fee(
     ledgers_to_expire: u32,
     snapshot_source: &ledger_storage::LedgerStorage,
 ) -> Result<(SorobanTransactionData, i64), Box<dyn error::Error>> {
-    let read_bytes =
-        calculate_unmodified_ledger_entry_bytes(footprint.read_only.as_vec(), snapshot_source)?;
+    let read_bytes = calculate_unmodified_ledger_entry_bytes(
+        footprint.read_only.as_vec(),
+        snapshot_source,
+        false,
+    )?;
     let soroban_resources = SorobanResources {
         footprint,
         instructions: 0,
@@ -334,20 +338,26 @@ pub(crate) fn compute_restore_footprint_transaction_data_and_min_fee(
     footprint: LedgerFootprint,
     snapshot_source: &ledger_storage::LedgerStorage,
 ) -> Result<(SorobanTransactionData, i64), Box<dyn error::Error>> {
-    let write_bytes =
-        calculate_unmodified_ledger_entry_bytes(footprint.read_write.as_vec(), snapshot_source)?;
+    let write_bytes = calculate_unmodified_ledger_entry_bytes(
+        footprint.read_write.as_vec(),
+        snapshot_source,
+        true,
+    )?;
     let soroban_resources = SorobanResources {
         footprint,
         instructions: 0,
-        read_bytes: 0,
+        // FIXME(fons): this seems to be a workaround a bug in code (the fix is to also count bytes read but not written in readBytes).
+        //        we should review it in preview 11.
+        read_bytes: write_bytes,
         write_bytes,
         extended_meta_data_size_bytes: 2 * write_bytes,
     };
+    let entry_count = u32::try_from(soroban_resources.footprint.read_write.as_vec().len())?;
     let transaction_resources = TransactionResources {
         instructions: 0,
-        read_entries: 0,
-        write_entries: u32::try_from(soroban_resources.footprint.read_write.as_vec().len())?,
-        read_bytes: 0,
+        read_entries: entry_count,
+        write_entries: entry_count,
+        read_bytes: soroban_resources.read_bytes,
         write_bytes: soroban_resources.write_bytes,
         metadata_size_bytes: soroban_resources.extended_meta_data_size_bytes,
         transaction_size_bytes: estimate_max_transaction_size_for_operation(


### PR DESCRIPTION
This PR contains fixes for restore footprint preflighting. They are taken from https://github.com/stellar/soroban-tools/pull/757 (which cannot be merged since it contains a test which takes more than 1 hour to run).


