### PR TITLE
 Upgrade generated TypeScript with Preview 10 changes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,36 +13,36 @@ jobs:
         scenario-filter: ["^TestDappDevelop$/^.*$"]
     runs-on: ubuntu-latest-4-cores
     env:
-      # the gh tag of system-test repo version to run 
+      # the gh tag of system-test repo version to run
       SYSTEM_TEST_GIT_REF: v1.0.18
 
       # the soroban tools source code to compile and run from system test
-      # refers to checked out source of current git hub ref context 
+      # refers to checked out source of current git hub ref context
       SYSTEM_TEST_SOROBAN_TOOLS_REF: ${{ github.workspace }}/soroban-tools
 
       # core git ref should be latest commit for stable soroban functionality
-      # the core bin can either be compiled in-line here as part of ci, 
+      # the core bin can either be compiled in-line here as part of ci,
       SYSTEM_TEST_CORE_GIT_REF: https://github.com/stellar/stellar-core.git#875f47e247cefc25c8a4b3982ee65610e6a620e3
       SYSTEM_TEST_CORE_COMPILE_CONFIGURE_FLAGS: "--disable-tests --enable-next-protocol-version-unsafe-for-production"
       # or can use option to pull a pre-compiled image instead
-      # SYSTEM_TEST_CORE_IMAGE: 
-      
-      # sets the version of rust toolchain that will be pre-installed in the 
+      # SYSTEM_TEST_CORE_IMAGE:
+
+      # sets the version of rust toolchain that will be pre-installed in the
       # test runtime environment, tests invoke rustc/cargo
       SYSTEM_TEST_RUST_TOOLCHAIN_VERSION: stable
 
       # sets the version of soroban-js-client used by tests
       SYSTEM_TEST_JS_SOROBAN_CLIENT_NPM_VERSION: "0.9.1"
-     
+
       # system test will build quickstart image internally to use for running the service stack
       # configured in standalone network mode(core, rpc)
       SYSTEM_TEST_QUICKSTART_GIT_REF: https://github.com/stellar/quickstart.git#df8303380d5869272852ddb45c39abfeb7d4c938
-      
+
       # triggers system test to log out details from quickstart's logs and test steps
       SYSTEM_TEST_VERBOSE_OUTPUT: "true"
 
       # the soroban test cases will compile various contracts from the examples repo
-      SYSTEM_TEST_SOROBAN_EXAMPLES_GIT_HASH: "release-preview-10"
+      SYSTEM_TEST_SOROBAN_EXAMPLES_GIT_HASH: "main"
       SYSTEM_TEST_SOROBAN_EXAMPLES_GIT_REPO: "https://github.com/stellar/soroban-examples.git"
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest-4-cores
     env:
       # the gh tag of system-test repo version to run 
-      SYSTEM_TEST_GIT_REF: v1.0.16
+      SYSTEM_TEST_GIT_REF: v1.0.17
 
       # the soroban tools source code to compile and run from system test
       # refers to checked out source of current git hub ref context 
@@ -32,7 +32,7 @@ jobs:
       SYSTEM_TEST_RUST_TOOLCHAIN_VERSION: stable
 
       # sets the version of soroban-js-client used by tests
-      SYSTEM_TEST_JS_SOROBAN_CLIENT_NPM_VERSION: "0.9.0"
+      SYSTEM_TEST_JS_SOROBAN_CLIENT_NPM_VERSION: "0.9.1"
      
       # system test will build quickstart image internally to use for running the service stack
       # configured in standalone network mode(core, rpc)

--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -61,7 +61,9 @@ jobs:
         with:
           go-version: 1.20.1
 
-      - run: rustup target add ${{ matrix.rust_target }}
+      - run: |
+          rustup target add ${{ matrix.rust_target }}
+          rustup update
 
       # On windows, make sure we have the same compiler (linker) used by rust.
       # This is important since the symbols names won't match otherwise.
@@ -130,7 +132,7 @@ jobs:
           # libc++1-8 won't be installed if another version is installed (but apt won't give you a helpful
           # message about why the installation fails)
           sudo apt-get remove -y libc++1-10 libc++abi1-10 || true
-          
+
           sudo wget -qO - https://apt.stellar.org/SDF.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true sudo apt-key add -
           sudo bash -c 'echo "deb https://apt.stellar.org focal unstable" > /etc/apt/sources.list.d/SDF-unstable.list'
           sudo apt-get update && sudo apt-get install -y stellar-core="$PROTOCOL_20_CORE_DEBIAN_PKG_VERSION"
