### PR TITLE
feat(CLI): restore/bump if no keys provided contract instance used

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/bump.rs
+++ b/cmd/soroban-cli/src/commands/contract/bump.rs
@@ -25,7 +25,7 @@ use crate::{
 #[derive(Parser, Debug, Clone)]
 #[group(skip)]
 pub struct Cmd {
-    /// Contract ID to which owns the data entries
+    /// Contract ID to which owns the data entries.
     /// If no keys provided the Contract's instance will be bumped
     #[arg(long = "id", required_unless_present = "wasm")]
     contract_id: Option<String>,

--- a/cmd/soroban-cli/src/commands/contract/bump.rs
+++ b/cmd/soroban-cli/src/commands/contract/bump.rs
@@ -26,6 +26,7 @@ use crate::{
 #[group(skip)]
 pub struct Cmd {
     /// Contract ID to which owns the data entries
+    /// If no keys provided the Contract's instance will be bumped
     #[arg(long = "id", required_unless_present = "wasm")]
     contract_id: Option<String>,
     /// Storage key (symbols only)
@@ -259,7 +260,7 @@ impl Cmd {
         } else if let Some(wasm) = &self.wasm {
             return Ok(crate::wasm::Args { wasm: wasm.clone() }.try_into()?);
         } else {
-            return Err(Error::KeyIsRequired);
+            ScVal::LedgerKeyContractInstance
         };
         let contract_id = self.contract_id()?;
 

--- a/cmd/soroban-cli/src/commands/contract/mod.rs
+++ b/cmd/soroban-cli/src/commands/contract/mod.rs
@@ -19,6 +19,8 @@ pub enum Cmd {
     Build(build::Cmd),
 
     /// Extend the expiry ledger of a contract-data ledger entry
+    ///
+    /// If no keys are specificed the contract itself is bumped.
     Bump(bump::Cmd),
 
     /// Deploy a contract
@@ -50,6 +52,8 @@ pub enum Cmd {
     Read(read::Cmd),
 
     /// Restore an evicted value for a contract-data legder entry
+    ///
+    /// If no keys are specificed the contract itself is restored.
     Restore(restore::Cmd),
 }
 

--- a/cmd/soroban-cli/src/commands/contract/mod.rs
+++ b/cmd/soroban-cli/src/commands/contract/mod.rs
@@ -18,7 +18,7 @@ pub enum Cmd {
 
     Build(build::Cmd),
 
-    /// Extend the expiry ledger of a contract-data ledger entry
+    /// Extend the expiry ledger of a contract-data ledger entry.
     ///
     /// If no keys are specificed the contract itself is bumped.
     Bump(bump::Cmd),
@@ -51,7 +51,7 @@ pub enum Cmd {
     /// Print the current value of a contract-data ledger entry
     Read(read::Cmd),
 
-    /// Restore an evicted value for a contract-data legder entry
+    /// Restore an evicted value for a contract-data legder entry.
     ///
     /// If no keys are specificed the contract itself is restored.
     Restore(restore::Cmd),

--- a/cmd/soroban-cli/src/commands/contract/restore.rs
+++ b/cmd/soroban-cli/src/commands/contract/restore.rs
@@ -24,7 +24,7 @@ use crate::{
 #[derive(Parser, Debug, Clone)]
 #[group(skip)]
 pub struct Cmd {
-    /// Contract ID to which owns the data entries
+    /// Contract ID to which owns the data entries.
     /// If no keys provided the Contract's instance will be restored
     #[arg(long = "id", required_unless_present = "wasm")]
     contract_id: Option<String>,

--- a/cmd/soroban-cli/src/commands/contract/restore.rs
+++ b/cmd/soroban-cli/src/commands/contract/restore.rs
@@ -25,6 +25,7 @@ use crate::{
 #[group(skip)]
 pub struct Cmd {
     /// Contract ID to which owns the data entries
+    /// If no keys provided the Contract's instance will be restored
     #[arg(long = "id", required_unless_present = "wasm")]
     contract_id: Option<String>,
     /// Storage key (symbols only)
@@ -248,7 +249,7 @@ impl Cmd {
         }
 
         if keys.is_empty() {
-            return Err(Error::KeyIsRequired);
+            keys.push(ScVal::LedgerKeyContractInstance);
         };
 
         Ok(keys

--- a/docs/soroban-cli-full-docs.md
+++ b/docs/soroban-cli-full-docs.md
@@ -203,11 +203,13 @@ To view the commands that will be executed, without executing them, use the --pr
 
 Extend the expiry ledger of a contract-data ledger entry
 
+If no keys are specificed the contract itself is bumped.
+
 **Usage:** `soroban contract bump [OPTIONS] --durability <DURABILITY> --ledgers-to-expire <LEDGERS_TO_EXPIRE>`
 
 ###### **Options:**
 
-* `--id <CONTRACT_ID>` — Contract ID to which owns the data entries
+* `--id <CONTRACT_ID>` — Contract ID to which owns the data entries If no keys provided the Contract's instance will be bumped
 * `--key <KEY>` — Storage key (symbols only)
 * `--key-xdr <KEY_XDR>` — Storage key (base64-encoded XDR)
 * `--wasm <WASM>` — Path to Wasm file of contract code to bump
@@ -410,11 +412,13 @@ Print the current value of a contract-data ledger entry
 
 Restore an evicted value for a contract-data legder entry
 
+If no keys are specificed the contract itself is restored.
+
 **Usage:** `soroban contract restore [OPTIONS]`
 
 ###### **Options:**
 
-* `--id <CONTRACT_ID>` — Contract ID to which owns the data entries
+* `--id <CONTRACT_ID>` — Contract ID to which owns the data entries If no keys provided the Contract's instance will be restored
 * `--key <KEY>` — Storage key (symbols only)
 * `--key-xdr <KEY_XDR>` — Storage key (base64-encoded XDR)
 * `--wasm <WASM>` — Path to Wasm file of contract code to restore

--- a/docs/soroban-cli-full-docs.md
+++ b/docs/soroban-cli-full-docs.md
@@ -201,7 +201,7 @@ To view the commands that will be executed, without executing them, use the --pr
 
 ## `soroban contract bump`
 
-Extend the expiry ledger of a contract-data ledger entry
+Extend the expiry ledger of a contract-data ledger entry.
 
 If no keys are specificed the contract itself is bumped.
 
@@ -209,7 +209,7 @@ If no keys are specificed the contract itself is bumped.
 
 ###### **Options:**
 
-* `--id <CONTRACT_ID>` — Contract ID to which owns the data entries If no keys provided the Contract's instance will be bumped
+* `--id <CONTRACT_ID>` — Contract ID to which owns the data entries. If no keys provided the Contract's instance will be bumped
 * `--key <KEY>` — Storage key (symbols only)
 * `--key-xdr <KEY_XDR>` — Storage key (base64-encoded XDR)
 * `--wasm <WASM>` — Path to Wasm file of contract code to bump
@@ -410,7 +410,7 @@ Print the current value of a contract-data ledger entry
 
 ## `soroban contract restore`
 
-Restore an evicted value for a contract-data legder entry
+Restore an evicted value for a contract-data legder entry.
 
 If no keys are specificed the contract itself is restored.
 
@@ -418,7 +418,7 @@ If no keys are specificed the contract itself is restored.
 
 ###### **Options:**
 
-* `--id <CONTRACT_ID>` — Contract ID to which owns the data entries If no keys provided the Contract's instance will be restored
+* `--id <CONTRACT_ID>` — Contract ID to which owns the data entries. If no keys provided the Contract's instance will be restored
 * `--key <KEY>` — Storage key (symbols only)
 * `--key-xdr <KEY_XDR>` — Storage key (base64-encoded XDR)
 * `--wasm <WASM>` — Path to Wasm file of contract code to restore


### PR DESCRIPTION
### What

Currently users must manually provide the xdr key corresponding ScVal for LedgerKeyContractInstance.

Now when no keys are provided this key is used.

### Why

Currently users must use a special magic value. This handles it for them.

### Known limitations

[TODO or N/A]
