### PR TITLE
soroban-cli: Add better feedback to bump+restore ops

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/bump.rs
+++ b/cmd/soroban-cli/src/commands/contract/bump.rs
@@ -6,7 +6,7 @@ use soroban_env_host::xdr::{
     LedgerEntry, LedgerEntryData, LedgerFootprint, LedgerKey, LedgerKeyContractData, Memo,
     MuxedAccount, Operation, OperationBody, Preconditions, ReadXdr, ScAddress, ScSpecTypeDef,
     ScVal, SequenceNumber, SorobanResources, SorobanTransactionData, Transaction, TransactionExt,
-    Uint256,
+    TransactionMeta, TransactionMetaV3, Uint256,
 };
 use stellar_strkey::DecodeError;
 
@@ -75,6 +75,8 @@ pub enum Error {
     KeyIsRequired,
     #[error("xdr processing error: {0}")]
     Xdr(#[from] XdrError),
+    #[error("Ledger entry not found")]
+    LedgerEntryNotFound,
     #[error("missing operation result")]
     MissingOperationResult,
     #[error(transparent)]
@@ -135,7 +137,7 @@ impl Cmd {
             }),
         };
 
-        let (result, _meta, events) = client
+        let (result, meta, events) = client
             .prepare_and_send_transaction(&tx, &key, &network.network_passphrase, None)
             .await?;
 
@@ -143,6 +145,18 @@ impl Cmd {
         if !events.is_empty() {
             tracing::debug!(?events);
         }
+
+        // The transaction from core will succeed regardless of whether it actually found & bumped
+        // the entry, so we have to inspect the result meta to tell if it worked or not.
+        if let TransactionMeta::V3(TransactionMetaV3 { operations, .. }) = meta {
+            // Simply check if there is exactly one entry here. We only support bumping a single
+            // entry via this command (which we should fix separately, but).
+            if operations.len() == 0 {
+                return Err(Error::LedgerEntryNotFound);
+            }
+        } else {
+            return Err(Error::LedgerEntryNotFound);
+        };
 
         Ok(())
     }

--- a/cmd/soroban-cli/src/commands/contract/bump.rs
+++ b/cmd/soroban-cli/src/commands/contract/bump.rs
@@ -167,7 +167,16 @@ impl Cmd {
             return Err(Error::LedgerEntryNotFound);
         }
 
-        let (LedgerEntryChange::State(_state), LedgerEntryChange::Updated(LedgerEntry{ data: LedgerEntryData::ContractData(ContractDataEntry{expiration_ledger_seq, ..}), ..})) = (&operations[0].changes[0], &operations[0].changes[1]) else {
+        let (
+            LedgerEntryChange::State(_state),
+            LedgerEntryChange::Updated(LedgerEntry{
+                data: LedgerEntryData::ContractData(ContractDataEntry{
+                    expiration_ledger_seq,
+                    ..
+                }),
+                ..
+            })
+        ) = (&operations[0].changes[0], &operations[0].changes[1]) else {
             return Err(Error::LedgerEntryNotFound);
         };
 

--- a/cmd/soroban-cli/src/commands/contract/restore.rs
+++ b/cmd/soroban-cli/src/commands/contract/restore.rs
@@ -2,11 +2,12 @@ use std::{fmt::Debug, path::Path, str::FromStr};
 
 use clap::{command, Parser};
 use soroban_env_host::xdr::{
-    ContractDataDurability, ContractEntryBodyType, Error as XdrError, ExtensionPoint, Hash,
-    LedgerFootprint, LedgerKey, LedgerKeyContractData, Memo, MuxedAccount, Operation,
-    OperationBody, Preconditions, ReadXdr, RestoreFootprintOp, ScAddress, ScSpecTypeDef, ScVal,
-    SequenceNumber, SorobanResources, SorobanTransactionData, Transaction, TransactionExt,
-    TransactionMeta, TransactionMetaV3, Uint256,
+    ContractDataDurability, ContractDataEntry, ContractEntryBodyType, Error as XdrError,
+    ExtensionPoint, Hash, LedgerEntry, LedgerEntryChange, LedgerEntryData, LedgerFootprint,
+    LedgerKey, LedgerKeyContractData, Memo, MuxedAccount, Operation, OperationBody, Preconditions,
+    ReadXdr, RestoreFootprintOp, ScAddress, ScSpecTypeDef, ScVal, SequenceNumber, SorobanResources,
+    SorobanTransactionData, Transaction, TransactionExt, TransactionMeta, TransactionMetaV3,
+    Uint256,
 };
 use stellar_strkey::DecodeError;
 
@@ -80,14 +81,18 @@ pub enum Error {
 impl Cmd {
     #[allow(clippy::too_many_lines)]
     pub async fn run(&self) -> Result<(), Error> {
-        if self.config.is_no_network() {
-            self.run_in_sandbox()
+        let expiration_ledger_seq = if self.config.is_no_network() {
+            self.run_in_sandbox()?
         } else {
-            self.run_against_rpc_server().await
-        }
+            self.run_against_rpc_server().await?
+        };
+
+        println!("New expiration ledger: {expiration_ledger_seq}");
+
+        Ok(())
     }
 
-    async fn run_against_rpc_server(&self) -> Result<(), Error> {
+    async fn run_against_rpc_server(&self) -> Result<u32, Error> {
         let network = self.config.get_network()?;
         tracing::trace!(?network);
         let contract_id = self.contract_id()?;
@@ -139,22 +144,30 @@ impl Cmd {
             tracing::debug!(?events);
         }
 
-        // The transaction from core will succeed regardless of whether it actually found & bumped
-        // the entry, so we have to inspect the result meta to tell if it worked or not.
-        if let TransactionMeta::V3(TransactionMetaV3 { operations, .. }) = meta {
-            // Simply check if there is exactly one entry here. We only support bumping a single
-            // entry via this command (which we should fix separately, but).
-            if operations.len() == 0 {
-                return Err(Error::LedgerEntryNotFound);
-            }
-        } else {
+        // The transaction from core will succeed regardless of whether it actually found &
+        // restored the entry, so we have to inspect the result meta to tell if it worked or not.
+        let TransactionMeta::V3(TransactionMetaV3 { operations, .. }) = meta else {
             return Err(Error::LedgerEntryNotFound);
         };
 
-        Ok(())
+        // Simply check if there is exactly one entry here. We only support bumping a single
+        // entry via this command (which we should fix separately, but).
+        if operations.len() == 0 {
+            return Err(Error::LedgerEntryNotFound);
+        }
+
+        if operations[0].changes.len() != 1 {
+            return Err(Error::LedgerEntryNotFound);
+        }
+
+        let LedgerEntryChange::Created(LedgerEntry{ data: LedgerEntryData::ContractData(ContractDataEntry{expiration_ledger_seq, ..}), ..}) = &operations[0].changes[0] else {
+            return Err(Error::LedgerEntryNotFound);
+        };
+
+        Ok(*expiration_ledger_seq)
     }
 
-    fn run_in_sandbox(&self) -> Result<(), Error> {
+    fn run_in_sandbox(&self) -> Result<u32, Error> {
         // TODO: Implement this. This means we need to store ledger entries somewhere, and handle
         // eviction, and restoration with that evicted state store.
         todo!("Restoring ledger entries is not supported in the local sandbox mode");


### PR DESCRIPTION
### What

Have bump+restore subcommands either output the new expiration ledger seq, or that the entry could not be bumped.

### Why

Previously there was no way to tell if it was successful or not since the core txn is always successful.

### Known limitations

Doesn't really differentiate between entry not found and the entry not being bumped. We could check that by querying the rpc after to see if it exists.