@@ -142,7 +144,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y ca-certificates curl gnupg
-          
+
           # Install docker apt repo
           sudo install -m 0755 -d /etc/apt/keyrings
           curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
@@ -162,7 +164,7 @@ jobs:
 
       - name: Build libpreflight
         run: make build-libpreflight
-      
+
       - name: Run Soroban RPC Integration Tests
         run: |
           go test -race -timeout 25m -v ./cmd/soroban-rpc/internal/test/...

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/cjs/convert.d.ts
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/cjs/convert.d.ts
@@ -1,5 +1,4 @@
 import { xdr } from 'soroban-client';
-export declare function scvalToBigInt(scval: xdr.ScVal | undefined): BigInt;
 export declare function strToScVal(base64Xdr: string): xdr.ScVal;
 export declare function scValStrToJs<T>(base64Xdr: string): T;
 export declare function scValToJs<T>(val: xdr.ScVal): T;

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/cjs/convert.js
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/cjs/convert.js
@@ -1,41 +1,8 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.u128ToScVal = exports.i128ToScVal = exports.addressToScVal = exports.scValToJs = exports.scValStrToJs = exports.strToScVal = exports.scvalToBigInt = void 0;
+exports.u128ToScVal = exports.i128ToScVal = exports.addressToScVal = exports.scValToJs = exports.scValStrToJs = exports.strToScVal = void 0;
 const soroban_client_1 = require("soroban-client");
 const buffer_1 = require("buffer");
-const bigint_conversion_1 = require("bigint-conversion");
-function scvalToBigInt(scval) {
-    switch (scval?.switch()) {
-        case undefined: {
-            return BigInt(0);
-        }
-        case soroban_client_1.xdr.ScValType.scvU64(): {
-            const { high, low } = scval.u64();
-            return (0, bigint_conversion_1.bufToBigint)(new Uint32Array([high, low]));
-        }
-        case soroban_client_1.xdr.ScValType.scvI64(): {
-            const { high, low } = scval.i64();
-            return (0, bigint_conversion_1.bufToBigint)(new Int32Array([high, low]));
-        }
-        case soroban_client_1.xdr.ScValType.scvU128(): {
-            const parts = scval.u128();
-            const a = parts.hi();
-            const b = parts.lo();
-            return (0, bigint_conversion_1.bufToBigint)(new Uint32Array([a.high, a.low, b.high, b.low]));
-        }
-        case soroban_client_1.xdr.ScValType.scvI128(): {
-            const parts = scval.i128();
-            const a = parts.hi();
-            const b = parts.lo();
-            return (0, bigint_conversion_1.bufToBigint)(new Int32Array([a.high, a.low, b.high, b.low]));
-        }
-        default: {
-            throw new Error(`Invalid type for scvalToBigInt: ${scval?.switch().name}`);
-        }
-    }
-    ;
-}
-exports.scvalToBigInt = scvalToBigInt;
 function strToScVal(base64Xdr) {
     return soroban_client_1.xdr.ScVal.fromXDR(buffer_1.Buffer.from(base64Xdr, 'base64'));
 }
