### PR TITLE
Upgrade generated TypeScript with Preview 10 changes

### DIFF
--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/cjs/convert.d.ts
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/cjs/convert.d.ts
@@ -1,5 +1,4 @@
 import { xdr } from 'soroban-client';
-export declare function scvalToBigInt(scval: xdr.ScVal | undefined): BigInt;
 export declare function strToScVal(base64Xdr: string): xdr.ScVal;
 export declare function scValStrToJs<T>(base64Xdr: string): T;
 export declare function scValToJs<T>(val: xdr.ScVal): T;

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/cjs/convert.js
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/cjs/convert.js
@@ -1,41 +1,8 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.u128ToScVal = exports.i128ToScVal = exports.addressToScVal = exports.scValToJs = exports.scValStrToJs = exports.strToScVal = exports.scvalToBigInt = void 0;
+exports.u128ToScVal = exports.i128ToScVal = exports.addressToScVal = exports.scValToJs = exports.scValStrToJs = exports.strToScVal = void 0;
 const soroban_client_1 = require("soroban-client");
 const buffer_1 = require("buffer");
-const bigint_conversion_1 = require("bigint-conversion");
-function scvalToBigInt(scval) {
-    switch (scval?.switch()) {
-        case undefined: {
-            return BigInt(0);
-        }
-        case soroban_client_1.xdr.ScValType.scvU64(): {
-            const { high, low } = scval.u64();
-            return (0, bigint_conversion_1.bufToBigint)(new Uint32Array([high, low]));
-        }
-        case soroban_client_1.xdr.ScValType.scvI64(): {
-            const { high, low } = scval.i64();
-            return (0, bigint_conversion_1.bufToBigint)(new Int32Array([high, low]));
-        }
-        case soroban_client_1.xdr.ScValType.scvU128(): {
-            const parts = scval.u128();
-            const a = parts.hi();
-            const b = parts.lo();
-            return (0, bigint_conversion_1.bufToBigint)(new Uint32Array([a.high, a.low, b.high, b.low]));
-        }
-        case soroban_client_1.xdr.ScValType.scvI128(): {
-            const parts = scval.i128();
-            const a = parts.hi();
-            const b = parts.lo();
-            return (0, bigint_conversion_1.bufToBigint)(new Int32Array([a.high, a.low, b.high, b.low]));
-        }
-        default: {
-            throw new Error(`Invalid type for scvalToBigInt: ${scval?.switch().name}`);
-        }
-    }
-    ;
-}
-exports.scvalToBigInt = scvalToBigInt;
 function strToScVal(base64Xdr) {
     return soroban_client_1.xdr.ScVal.fromXDR(buffer_1.Buffer.from(base64Xdr, 'base64'));
 }