@@ -65,7 +32,7 @@ function scValToJs(val) {
         case soroban_client_1.xdr.ScValType.scvI128():
         case soroban_client_1.xdr.ScValType.scvU256():
         case soroban_client_1.xdr.ScValType.scvI256(): {
-            return scvalToBigInt(val);
+            return scValToBigInt(val);
         }
         case soroban_client_1.xdr.ScValType.scvAddress(): {
             return soroban_client_1.Address.fromScVal(val).toString();
@@ -132,16 +99,10 @@ function addressToScVal(addr) {
 }
 exports.addressToScVal = addressToScVal;
 function i128ToScVal(i) {
-    return soroban_client_1.xdr.ScVal.scvI128(new soroban_client_1.xdr.Int128Parts({
-        lo: soroban_client_1.xdr.Uint64.fromString((i & BigInt(0xffffffffffffffffn)).toString()),
-        hi: soroban_client_1.xdr.Int64.fromString(((i >> BigInt(64)) & BigInt(0xffffffffffffffffn)).toString()),
-    }));
+    return new soroban_client_1.ScInt(i).toI128();
 }
 exports.i128ToScVal = i128ToScVal;
 function u128ToScVal(i) {
-    return soroban_client_1.xdr.ScVal.scvU128(new soroban_client_1.xdr.UInt128Parts({
-        lo: soroban_client_1.xdr.Uint64.fromString((i & BigInt(0xffffffffffffffffn)).toString()),
-        hi: soroban_client_1.xdr.Int64.fromString(((i >> BigInt(64)) & BigInt(0xffffffffffffffffn)).toString()),
-    }));
+    return new soroban_client_1.ScInt(i).toU128();
 }
 exports.u128ToScVal = u128ToScVal;

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/cjs/convert.js
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/cjs/convert.js
@@ -32,7 +32,7 @@ function scValToJs(val) {
         case soroban_client_1.xdr.ScValType.scvI128():
         case soroban_client_1.xdr.ScValType.scvU256():
         case soroban_client_1.xdr.ScValType.scvI256(): {
-            return scValToBigInt(val);
+            return (0, soroban_client_1.scValToBigInt)(val);
         }
         case soroban_client_1.xdr.ScValType.scvAddress(): {
             return soroban_client_1.Address.fromScVal(val).toString();

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/cjs/index.js
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/cjs/index.js
@@ -136,7 +136,7 @@ var RoyalCard;
     RoyalCard[RoyalCard["Jack"] = 11] = "Jack";
     RoyalCard[RoyalCard["Queen"] = 12] = "Queen";
     RoyalCard[RoyalCard["King"] = 13] = "King";
-})(RoyalCard = exports.RoyalCard || (exports.RoyalCard = {}));
+})(RoyalCard || (exports.RoyalCard = RoyalCard = {}));
 function RoyalCardFromXdr(base64Xdr) {
     return (0, convert_js_1.scValStrToJs)(base64Xdr);
 }

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/esm/convert.d.ts
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/esm/convert.d.ts
@@ -1,5 +1,4 @@
 import { xdr } from 'soroban-client';
-export declare function scvalToBigInt(scval: xdr.ScVal | undefined): BigInt;
 export declare function strToScVal(base64Xdr: string): xdr.ScVal;
 export declare function scValStrToJs<T>(base64Xdr: string): T;
 export declare function scValToJs<T>(val: xdr.ScVal): T;

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/esm/convert.js
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/esm/convert.js
@@ -1,37 +1,5 @@
-import { Address, xdr } from 'soroban-client';
+import { Address, xdr, scValToBigInt, ScInt } from 'soroban-client';
 import { Buffer } from "buffer";
-import { bufToBigint } from 'bigint-conversion';
-export function scvalToBigInt(scval) {
-    switch (scval?.switch()) {
-        case undefined: {
-            return BigInt(0);
-        }
-        case xdr.ScValType.scvU64(): {
-            const { high, low } = scval.u64();
-            return bufToBigint(new Uint32Array([high, low]));
-        }
-        case xdr.ScValType.scvI64(): {
-            const { high, low } = scval.i64();
-            return bufToBigint(new Int32Array([high, low]));
-        }
-        case xdr.ScValType.scvU128(): {
-            const parts = scval.u128();
-            const a = parts.hi();
-            const b = parts.lo();
-            return bufToBigint(new Uint32Array([a.high, a.low, b.high, b.low]));
-        }
-        case xdr.ScValType.scvI128(): {
-            const parts = scval.i128();
-            const a = parts.hi();
-            const b = parts.lo();
-            return bufToBigint(new Int32Array([a.high, a.low, b.high, b.low]));
-        }
-        default: {
-            throw new Error(`Invalid type for scvalToBigInt: ${scval?.switch().name}`);
-        }
-    }
-    ;
-}
 export function strToScVal(base64Xdr) {
     return xdr.ScVal.fromXDR(Buffer.from(base64Xdr, 'base64'));
 }
@@ -59,7 +27,7 @@ export function scValToJs(val) {
         case xdr.ScValType.scvI128():
         case xdr.ScValType.scvU256():
         case xdr.ScValType.scvI256(): {
-            return scvalToBigInt(val);
+            return scValToBigInt(val);
         }
         case xdr.ScValType.scvAddress(): {
             return Address.fromScVal(val).toString();
@@ -124,14 +92,8 @@ export function addressToScVal(addr) {
     return addrObj.toScVal();
 }
 export function i128ToScVal(i) {
-    return xdr.ScVal.scvI128(new xdr.Int128Parts({
-        lo: xdr.Uint64.fromString((i & BigInt(0xffffffffffffffffn)).toString()),
-        hi: xdr.Int64.fromString(((i >> BigInt(64)) & BigInt(0xffffffffffffffffn)).toString()),
-    }));
+    return new ScInt(i).toI128();
 }
 export function u128ToScVal(i) {
-    return xdr.ScVal.scvU128(new xdr.UInt128Parts({
-        lo: xdr.Uint64.fromString((i & BigInt(0xffffffffffffffffn)).toString()),
-        hi: xdr.Int64.fromString(((i >> BigInt(64)) & BigInt(0xffffffffffffffffn)).toString()),
-    }));
+    return new ScInt(i).toU128();
 }

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/types/convert.d.ts
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/types/convert.d.ts
@@ -1,5 +1,4 @@
 import { xdr } from 'soroban-client';
-export declare function scvalToBigInt(scval: xdr.ScVal | undefined): BigInt;
 export declare function strToScVal(base64Xdr: string): xdr.ScVal;
 export declare function scValStrToJs<T>(base64Xdr: string): T;
 export declare function scValToJs<T>(val: xdr.ScVal): T;

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/package-lock.json
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/package-lock.json
@@ -8,24 +8,18 @@
             "name": "test_custom_types",
             "version": "0.0.0",
             "dependencies": {
-                "@stellar/freighter-api": "1.5.0",
-                "bigint-conversion": "2.4.1",
+                "@stellar/freighter-api": "1.5.1",
                 "buffer": "6.0.3",
                 "soroban-client": "0.9.1"
             },
             "devDependencies": {
-                "typescript": "5.0.4"
+                "typescript": "5.1.6"
             }
         },
-        "node_modules/@juanelas/base64": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@juanelas/base64/-/base64-1.1.2.tgz",
-            "integrity": "sha512-mr2pfRQpWap0Uq4tlrCgp3W+Yjx1/Bpq4QJsYeAQUh1mExgyQvXz7xUhmYT2HcLLspuAL5dpnos8P2QhaCSXsQ=="
-        },
         "node_modules/@stellar/freighter-api": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@stellar/freighter-api/-/freighter-api-1.5.0.tgz",
-            "integrity": "sha512-j9bAo3U7UJ0jaEGhKkCcmAiRJ67xUG1Ty3N8dVb65WVkEdXtxEfFtPuRcsr9brX9sHeN+s2caS6KQL8FYZqixg=="
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/@stellar/freighter-api/-/freighter-api-1.5.1.tgz",
+            "integrity": "sha512-WEnKEqd+xVLnOq6bJv+fLXod8JQyPjzpOKTpH4g7tG9MM1fmXzD3y2SXJlpCIw8kVqtiC4ynWOlSWX+TKO7KiQ=="
         },
         "node_modules/asn1.js": {
             "version": "5.4.1",
@@ -84,14 +78,6 @@
                     "url": "https://feross.org/support"
                 }
             ]
-        },
-        "node_modules/bigint-conversion": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/bigint-conversion/-/bigint-conversion-2.4.1.tgz",
-            "integrity": "sha512-/DTRevseMZoqN4KLkN5BryOiom0KbwYajiXG5Vo+ZcEPAO0WBZyZoYyDZSgfeq/v/oegLo9bjdndDBlExvAhBQ==",
-            "dependencies": {
-                "@juanelas/base64": "^1.1.2"
-            }
         },
         "node_modules/bignumber.js": {
             "version": "9.1.1",
@@ -727,16 +713,16 @@
             "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
         },
         "node_modules/typescript": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-            "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+            "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
             },
             "engines": {
-                "node": ">=12.20"
+                "node": ">=14.17"
             }
         },
         "node_modules/urijs": {

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/package-lock.json
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/package-lock.json
@@ -11,7 +11,7 @@
                 "@stellar/freighter-api": "1.5.0",
                 "bigint-conversion": "2.4.1",
                 "buffer": "6.0.3",
-                "soroban-client": "0.9.0"
+                "soroban-client": "0.9.1"
             },
             "devDependencies": {
                 "typescript": "5.0.4"
@@ -673,9 +673,9 @@
             }
         },
         "node_modules/soroban-client": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/soroban-client/-/soroban-client-0.9.0.tgz",