@@ -65,7 +32,7 @@ function scValToJs(val) {
         case soroban_client_1.xdr.ScValType.scvI128():
         case soroban_client_1.xdr.ScValType.scvU256():
         case soroban_client_1.xdr.ScValType.scvI256(): {
-            return scvalToBigInt(val);
+            return scValToBigInt(val);
         }
         case soroban_client_1.xdr.ScValType.scvAddress(): {
             return soroban_client_1.Address.fromScVal(val).toString();
@@ -132,16 +99,10 @@ function addressToScVal(addr) {
 }
 exports.addressToScVal = addressToScVal;
 function i128ToScVal(i) {
-    return soroban_client_1.xdr.ScVal.scvI128(new soroban_client_1.xdr.Int128Parts({
-        lo: soroban_client_1.xdr.Uint64.fromString((i & BigInt(0xffffffffffffffffn)).toString()),
-        hi: soroban_client_1.xdr.Int64.fromString(((i >> BigInt(64)) & BigInt(0xffffffffffffffffn)).toString()),
-    }));
+    return new soroban_client_1.ScInt(i).toI128();
 }
 exports.i128ToScVal = i128ToScVal;
 function u128ToScVal(i) {
-    return soroban_client_1.xdr.ScVal.scvU128(new soroban_client_1.xdr.UInt128Parts({
-        lo: soroban_client_1.xdr.Uint64.fromString((i & BigInt(0xffffffffffffffffn)).toString()),
-        hi: soroban_client_1.xdr.Int64.fromString(((i >> BigInt(64)) & BigInt(0xffffffffffffffffn)).toString()),
-    }));
+    return new soroban_client_1.ScInt(i).toU128();
 }
 exports.u128ToScVal = u128ToScVal;

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/cjs/convert.js
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/cjs/convert.js
@@ -32,7 +32,7 @@ function scValToJs(val) {
         case soroban_client_1.xdr.ScValType.scvI128():
         case soroban_client_1.xdr.ScValType.scvU256():
         case soroban_client_1.xdr.ScValType.scvI256(): {
-            return scValToBigInt(val);
+            return (0, soroban_client_1.scValToBigInt)(val);
         }
         case soroban_client_1.xdr.ScValType.scvAddress(): {
             return soroban_client_1.Address.fromScVal(val).toString();

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/esm/convert.d.ts
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/esm/convert.d.ts
@@ -1,5 +1,4 @@
 import { xdr } from 'soroban-client';
-export declare function scvalToBigInt(scval: xdr.ScVal | undefined): BigInt;
 export declare function strToScVal(base64Xdr: string): xdr.ScVal;
 export declare function scValStrToJs<T>(base64Xdr: string): T;
 export declare function scValToJs<T>(val: xdr.ScVal): T;

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/esm/convert.js
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/esm/convert.js
@@ -1,37 +1,5 @@
-import { Address, xdr } from 'soroban-client';
+import { Address, xdr, scValToBigInt, ScInt } from 'soroban-client';
 import { Buffer } from "buffer";
-import { bufToBigint } from 'bigint-conversion';
-export function scvalToBigInt(scval) {
-    switch (scval?.switch()) {
-        case undefined: {
-            return BigInt(0);
-        }
-        case xdr.ScValType.scvU64(): {
-            const { high, low } = scval.u64();
-            return bufToBigint(new Uint32Array([high, low]));
-        }
-        case xdr.ScValType.scvI64(): {
-            const { high, low } = scval.i64();
-            return bufToBigint(new Int32Array([high, low]));
-        }
-        case xdr.ScValType.scvU128(): {
-            const parts = scval.u128();
-            const a = parts.hi();
-            const b = parts.lo();
-            return bufToBigint(new Uint32Array([a.high, a.low, b.high, b.low]));
-        }
-        case xdr.ScValType.scvI128(): {
-            const parts = scval.i128();
-            const a = parts.hi();
-            const b = parts.lo();
-            return bufToBigint(new Int32Array([a.high, a.low, b.high, b.low]));
-        }
-        default: {
-            throw new Error(`Invalid type for scvalToBigInt: ${scval?.switch().name}`);
-        }
-    }
-    ;
-}
 export function strToScVal(base64Xdr) {
     return xdr.ScVal.fromXDR(Buffer.from(base64Xdr, 'base64'));
 }
@@ -59,7 +27,7 @@ export function scValToJs(val) {
         case xdr.ScValType.scvI128():
         case xdr.ScValType.scvU256():
         case xdr.ScValType.scvI256(): {
-            return scvalToBigInt(val);
+            return scValToBigInt(val);
         }
         case xdr.ScValType.scvAddress(): {
             return Address.fromScVal(val).toString();
@@ -124,14 +92,8 @@ export function addressToScVal(addr) {
     return addrObj.toScVal();
 }
 export function i128ToScVal(i) {
-    return xdr.ScVal.scvI128(new xdr.Int128Parts({
-        lo: xdr.Uint64.fromString((i & BigInt(0xffffffffffffffffn)).toString()),
-        hi: xdr.Int64.fromString(((i >> BigInt(64)) & BigInt(0xffffffffffffffffn)).toString()),
-    }));
+    return new ScInt(i).toI128();
 }
 export function u128ToScVal(i) {
-    return xdr.ScVal.scvU128(new xdr.UInt128Parts({
-        lo: xdr.Uint64.fromString((i & BigInt(0xffffffffffffffffn)).toString()),
-        hi: xdr.Int64.fromString(((i >> BigInt(64)) & BigInt(0xffffffffffffffffn)).toString()),
-    }));
+    return new ScInt(i).toU128();
 }

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/types/convert.d.ts
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/types/convert.d.ts
@@ -1,5 +1,4 @@
 import { xdr } from 'soroban-client';
-export declare function scvalToBigInt(scval: xdr.ScVal | undefined): BigInt;
 export declare function strToScVal(base64Xdr: string): xdr.ScVal;
 export declare function scValStrToJs<T>(base64Xdr: string): T;
 export declare function scValToJs<T>(val: xdr.ScVal): T;

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/package-lock.json
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/package-lock.json
@@ -9,18 +9,12 @@
             "version": "0.0.0",
             "dependencies": {
                 "@stellar/freighter-api": "1.5.0",
-                "bigint-conversion": "2.4.1",
                 "buffer": "6.0.3",
                 "soroban-client": "0.9.0"
             },
             "devDependencies": {
                 "typescript": "5.0.4"
             }
-        },
-        "node_modules/@juanelas/base64": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@juanelas/base64/-/base64-1.1.2.tgz",
-            "integrity": "sha512-mr2pfRQpWap0Uq4tlrCgp3W+Yjx1/Bpq4QJsYeAQUh1mExgyQvXz7xUhmYT2HcLLspuAL5dpnos8P2QhaCSXsQ=="
         },
         "node_modules/@stellar/freighter-api": {
             "version": "1.5.0",
@@ -84,14 +78,6 @@
                     "url": "https://feross.org/support"
                 }
             ]
-        },
-        "node_modules/bigint-conversion": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/bigint-conversion/-/bigint-conversion-2.4.1.tgz",
-            "integrity": "sha512-/DTRevseMZoqN4KLkN5BryOiom0KbwYajiXG5Vo+ZcEPAO0WBZyZoYyDZSgfeq/v/oegLo9bjdndDBlExvAhBQ==",
-            "dependencies": {
-                "@juanelas/base64": "^1.1.2"
-            }
         },
         "node_modules/bignumber.js": {
             "version": "9.1.1",

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/package.json
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/package.json
@@ -4,8 +4,7 @@
     "dependencies": {
         "@stellar/freighter-api": "1.5.0",
         "buffer": "6.0.3",
-        "soroban-client": "0.9.0",
-        "bigint-conversion": "2.4.1"
+        "soroban-client": "0.9.0"
     },
     "scripts": {
         "build": "node ./scripts/build.mjs"

--- a/cmd/crates/soroban-spec-typescript/src/project_template/package.json
+++ b/cmd/crates/soroban-spec-typescript/src/project_template/package.json
@@ -4,8 +4,7 @@
     "dependencies": {
         "@stellar/freighter-api": "1.5.0",
         "buffer": "6.0.3",
-        "soroban-client": "0.9.0",
-        "bigint-conversion": "2.4.1"
+        "soroban-client": "0.9.0"
     },
     "scripts": {
         "build": "node ./scripts/build.mjs"

--- a/cmd/crates/soroban-spec-typescript/src/project_template/package.json
+++ b/cmd/crates/soroban-spec-typescript/src/project_template/package.json
@@ -2,7 +2,7 @@
     "version": "0.0.0",
     "name": "INSERT_CONTRACT_NAME_HERE",
     "dependencies": {
-        "@stellar/freighter-api": "1.5.0",
+        "@stellar/freighter-api": "1.5.1",
         "buffer": "6.0.3",
         "soroban-client": "0.9.0"
     },
@@ -15,6 +15,6 @@
     },
     "typings": "dist/types/index.d.ts",
     "devDependencies": {
-        "typescript": "5.0.4"
+        "typescript": "5.1.6"
     }
 }


### PR DESCRIPTION
### What
This is a first pass attempt at improving the generated TypeScript code to leverage the breaking changes and new features in `soroban-client@0.9.0` (see the [Release Notes](https://github.com/stellar/js-soroban-client/releases/tag/v0.9.0)). I tried to keep it minimal:

 * remove obsolete `scvalToBigInt` (in favor of `SorobanClient.scValToBigInt`)
 * remove bitwise manipulations in `i128ToScVal` and `u128ToScVal` (in favor of `SorobanClient.ScInt`)
 * this drops the need for the `bigint-conversion` library
 * ran the fixture update and updated other deps

I would even argue that `scValToJs` could be replaced by `SorobanClient.scValToNative`, but that would require extensive testing so I'm hesitant to do it here.

### Why
The generated code should be as simple and idiomatic as possible.

### Known limitations
n/a

**Note:** The main "functional" diff should mainly be `cmd/crates/soroban-spec-typescript/src/project_template/src/convert.ts` ([link](https://github.com/stellar/soroban-tools/pull/764/files#diff-157cc5d7c8ff4d63f8c66f141d63258c092d3055ffd090d8489637ab8c0446d6)).