-            "integrity": "sha512-qfdLYBhEk3CzglYcZ2jsLwzjcdJQIAMDOJnor2EPrTPS33DK+IjKEr6CPVALERG2yYzo7xbtAfwboxA4aAM+Xg==",
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/soroban-client/-/soroban-client-0.9.1.tgz",
+            "integrity": "sha512-wAxu8Z15vBirjizdGG5BnUtZDtf/+ul37q84xHqUUHS7t7sL8CBeTdM6bFYmlEVLjpfFtAhdB/yJBQU7Bo4kBQ==",
             "dependencies": {
                 "axios": "^1.4.0",
                 "bignumber.js": "^9.1.1",
@@ -685,15 +685,15 @@
                 "eventsource": "^2.0.2",
                 "lodash": "^4.17.21",
                 "randombytes": "^2.1.0",
-                "stellar-base": "10.0.0-soroban.2",
+                "stellar-base": "10.0.0-soroban.3",
                 "toml": "^3.0.0",
                 "urijs": "^1.19.1"
             }
         },
         "node_modules/stellar-base": {
-            "version": "10.0.0-soroban.2",
-            "resolved": "https://registry.npmjs.org/stellar-base/-/stellar-base-10.0.0-soroban.2.tgz",
-            "integrity": "sha512-WaC8AoFjtsas/pmO+odUm+i55bazzSee/bBlYjj85sTHFRKa7SE5bp3Ra6fbSNlYKd//FPPTNl92NKe0jix7Kw==",
+            "version": "10.0.0-soroban.3",
+            "resolved": "https://registry.npmjs.org/stellar-base/-/stellar-base-10.0.0-soroban.3.tgz",
+            "integrity": "sha512-XixwHHggxuWHQYY2CiVIzXLCGwaphS6pKF1GFyTC4QNIouR7IRWn/fzbXkYmzIbJTq6gM4mORO3kaLwl4bd7yA==",
             "dependencies": {
                 "base32.js": "^0.1.0",
                 "bignumber.js": "^9.1.1",

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/package.json
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/package.json
@@ -4,8 +4,7 @@
     "dependencies": {
         "@stellar/freighter-api": "1.5.0",
         "buffer": "6.0.3",
-        "soroban-client": "0.9.1",
-        "bigint-conversion": "2.4.1"
+        "soroban-client": "0.9.1"
     },
     "scripts": {
         "build": "node ./scripts/build.mjs"

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/package.json
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/package.json
@@ -4,7 +4,7 @@
     "dependencies": {
         "@stellar/freighter-api": "1.5.0",
         "buffer": "6.0.3",
-        "soroban-client": "0.9.0",
+        "soroban-client": "0.9.1",
         "bigint-conversion": "2.4.1"
     },
     "scripts": {

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/package.json
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/package.json
@@ -2,7 +2,7 @@
     "version": "0.0.0",
     "name": "test_custom_types",
     "dependencies": {
-        "@stellar/freighter-api": "1.5.0",
+        "@stellar/freighter-api": "1.5.1",
         "buffer": "6.0.3",
         "soroban-client": "0.9.1"
     },
@@ -15,6 +15,6 @@
     },
     "typings": "dist/types/index.d.ts",
     "devDependencies": {
-        "typescript": "5.0.4"
+        "typescript": "5.1.6"
     }
 }

--- a/cmd/crates/soroban-spec-typescript/src/project_template/package.json
+++ b/cmd/crates/soroban-spec-typescript/src/project_template/package.json
@@ -2,7 +2,7 @@
     "version": "0.0.0",
     "name": "INSERT_CONTRACT_NAME_HERE",
     "dependencies": {
-        "@stellar/freighter-api": "1.5.0",
+        "@stellar/freighter-api": "1.5.1",
         "buffer": "6.0.3",
         "soroban-client": "0.9.1"
     },
@@ -15,6 +15,6 @@
     },
     "typings": "dist/types/index.d.ts",
     "devDependencies": {
-        "typescript": "5.0.4"
+        "typescript": "5.1.6"
     }
 }

--- a/cmd/crates/soroban-spec-typescript/src/project_template/package.json
+++ b/cmd/crates/soroban-spec-typescript/src/project_template/package.json
@@ -4,8 +4,7 @@
     "dependencies": {
         "@stellar/freighter-api": "1.5.0",
         "buffer": "6.0.3",
-        "soroban-client": "0.9.1",
-        "bigint-conversion": "2.4.1"
+        "soroban-client": "0.9.1"
     },
     "scripts": {
         "build": "node ./scripts/build.mjs"

--- a/cmd/crates/soroban-spec-typescript/src/project_template/package.json
+++ b/cmd/crates/soroban-spec-typescript/src/project_template/package.json
@@ -4,7 +4,7 @@
     "dependencies": {
         "@stellar/freighter-api": "1.5.0",
         "buffer": "6.0.3",
-        "soroban-client": "0.9.0",
+        "soroban-client": "0.9.1",
         "bigint-conversion": "2.4.1"
     },
     "scripts": {


### PR DESCRIPTION
Replaces #764 to target `main`.

The only "real" change is to src/convert.ts [here](https://github.com/stellar/soroban-tools/pull/770/files#diff-157cc5d7c8ff4d63f8c66f141d63258c092d3055ffd090d8489637ab8c0446d6); the rest is just generated code.

cc @willemneal @chadoh 