### PR TITLE
feat(bindings-ts): make Wallet injectable

### DIFF
--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/cjs/index.d.ts
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/cjs/index.d.ts
@@ -1,6 +1,6 @@
 import * as SorobanClient from 'soroban-client';
 import { Buffer } from "buffer";
-import { ResponseTypes } from './method-options.js';
+import type { ResponseTypes, Wallet } from './method-options.js';
 export * from './constants.js';
 export * from './server.js';
 export * from './invoke.js';
@@ -75,6 +75,9 @@ export type ComplexEnum = {
     tag: "Enum";
     values: [SimpleEnum];
 } | {
+    tag: "Asset";
+    values: [Address, i128];
+} | {
     tag: "Void";
     values: void;
 };
@@ -97,6 +100,16 @@ export declare function hello<R extends ResponseTypes = undefined>({ hello }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? string : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : string>;
 export declare function woid<R extends ResponseTypes = undefined>(options?: {
     /**
@@ -115,6 +128,16 @@ export declare function woid<R extends ResponseTypes = undefined>(options?: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? void : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : void>;
 export declare function val<R extends ResponseTypes = undefined>(options?: {
     /**
@@ -133,6 +156,16 @@ export declare function val<R extends ResponseTypes = undefined>(options?: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? any : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : any>;
 export declare function u32FailOnEven<R extends ResponseTypes = undefined>({ u32_ }: {
     u32_: u32;
@@ -153,6 +186,16 @@ export declare function u32FailOnEven<R extends ResponseTypes = undefined>({ u32
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? Err<Error_> | Ok<number> : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : Err<Error_> | Ok<number>>;
 export declare function u32<R extends ResponseTypes = undefined>({ u32_ }: {
     u32_: u32;
@@ -173,6 +216,16 @@ export declare function u32<R extends ResponseTypes = undefined>({ u32_ }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? number : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : number>;
 export declare function i32<R extends ResponseTypes = undefined>({ i32_ }: {
     i32_: i32;
@@ -193,6 +246,16 @@ export declare function i32<R extends ResponseTypes = undefined>({ i32_ }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? number : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : number>;
 export declare function i64<R extends ResponseTypes = undefined>({ i64_ }: {
     i64_: i64;
@@ -213,6 +276,16 @@ export declare function i64<R extends ResponseTypes = undefined>({ i64_ }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? bigint : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : bigint>;
 /**
  * Example contract method which takes a struct
@@ -236,6 +309,16 @@ export declare function struktHel<R extends ResponseTypes = undefined>({ strukt 
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? string[] : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : string[]>;
 export declare function strukt<R extends ResponseTypes = undefined>({ strukt }: {
     strukt: Test;
@@ -256,6 +339,16 @@ export declare function strukt<R extends ResponseTypes = undefined>({ strukt }: 
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? Test : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : Test>;
 export declare function simple<R extends ResponseTypes = undefined>({ simple }: {
     simple: SimpleEnum;
@@ -276,6 +369,16 @@ export declare function simple<R extends ResponseTypes = undefined>({ simple }: 
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? SimpleEnum : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : SimpleEnum>;
 export declare function complex<R extends ResponseTypes = undefined>({ complex }: {
     complex: ComplexEnum;
@@ -296,6 +399,16 @@ export declare function complex<R extends ResponseTypes = undefined>({ complex }
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? ComplexEnum : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : ComplexEnum>;
 export declare function addresse<R extends ResponseTypes = undefined>({ addresse }: {
     addresse: Address;
@@ -316,6 +429,16 @@ export declare function addresse<R extends ResponseTypes = undefined>({ addresse
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? string : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : string>;
 export declare function bytes<R extends ResponseTypes = undefined>({ bytes }: {
     bytes: Buffer;
@@ -336,6 +459,16 @@ export declare function bytes<R extends ResponseTypes = undefined>({ bytes }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? Buffer : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : Buffer>;
 export declare function bytesN<R extends ResponseTypes = undefined>({ bytes_n }: {
     bytes_n: Buffer;
@@ -356,6 +489,16 @@ export declare function bytesN<R extends ResponseTypes = undefined>({ bytes_n }:
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? Buffer : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : Buffer>;
 export declare function card<R extends ResponseTypes = undefined>({ card }: {
     card: RoyalCard;
@@ -376,6 +519,16 @@ export declare function card<R extends ResponseTypes = undefined>({ card }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? RoyalCard : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : RoyalCard>;
 export declare function booleanMethod<R extends ResponseTypes = undefined>({ boolean }: {
     boolean: boolean;
@@ -396,6 +549,16 @@ export declare function booleanMethod<R extends ResponseTypes = undefined>({ boo
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? boolean : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : boolean>;
 /**
  * Negates a boolean value
@@ -419,6 +582,16 @@ export declare function not<R extends ResponseTypes = undefined>({ boolean }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? boolean : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : boolean>;
 export declare function i128<R extends ResponseTypes = undefined>({ i128 }: {
     i128: i128;
@@ -439,6 +612,16 @@ export declare function i128<R extends ResponseTypes = undefined>({ i128 }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? bigint : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : bigint>;
 export declare function u128<R extends ResponseTypes = undefined>({ u128 }: {
     u128: u128;
@@ -459,6 +642,16 @@ export declare function u128<R extends ResponseTypes = undefined>({ u128 }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? bigint : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : bigint>;
 export declare function multiArgs<R extends ResponseTypes = undefined>({ a, b }: {
     a: u32;
@@ -480,6 +673,16 @@ export declare function multiArgs<R extends ResponseTypes = undefined>({ a, b }:
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? number : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : number>;
 export declare function map<R extends ResponseTypes = undefined>({ map }: {
     map: Map<u32, boolean>;
@@ -500,6 +703,16 @@ export declare function map<R extends ResponseTypes = undefined>({ map }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? Map<number, boolean> : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : Map<number, boolean>>;
 export declare function vec<R extends ResponseTypes = undefined>({ vec }: {
     vec: Array<u32>;
@@ -520,6 +733,16 @@ export declare function vec<R extends ResponseTypes = undefined>({ vec }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? number[] : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : number[]>;
 export declare function tuple<R extends ResponseTypes = undefined>({ tuple }: {
     tuple: [string, u32];
@@ -540,6 +763,16 @@ export declare function tuple<R extends ResponseTypes = undefined>({ tuple }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? [string, number] : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : [string, number]>;
 /**
  * Example of an optional argument
@@ -563,6 +796,16 @@ export declare function option<R extends ResponseTypes = undefined>({ option }: 
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? number : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : number>;
 export declare function u256<R extends ResponseTypes = undefined>({ u256 }: {
     u256: u256;
@@ -583,6 +826,16 @@ export declare function u256<R extends ResponseTypes = undefined>({ u256 }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? bigint : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : bigint>;
 export declare function i256<R extends ResponseTypes = undefined>({ i256 }: {
     i256: i256;
@@ -603,6 +856,16 @@ export declare function i256<R extends ResponseTypes = undefined>({ i256 }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? bigint : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : bigint>;
 export declare function string<R extends ResponseTypes = undefined>({ string }: {
     string: string;
@@ -623,6 +886,16 @@ export declare function string<R extends ResponseTypes = undefined>({ string }: 
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? string : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : string>;
 export declare function tupleStrukt<R extends ResponseTypes = undefined>({ tuple_strukt }: {
     tuple_strukt: TupleStruct;
@@ -643,4 +916,14 @@ export declare function tupleStrukt<R extends ResponseTypes = undefined>({ tuple
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? TupleStruct : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : TupleStruct>;

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/cjs/index.js
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/cjs/index.js
@@ -174,6 +174,11 @@ function ComplexEnumToXdr(complexEnum) {
             res.push(((i) => soroban_client_1.xdr.ScVal.scvSymbol(i))("Enum"));
             res.push(((i) => SimpleEnumToXdr(i))(complexEnum.values[0]));
             break;
+        case "Asset":
+            res.push(((i) => soroban_client_1.xdr.ScVal.scvSymbol(i))("Asset"));
+            res.push(((i) => (0, convert_js_1.addressToScVal)(i))(complexEnum.values[0]));
+            res.push(((i) => (0, convert_js_1.i128ToScVal)(i))(complexEnum.values[1]));
+            break;
         case "Void":
             res.push(((i) => soroban_client_1.xdr.ScVal.scvSymbol(i))("Void"));
             break;

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/cjs/invoke.d.ts
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/cjs/invoke.d.ts
@@ -1,6 +1,6 @@
 import * as SorobanClient from 'soroban-client';
 import type { Memo, MemoType, Operation, Transaction } from 'soroban-client';
-import { Options, ResponseTypes } from './method-options.js';
+import type { Options, ResponseTypes, Wallet } from './method-options.js';
 export type Tx = Transaction<Memo<MemoType>, Operation[]>;
 export declare class NotImplementedError extends Error {
 }
@@ -30,7 +30,7 @@ export declare function invoke<R extends ResponseTypes = undefined, T = string>(
  * or one of the exported contract methods, you may want to use this function
  * to sign the transaction with Freighter.
  */
-export declare function signTx(tx: Tx): Promise<Tx>;
+export declare function signTx(wallet: Wallet, tx: Tx): Promise<Tx>;
 /**
  * Send a transaction to the Soroban network.
  *

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/cjs/invoke.js
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/cjs/invoke.js
@@ -1,9 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.sendTx = exports.signTx = exports.invoke = exports.NotImplementedError = void 0;
-const freighter_api_1 = require("@stellar/freighter-api");
-// working around ESM compatibility issues
-const { isConnected, isAllowed, getUserInfo, signTransaction, } = freighter_api_1.default;
 const SorobanClient = require("soroban-client");
 const constants_js_1 = require("./constants.js");
 const server_js_1 = require("./server.js");
@@ -11,11 +8,11 @@ const server_js_1 = require("./server.js");
  * Get account details from the Soroban network for the publicKey currently
  * selected in Freighter. If not connected to Freighter, return null.
  */
-async function getAccount() {
-    if (!await isConnected() || !await isAllowed()) {
+async function getAccount(wallet) {
+    if (!await wallet.isConnected() || !await wallet.isAllowed()) {
         return null;
     }
-    const { publicKey } = await getUserInfo();
+    const { publicKey } = await wallet.getUserInfo();
     if (!publicKey) {
         return null;
     }
@@ -26,10 +23,11 @@ class NotImplementedError extends Error {
 exports.NotImplementedError = NotImplementedError;
 // defined this way so typeahead shows full union, not named alias
 let someRpcResponse;
-async function invoke({ method, args = [], fee = 100, responseType, parseResultXdr, secondsToWait = 10, }) {
-    const freighterAccount = await getAccount();
+async function invoke({ method, args = [], fee = 100, responseType, parseResultXdr, secondsToWait = 10, wallet, }) {
+    wallet = wallet ?? await Promise.resolve().then(() => require('@stellar/freighter-api'));
+    const walletAccount = await getAccount(wallet);
     // use a placeholder null account if not yet connected to Freighter so that view calls can still work
-    const account = freighterAccount ?? new SorobanClient.Account('GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF', '0');
+    const account = walletAccount ?? new SorobanClient.Account('GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF', '0');
     const contract = new SorobanClient.Contract(constants_js_1.CONTRACT_ID);
     let tx = new SorobanClient.TransactionBuilder(account, {
         fee: fee.toString(10),
@@ -46,8 +44,8 @@ async function invoke({ method, args = [], fee = 100, responseType, parseResultX
     let authsCount = auths?.length ?? 0;
     const writeLength = SorobanClient.xdr.SorobanTransactionData.fromXDR(simulated.transactionData, 'base64').resources().footprint().readWrite().length;
     const parse = parseResultXdr ?? (xdr => xdr);
-    // if VIEW ˅˅˅˅
-    if (authsCount === 0 && writeLength === 0) {
+    const isViewCall = authsCount === 0 && writeLength === 0;
+    if (isViewCall) {
         if (responseType === 'full')
             return simulated;
         const { results } = simulated;
@@ -59,7 +57,6 @@ async function invoke({ method, args = [], fee = 100, responseType, parseResultX
         }
         return parse(results[0].xdr);
     }
-    // ^^^^ else, is CHANGE method ˅˅˅˅
     if (authsCount > 1) {
         throw new NotImplementedError("Multiple auths not yet supported");
     }
@@ -72,11 +69,11 @@ async function invoke({ method, args = [], fee = 100, responseType, parseResultX
         //     }; Not yet supported`
         //   )
         // }
-        if (!freighterAccount) {
-            throw new Error('Not connected to Freighter');
-        }
-        tx = await signTx(SorobanClient.assembleTransaction(tx, constants_js_1.NETWORK_PASSPHRASE, simulated));
     }
+    if (!walletAccount) {
+        throw new Error('Not connected to Freighter');
+    }
+    tx = await signTx(wallet, SorobanClient.assembleTransaction(tx, constants_js_1.NETWORK_PASSPHRASE, simulated));
     const raw = await sendTx(tx, secondsToWait);
     if (responseType === 'full')
         return raw;
@@ -100,8 +97,8 @@ exports.invoke = invoke;
  * or one of the exported contract methods, you may want to use this function
  * to sign the transaction with Freighter.
  */
-async function signTx(tx) {
-    const signed = await signTransaction(tx.toXDR(), {
+async function signTx(wallet, tx) {
+    const signed = await wallet.signTransaction(tx.toXDR(), {
         networkPassphrase: constants_js_1.NETWORK_PASSPHRASE,
     });
     return SorobanClient.TransactionBuilder.fromXDR(signed, constants_js_1.NETWORK_PASSPHRASE);

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/cjs/method-options.d.ts
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/cjs/method-options.d.ts
@@ -1,5 +1,18 @@
 declare let responseTypes: 'simulated' | 'full' | undefined;
 export type ResponseTypes = typeof responseTypes;
+export type XDR_BASE64 = string;
+export interface Wallet {
+    isConnected: () => Promise<boolean>;
+    isAllowed: () => Promise<boolean>;
+    getUserInfo: () => Promise<{
+        publicKey?: string;
+    }>;
+    signTransaction: (tx: XDR_BASE64, opts?: {
+        network?: string;
+        networkPassphrase?: string;
+        accountToSign?: string;
+    }) => Promise<XDR_BASE64>;
+}
 export type Options<R extends ResponseTypes> = {
     /**
      * The fee to pay for the transaction. Default: 100.
@@ -17,5 +30,15 @@ export type Options<R extends ResponseTypes> = {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 };
 export {};

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/esm/index.d.ts
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/esm/index.d.ts
@@ -1,6 +1,6 @@
 import * as SorobanClient from 'soroban-client';
 import { Buffer } from "buffer";
-import { ResponseTypes } from './method-options.js';
+import type { ResponseTypes, Wallet } from './method-options.js';
 export * from './constants.js';
 export * from './server.js';
 export * from './invoke.js';
@@ -75,6 +75,9 @@ export type ComplexEnum = {
     tag: "Enum";
     values: [SimpleEnum];
 } | {
+    tag: "Asset";
+    values: [Address, i128];
+} | {
     tag: "Void";
     values: void;
 };
@@ -97,6 +100,16 @@ export declare function hello<R extends ResponseTypes = undefined>({ hello }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? string : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : string>;
 export declare function woid<R extends ResponseTypes = undefined>(options?: {
     /**
@@ -115,6 +128,16 @@ export declare function woid<R extends ResponseTypes = undefined>(options?: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? void : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : void>;
 export declare function val<R extends ResponseTypes = undefined>(options?: {
     /**
@@ -133,6 +156,16 @@ export declare function val<R extends ResponseTypes = undefined>(options?: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? any : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : any>;
 export declare function u32FailOnEven<R extends ResponseTypes = undefined>({ u32_ }: {
     u32_: u32;
@@ -153,6 +186,16 @@ export declare function u32FailOnEven<R extends ResponseTypes = undefined>({ u32
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? Err<Error_> | Ok<number> : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : Err<Error_> | Ok<number>>;
 export declare function u32<R extends ResponseTypes = undefined>({ u32_ }: {
     u32_: u32;
@@ -173,6 +216,16 @@ export declare function u32<R extends ResponseTypes = undefined>({ u32_ }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? number : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : number>;
 export declare function i32<R extends ResponseTypes = undefined>({ i32_ }: {
     i32_: i32;
@@ -193,6 +246,16 @@ export declare function i32<R extends ResponseTypes = undefined>({ i32_ }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? number : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : number>;
 export declare function i64<R extends ResponseTypes = undefined>({ i64_ }: {
     i64_: i64;
@@ -213,6 +276,16 @@ export declare function i64<R extends ResponseTypes = undefined>({ i64_ }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? bigint : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : bigint>;
 /**
  * Example contract method which takes a struct
@@ -236,6 +309,16 @@ export declare function struktHel<R extends ResponseTypes = undefined>({ strukt 
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? string[] : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : string[]>;
 export declare function strukt<R extends ResponseTypes = undefined>({ strukt }: {
     strukt: Test;
@@ -256,6 +339,16 @@ export declare function strukt<R extends ResponseTypes = undefined>({ strukt }: 
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? Test : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : Test>;
 export declare function simple<R extends ResponseTypes = undefined>({ simple }: {
     simple: SimpleEnum;
@@ -276,6 +369,16 @@ export declare function simple<R extends ResponseTypes = undefined>({ simple }: 
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? SimpleEnum : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : SimpleEnum>;
 export declare function complex<R extends ResponseTypes = undefined>({ complex }: {
     complex: ComplexEnum;
@@ -296,6 +399,16 @@ export declare function complex<R extends ResponseTypes = undefined>({ complex }
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? ComplexEnum : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : ComplexEnum>;
 export declare function addresse<R extends ResponseTypes = undefined>({ addresse }: {
     addresse: Address;
@@ -316,6 +429,16 @@ export declare function addresse<R extends ResponseTypes = undefined>({ addresse
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? string : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : string>;
 export declare function bytes<R extends ResponseTypes = undefined>({ bytes }: {
     bytes: Buffer;
@@ -336,6 +459,16 @@ export declare function bytes<R extends ResponseTypes = undefined>({ bytes }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? Buffer : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : Buffer>;
 export declare function bytesN<R extends ResponseTypes = undefined>({ bytes_n }: {
     bytes_n: Buffer;
@@ -356,6 +489,16 @@ export declare function bytesN<R extends ResponseTypes = undefined>({ bytes_n }:
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? Buffer : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : Buffer>;
 export declare function card<R extends ResponseTypes = undefined>({ card }: {
     card: RoyalCard;
@@ -376,6 +519,16 @@ export declare function card<R extends ResponseTypes = undefined>({ card }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? RoyalCard : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : RoyalCard>;
 export declare function booleanMethod<R extends ResponseTypes = undefined>({ boolean }: {
     boolean: boolean;
@@ -396,6 +549,16 @@ export declare function booleanMethod<R extends ResponseTypes = undefined>({ boo
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? boolean : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : boolean>;
 /**
  * Negates a boolean value
@@ -419,6 +582,16 @@ export declare function not<R extends ResponseTypes = undefined>({ boolean }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? boolean : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : boolean>;
 export declare function i128<R extends ResponseTypes = undefined>({ i128 }: {
     i128: i128;
@@ -439,6 +612,16 @@ export declare function i128<R extends ResponseTypes = undefined>({ i128 }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? bigint : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : bigint>;
 export declare function u128<R extends ResponseTypes = undefined>({ u128 }: {
     u128: u128;
@@ -459,6 +642,16 @@ export declare function u128<R extends ResponseTypes = undefined>({ u128 }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? bigint : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : bigint>;
 export declare function multiArgs<R extends ResponseTypes = undefined>({ a, b }: {
     a: u32;
@@ -480,6 +673,16 @@ export declare function multiArgs<R extends ResponseTypes = undefined>({ a, b }:
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? number : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : number>;
 export declare function map<R extends ResponseTypes = undefined>({ map }: {
     map: Map<u32, boolean>;
@@ -500,6 +703,16 @@ export declare function map<R extends ResponseTypes = undefined>({ map }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? Map<number, boolean> : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : Map<number, boolean>>;
 export declare function vec<R extends ResponseTypes = undefined>({ vec }: {
     vec: Array<u32>;
@@ -520,6 +733,16 @@ export declare function vec<R extends ResponseTypes = undefined>({ vec }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? number[] : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : number[]>;
 export declare function tuple<R extends ResponseTypes = undefined>({ tuple }: {
     tuple: [string, u32];
@@ -540,6 +763,16 @@ export declare function tuple<R extends ResponseTypes = undefined>({ tuple }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? [string, number] : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : [string, number]>;
 /**
  * Example of an optional argument
@@ -563,6 +796,16 @@ export declare function option<R extends ResponseTypes = undefined>({ option }: 
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? number : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : number>;
 export declare function u256<R extends ResponseTypes = undefined>({ u256 }: {
     u256: u256;
@@ -583,6 +826,16 @@ export declare function u256<R extends ResponseTypes = undefined>({ u256 }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? bigint : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : bigint>;
 export declare function i256<R extends ResponseTypes = undefined>({ i256 }: {
     i256: i256;
@@ -603,6 +856,16 @@ export declare function i256<R extends ResponseTypes = undefined>({ i256 }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? bigint : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : bigint>;
 export declare function string<R extends ResponseTypes = undefined>({ string }: {
     string: string;
@@ -623,6 +886,16 @@ export declare function string<R extends ResponseTypes = undefined>({ string }: 
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? string : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : string>;
 export declare function tupleStrukt<R extends ResponseTypes = undefined>({ tuple_strukt }: {
     tuple_strukt: TupleStruct;
@@ -643,4 +916,14 @@ export declare function tupleStrukt<R extends ResponseTypes = undefined>({ tuple
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? TupleStruct : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : TupleStruct>;

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/esm/index.js
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/esm/index.js
@@ -155,6 +155,11 @@ function ComplexEnumToXdr(complexEnum) {
             res.push(((i) => xdr.ScVal.scvSymbol(i))("Enum"));
             res.push(((i) => SimpleEnumToXdr(i))(complexEnum.values[0]));
             break;
+        case "Asset":
+            res.push(((i) => xdr.ScVal.scvSymbol(i))("Asset"));
+            res.push(((i) => addressToScVal(i))(complexEnum.values[0]));
+            res.push(((i) => i128ToScVal(i))(complexEnum.values[1]));
+            break;
         case "Void":
             res.push(((i) => xdr.ScVal.scvSymbol(i))("Void"));
             break;

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/esm/invoke.d.ts
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/esm/invoke.d.ts
@@ -1,6 +1,6 @@
 import * as SorobanClient from 'soroban-client';
 import type { Memo, MemoType, Operation, Transaction } from 'soroban-client';
-import { Options, ResponseTypes } from './method-options.js';
+import type { Options, ResponseTypes, Wallet } from './method-options.js';
 export type Tx = Transaction<Memo<MemoType>, Operation[]>;
 export declare class NotImplementedError extends Error {
 }
@@ -30,7 +30,7 @@ export declare function invoke<R extends ResponseTypes = undefined, T = string>(
  * or one of the exported contract methods, you may want to use this function
  * to sign the transaction with Freighter.
  */
-export declare function signTx(tx: Tx): Promise<Tx>;
+export declare function signTx(wallet: Wallet, tx: Tx): Promise<Tx>;
 /**
  * Send a transaction to the Soroban network.
  *

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/esm/method-options.d.ts
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/esm/method-options.d.ts
@@ -1,5 +1,18 @@
 declare let responseTypes: 'simulated' | 'full' | undefined;
 export type ResponseTypes = typeof responseTypes;
+export type XDR_BASE64 = string;
+export interface Wallet {
+    isConnected: () => Promise<boolean>;
+    isAllowed: () => Promise<boolean>;
+    getUserInfo: () => Promise<{
+        publicKey?: string;
+    }>;
+    signTransaction: (tx: XDR_BASE64, opts?: {
+        network?: string;
+        networkPassphrase?: string;
+        accountToSign?: string;
+    }) => Promise<XDR_BASE64>;
+}
 export type Options<R extends ResponseTypes> = {
     /**
      * The fee to pay for the transaction. Default: 100.
@@ -17,5 +30,15 @@ export type Options<R extends ResponseTypes> = {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 };
 export {};

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/types/index.d.ts
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/types/index.d.ts
@@ -1,6 +1,6 @@
 import * as SorobanClient from 'soroban-client';
 import { Buffer } from "buffer";
-import { ResponseTypes } from './method-options.js';
+import type { ResponseTypes, Wallet } from './method-options.js';
 export * from './constants.js';
 export * from './server.js';
 export * from './invoke.js';
@@ -75,6 +75,9 @@ export type ComplexEnum = {
     tag: "Enum";
     values: [SimpleEnum];
 } | {
+    tag: "Asset";
+    values: [Address, i128];
+} | {
     tag: "Void";
     values: void;
 };
@@ -97,6 +100,16 @@ export declare function hello<R extends ResponseTypes = undefined>({ hello }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? string : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : string>;
 export declare function woid<R extends ResponseTypes = undefined>(options?: {
     /**
@@ -115,6 +128,16 @@ export declare function woid<R extends ResponseTypes = undefined>(options?: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? void : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : void>;
 export declare function val<R extends ResponseTypes = undefined>(options?: {
     /**
@@ -133,6 +156,16 @@ export declare function val<R extends ResponseTypes = undefined>(options?: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? any : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : any>;
 export declare function u32FailOnEven<R extends ResponseTypes = undefined>({ u32_ }: {
     u32_: u32;
@@ -153,6 +186,16 @@ export declare function u32FailOnEven<R extends ResponseTypes = undefined>({ u32
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? Err<Error_> | Ok<number> : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : Err<Error_> | Ok<number>>;
 export declare function u32<R extends ResponseTypes = undefined>({ u32_ }: {
     u32_: u32;
@@ -173,6 +216,16 @@ export declare function u32<R extends ResponseTypes = undefined>({ u32_ }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? number : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : number>;
 export declare function i32<R extends ResponseTypes = undefined>({ i32_ }: {
     i32_: i32;
@@ -193,6 +246,16 @@ export declare function i32<R extends ResponseTypes = undefined>({ i32_ }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? number : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : number>;
 export declare function i64<R extends ResponseTypes = undefined>({ i64_ }: {
     i64_: i64;
@@ -213,6 +276,16 @@ export declare function i64<R extends ResponseTypes = undefined>({ i64_ }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? bigint : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : bigint>;
 /**
  * Example contract method which takes a struct
@@ -236,6 +309,16 @@ export declare function struktHel<R extends ResponseTypes = undefined>({ strukt 
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? string[] : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : string[]>;
 export declare function strukt<R extends ResponseTypes = undefined>({ strukt }: {
     strukt: Test;
@@ -256,6 +339,16 @@ export declare function strukt<R extends ResponseTypes = undefined>({ strukt }: 
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? Test : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : Test>;
 export declare function simple<R extends ResponseTypes = undefined>({ simple }: {
     simple: SimpleEnum;
@@ -276,6 +369,16 @@ export declare function simple<R extends ResponseTypes = undefined>({ simple }: 
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? SimpleEnum : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : SimpleEnum>;
 export declare function complex<R extends ResponseTypes = undefined>({ complex }: {
     complex: ComplexEnum;
@@ -296,6 +399,16 @@ export declare function complex<R extends ResponseTypes = undefined>({ complex }
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? ComplexEnum : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : ComplexEnum>;
 export declare function addresse<R extends ResponseTypes = undefined>({ addresse }: {
     addresse: Address;
@@ -316,6 +429,16 @@ export declare function addresse<R extends ResponseTypes = undefined>({ addresse
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? string : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : string>;
 export declare function bytes<R extends ResponseTypes = undefined>({ bytes }: {
     bytes: Buffer;
@@ -336,6 +459,16 @@ export declare function bytes<R extends ResponseTypes = undefined>({ bytes }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? Buffer : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : Buffer>;
 export declare function bytesN<R extends ResponseTypes = undefined>({ bytes_n }: {
     bytes_n: Buffer;
@@ -356,6 +489,16 @@ export declare function bytesN<R extends ResponseTypes = undefined>({ bytes_n }:
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? Buffer : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : Buffer>;
 export declare function card<R extends ResponseTypes = undefined>({ card }: {
     card: RoyalCard;
@@ -376,6 +519,16 @@ export declare function card<R extends ResponseTypes = undefined>({ card }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? RoyalCard : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : RoyalCard>;
 export declare function booleanMethod<R extends ResponseTypes = undefined>({ boolean }: {
     boolean: boolean;
@@ -396,6 +549,16 @@ export declare function booleanMethod<R extends ResponseTypes = undefined>({ boo
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? boolean : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : boolean>;
 /**
  * Negates a boolean value
@@ -419,6 +582,16 @@ export declare function not<R extends ResponseTypes = undefined>({ boolean }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? boolean : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : boolean>;
 export declare function i128<R extends ResponseTypes = undefined>({ i128 }: {
     i128: i128;
@@ -439,6 +612,16 @@ export declare function i128<R extends ResponseTypes = undefined>({ i128 }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? bigint : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : bigint>;
 export declare function u128<R extends ResponseTypes = undefined>({ u128 }: {
     u128: u128;
@@ -459,6 +642,16 @@ export declare function u128<R extends ResponseTypes = undefined>({ u128 }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? bigint : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : bigint>;
 export declare function multiArgs<R extends ResponseTypes = undefined>({ a, b }: {
     a: u32;
@@ -480,6 +673,16 @@ export declare function multiArgs<R extends ResponseTypes = undefined>({ a, b }:
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? number : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : number>;
 export declare function map<R extends ResponseTypes = undefined>({ map }: {
     map: Map<u32, boolean>;
@@ -500,6 +703,16 @@ export declare function map<R extends ResponseTypes = undefined>({ map }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? Map<number, boolean> : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : Map<number, boolean>>;
 export declare function vec<R extends ResponseTypes = undefined>({ vec }: {
     vec: Array<u32>;
@@ -520,6 +733,16 @@ export declare function vec<R extends ResponseTypes = undefined>({ vec }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? number[] : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : number[]>;
 export declare function tuple<R extends ResponseTypes = undefined>({ tuple }: {
     tuple: [string, u32];
@@ -540,6 +763,16 @@ export declare function tuple<R extends ResponseTypes = undefined>({ tuple }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? [string, number] : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : [string, number]>;
 /**
  * Example of an optional argument
@@ -563,6 +796,16 @@ export declare function option<R extends ResponseTypes = undefined>({ option }: 
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? number : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : number>;
 export declare function u256<R extends ResponseTypes = undefined>({ u256 }: {
     u256: u256;
@@ -583,6 +826,16 @@ export declare function u256<R extends ResponseTypes = undefined>({ u256 }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? bigint : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : bigint>;
 export declare function i256<R extends ResponseTypes = undefined>({ i256 }: {
     i256: i256;
@@ -603,6 +856,16 @@ export declare function i256<R extends ResponseTypes = undefined>({ i256 }: {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? bigint : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : bigint>;
 export declare function string<R extends ResponseTypes = undefined>({ string }: {
     string: string;
@@ -623,6 +886,16 @@ export declare function string<R extends ResponseTypes = undefined>({ string }: 
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? string : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : string>;
 export declare function tupleStrukt<R extends ResponseTypes = undefined>({ tuple_strukt }: {
     tuple_strukt: TupleStruct;
@@ -643,4 +916,14 @@ export declare function tupleStrukt<R extends ResponseTypes = undefined>({ tuple
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 }): Promise<R extends undefined ? TupleStruct : R extends "simulated" ? SorobanClient.SorobanRpc.SimulateTransactionResponse : R extends "full" ? SorobanClient.SorobanRpc.SimulateTransactionResponse | SorobanClient.SorobanRpc.SendTransactionResponse | SorobanClient.SorobanRpc.GetTransactionResponse : TupleStruct>;

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/types/invoke.d.ts
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/types/invoke.d.ts
@@ -1,6 +1,6 @@
 import * as SorobanClient from 'soroban-client';
 import type { Memo, MemoType, Operation, Transaction } from 'soroban-client';
-import { Options, ResponseTypes } from './method-options.js';
+import type { Options, ResponseTypes, Wallet } from './method-options.js';
 export type Tx = Transaction<Memo<MemoType>, Operation[]>;
 export declare class NotImplementedError extends Error {
 }
@@ -30,7 +30,7 @@ export declare function invoke<R extends ResponseTypes = undefined, T = string>(
  * or one of the exported contract methods, you may want to use this function
  * to sign the transaction with Freighter.
  */
-export declare function signTx(tx: Tx): Promise<Tx>;
+export declare function signTx(wallet: Wallet, tx: Tx): Promise<Tx>;
 /**
  * Send a transaction to the Soroban network.
  *

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/types/method-options.d.ts
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/dist/types/method-options.d.ts
@@ -1,5 +1,18 @@
 declare let responseTypes: 'simulated' | 'full' | undefined;
 export type ResponseTypes = typeof responseTypes;
+export type XDR_BASE64 = string;
+export interface Wallet {
+    isConnected: () => Promise<boolean>;
+    isAllowed: () => Promise<boolean>;
+    getUserInfo: () => Promise<{
+        publicKey?: string;
+    }>;
+    signTransaction: (tx: XDR_BASE64, opts?: {
+        network?: string;
+        networkPassphrase?: string;
+        accountToSign?: string;
+    }) => Promise<XDR_BASE64>;
+}
 export type Options<R extends ResponseTypes> = {
     /**
      * The fee to pay for the transaction. Default: 100.
@@ -17,5 +30,15 @@ export type Options<R extends ResponseTypes> = {
      * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
      */
     secondsToWait?: number;
+    /**
+     * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+     *
+     * ```ts
+     * import freighter from "@stellar/freighter-api";
+     *
+     * // later, when calling this function:
+     *   wallet: freighter,
+     */
+    wallet?: Wallet;
 };
 export {};

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/src/index.ts
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/src/index.ts
@@ -3,7 +3,7 @@ import { xdr } from 'soroban-client';
 import { Buffer } from "buffer";
 import { scValStrToJs, scValToJs, addressToScVal, u128ToScVal, i128ToScVal, strToScVal } from './convert.js';
 import { invoke } from './invoke.js';
-import { ResponseTypes } from './method-options.js'
+import type { ResponseTypes, Wallet } from './method-options.js'
 
 export * from './constants.js'
 export * from './server.js'
@@ -191,7 +191,7 @@ function TupleStructFromXdr(base64Xdr: string): TupleStruct {
     return scValStrToJs(base64Xdr) as TupleStruct;
 }
 
-export type ComplexEnum = {tag: "Struct", values: [Test]} | {tag: "Tuple", values: [TupleStruct]} | {tag: "Enum", values: [SimpleEnum]} | {tag: "Void", values: void};
+export type ComplexEnum = {tag: "Struct", values: [Test]} | {tag: "Tuple", values: [TupleStruct]} | {tag: "Enum", values: [SimpleEnum]} | {tag: "Asset", values: [Address, i128]} | {tag: "Void", values: void};
 
 function ComplexEnumToXdr(complexEnum?: ComplexEnum): xdr.ScVal {
     if (!complexEnum) {
@@ -210,6 +210,11 @@ function ComplexEnumToXdr(complexEnum?: ComplexEnum): xdr.ScVal {
     case "Enum":
             res.push(((i) => xdr.ScVal.scvSymbol(i))("Enum"));
             res.push(((i)=>SimpleEnumToXdr(i))(complexEnum.values[0]));
+            break;
+    case "Asset":
+            res.push(((i) => xdr.ScVal.scvSymbol(i))("Asset"));
+            res.push(((i)=>addressToScVal(i))(complexEnum.values[0]));
+            res.push(((i)=>i128ToScVal(i))(complexEnum.values[1]));
             break;
     case "Void":
             res.push(((i) => xdr.ScVal.scvSymbol(i))("Void"));
@@ -248,6 +253,16 @@ export async function hello<R extends ResponseTypes = undefined>({hello}: {hello
    * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
    */
   secondsToWait?: number
+  /**
+   * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+   *
+   * ```ts
+   * import freighter from "@stellar/freighter-api";
+   *
+   * // later, when calling this function:
+   *   wallet: freighter,
+   */
+  wallet?: Wallet
 } = {}) {
     return await invoke({
         method: 'hello',
@@ -276,6 +291,16 @@ export async function woid<R extends ResponseTypes = undefined>(options: {
    * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
    */
   secondsToWait?: number
+  /**
+   * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+   *
+   * ```ts
+   * import freighter from "@stellar/freighter-api";
+   *
+   * // later, when calling this function:
+   *   wallet: freighter,
+   */
+  wallet?: Wallet
 } = {}) {
     return await invoke({
         method: 'woid',
@@ -301,6 +326,16 @@ export async function val<R extends ResponseTypes = undefined>(options: {
    * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
    */
   secondsToWait?: number
+  /**
+   * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+   *
+   * ```ts
+   * import freighter from "@stellar/freighter-api";
+   *
+   * // later, when calling this function:
+   *   wallet: freighter,
+   */
+  wallet?: Wallet
 } = {}) {
     return await invoke({
         method: 'val',
@@ -328,6 +363,16 @@ export async function u32FailOnEven<R extends ResponseTypes = undefined>({u32_}:
    * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
    */
   secondsToWait?: number
+  /**
+   * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+   *
+   * ```ts
+   * import freighter from "@stellar/freighter-api";
+   *
+   * // later, when calling this function:
+   *   wallet: freighter,
+   */
+  wallet?: Wallet
 } = {}) {
     return await invoke({
         method: 'u32_fail_on_even',
@@ -366,6 +411,16 @@ export async function u32<R extends ResponseTypes = undefined>({u32_}: {u32_: u3
    * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
    */
   secondsToWait?: number
+  /**
+   * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+   *
+   * ```ts
+   * import freighter from "@stellar/freighter-api";
+   *
+   * // later, when calling this function:
+   *   wallet: freighter,
+   */
+  wallet?: Wallet
 } = {}) {
     return await invoke({
         method: 'u32_',
@@ -394,6 +449,16 @@ export async function i32<R extends ResponseTypes = undefined>({i32_}: {i32_: i3
    * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
    */
   secondsToWait?: number
+  /**
+   * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+   *
+   * ```ts
+   * import freighter from "@stellar/freighter-api";
+   *
+   * // later, when calling this function:
+   *   wallet: freighter,
+   */
+  wallet?: Wallet
 } = {}) {
     return await invoke({
         method: 'i32_',
@@ -422,6 +487,16 @@ export async function i64<R extends ResponseTypes = undefined>({i64_}: {i64_: i6
    * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
    */
   secondsToWait?: number
+  /**
+   * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+   *
+   * ```ts
+   * import freighter from "@stellar/freighter-api";
+   *
+   * // later, when calling this function:
+   *   wallet: freighter,
+   */
+  wallet?: Wallet
 } = {}) {
     return await invoke({
         method: 'i64_',
@@ -453,6 +528,16 @@ export async function struktHel<R extends ResponseTypes = undefined>({strukt}: {
    * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
    */
   secondsToWait?: number
+  /**
+   * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+   *
+   * ```ts
+   * import freighter from "@stellar/freighter-api";
+   *
+   * // later, when calling this function:
+   *   wallet: freighter,
+   */
+  wallet?: Wallet
 } = {}) {
     return await invoke({
         method: 'strukt_hel',
@@ -481,6 +566,16 @@ export async function strukt<R extends ResponseTypes = undefined>({strukt}: {str
    * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
    */
   secondsToWait?: number
+  /**
+   * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+   *
+   * ```ts
+   * import freighter from "@stellar/freighter-api";
+   *
+   * // later, when calling this function:
+   *   wallet: freighter,
+   */
+  wallet?: Wallet
 } = {}) {
     return await invoke({
         method: 'strukt',
@@ -509,6 +604,16 @@ export async function simple<R extends ResponseTypes = undefined>({simple}: {sim
    * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
    */
   secondsToWait?: number
+  /**
+   * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+   *
+   * ```ts
+   * import freighter from "@stellar/freighter-api";
+   *
+   * // later, when calling this function:
+   *   wallet: freighter,
+   */
+  wallet?: Wallet
 } = {}) {
     return await invoke({
         method: 'simple',
@@ -537,6 +642,16 @@ export async function complex<R extends ResponseTypes = undefined>({complex}: {c
    * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
    */
   secondsToWait?: number
+  /**
+   * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+   *
+   * ```ts
+   * import freighter from "@stellar/freighter-api";
+   *
+   * // later, when calling this function:
+   *   wallet: freighter,
+   */
+  wallet?: Wallet
 } = {}) {
     return await invoke({
         method: 'complex',
@@ -565,6 +680,16 @@ export async function addresse<R extends ResponseTypes = undefined>({addresse}: 
    * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
    */
   secondsToWait?: number
+  /**
+   * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+   *
+   * ```ts
+   * import freighter from "@stellar/freighter-api";
+   *
+   * // later, when calling this function:
+   *   wallet: freighter,
+   */
+  wallet?: Wallet
 } = {}) {
     return await invoke({
         method: 'addresse',
@@ -593,6 +718,16 @@ export async function bytes<R extends ResponseTypes = undefined>({bytes}: {bytes
    * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
    */
   secondsToWait?: number
+  /**
+   * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+   *
+   * ```ts
+   * import freighter from "@stellar/freighter-api";
+   *
+   * // later, when calling this function:
+   *   wallet: freighter,
+   */
+  wallet?: Wallet
 } = {}) {
     return await invoke({
         method: 'bytes',
@@ -621,6 +756,16 @@ export async function bytesN<R extends ResponseTypes = undefined>({bytes_n}: {by
    * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
    */
   secondsToWait?: number
+  /**
+   * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+   *
+   * ```ts
+   * import freighter from "@stellar/freighter-api";
+   *
+   * // later, when calling this function:
+   *   wallet: freighter,
+   */
+  wallet?: Wallet
 } = {}) {
     return await invoke({
         method: 'bytes_n',
@@ -649,6 +794,16 @@ export async function card<R extends ResponseTypes = undefined>({card}: {card: R
    * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
    */
   secondsToWait?: number
+  /**
+   * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+   *
+   * ```ts
+   * import freighter from "@stellar/freighter-api";
+   *
+   * // later, when calling this function:
+   *   wallet: freighter,
+   */
+  wallet?: Wallet
 } = {}) {
     return await invoke({
         method: 'card',
@@ -677,6 +832,16 @@ export async function booleanMethod<R extends ResponseTypes = undefined>({boolea
    * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
    */
   secondsToWait?: number
+  /**
+   * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+   *
+   * ```ts
+   * import freighter from "@stellar/freighter-api";
+   *
+   * // later, when calling this function:
+   *   wallet: freighter,
+   */
+  wallet?: Wallet
 } = {}) {
     return await invoke({
         method: 'boolean',
@@ -708,6 +873,16 @@ export async function not<R extends ResponseTypes = undefined>({boolean}: {boole
    * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
    */
   secondsToWait?: number
+  /**
+   * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+   *
+   * ```ts
+   * import freighter from "@stellar/freighter-api";
+   *
+   * // later, when calling this function:
+   *   wallet: freighter,
+   */
+  wallet?: Wallet
 } = {}) {
     return await invoke({
         method: 'not',
@@ -736,6 +911,16 @@ export async function i128<R extends ResponseTypes = undefined>({i128}: {i128: i
    * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
    */
   secondsToWait?: number
+  /**
+   * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+   *
+   * ```ts
+   * import freighter from "@stellar/freighter-api";
+   *
+   * // later, when calling this function:
+   *   wallet: freighter,
+   */
+  wallet?: Wallet
 } = {}) {
     return await invoke({
         method: 'i128',
@@ -764,6 +949,16 @@ export async function u128<R extends ResponseTypes = undefined>({u128}: {u128: u
    * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
    */
   secondsToWait?: number
+  /**
+   * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+   *
+   * ```ts
+   * import freighter from "@stellar/freighter-api";
+   *
+   * // later, when calling this function:
+   *   wallet: freighter,
+   */
+  wallet?: Wallet
 } = {}) {
     return await invoke({
         method: 'u128',
@@ -792,6 +987,16 @@ export async function multiArgs<R extends ResponseTypes = undefined>({a, b}: {a:
    * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
    */
   secondsToWait?: number
+  /**
+   * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+   *
+   * ```ts
+   * import freighter from "@stellar/freighter-api";
+   *
+   * // later, when calling this function:
+   *   wallet: freighter,
+   */
+  wallet?: Wallet
 } = {}) {
     return await invoke({
         method: 'multi_args',
@@ -821,6 +1026,16 @@ export async function map<R extends ResponseTypes = undefined>({map}: {map: Map<
    * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
    */
   secondsToWait?: number
+  /**
+   * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+   *
+   * ```ts
+   * import freighter from "@stellar/freighter-api";
+   *
+   * // later, when calling this function:
+   *   wallet: freighter,
+   */
+  wallet?: Wallet
 } = {}) {
     return await invoke({
         method: 'map',
@@ -853,6 +1068,16 @@ export async function vec<R extends ResponseTypes = undefined>({vec}: {vec: Arra
    * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
    */
   secondsToWait?: number
+  /**
+   * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+   *
+   * ```ts
+   * import freighter from "@stellar/freighter-api";
+   *
+   * // later, when calling this function:
+   *   wallet: freighter,
+   */
+  wallet?: Wallet
 } = {}) {
     return await invoke({
         method: 'vec',
@@ -881,6 +1106,16 @@ export async function tuple<R extends ResponseTypes = undefined>({tuple}: {tuple
    * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
    */
   secondsToWait?: number
+  /**
+   * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+   *
+   * ```ts
+   * import freighter from "@stellar/freighter-api";
+   *
+   * // later, when calling this function:
+   *   wallet: freighter,
+   */
+  wallet?: Wallet
 } = {}) {
     return await invoke({
         method: 'tuple',
@@ -913,6 +1148,16 @@ export async function option<R extends ResponseTypes = undefined>({option}: {opt
    * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
    */
   secondsToWait?: number
+  /**
+   * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+   *
+   * ```ts
+   * import freighter from "@stellar/freighter-api";
+   *
+   * // later, when calling this function:
+   *   wallet: freighter,
+   */
+  wallet?: Wallet
 } = {}) {
     return await invoke({
         method: 'option',
@@ -941,6 +1186,16 @@ export async function u256<R extends ResponseTypes = undefined>({u256}: {u256: u
    * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
    */
   secondsToWait?: number
+  /**
+   * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+   *
+   * ```ts
+   * import freighter from "@stellar/freighter-api";
+   *
+   * // later, when calling this function:
+   *   wallet: freighter,
+   */
+  wallet?: Wallet
 } = {}) {
     return await invoke({
         method: 'u256',
@@ -969,6 +1224,16 @@ export async function i256<R extends ResponseTypes = undefined>({i256}: {i256: i
    * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
    */
   secondsToWait?: number
+  /**
+   * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+   *
+   * ```ts
+   * import freighter from "@stellar/freighter-api";
+   *
+   * // later, when calling this function:
+   *   wallet: freighter,
+   */
+  wallet?: Wallet
 } = {}) {
     return await invoke({
         method: 'i256',
@@ -997,6 +1262,16 @@ export async function string<R extends ResponseTypes = undefined>({string}: {str
    * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
    */
   secondsToWait?: number
+  /**
+   * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+   *
+   * ```ts
+   * import freighter from "@stellar/freighter-api";
+   *
+   * // later, when calling this function:
+   *   wallet: freighter,
+   */
+  wallet?: Wallet
 } = {}) {
     return await invoke({
         method: 'string',
@@ -1025,6 +1300,16 @@ export async function tupleStrukt<R extends ResponseTypes = undefined>({tuple_st
    * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
    */
   secondsToWait?: number
+  /**
+   * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+   *
+   * ```ts
+   * import freighter from "@stellar/freighter-api";
+   *
+   * // later, when calling this function:
+   *   wallet: freighter,
+   */
+  wallet?: Wallet
 } = {}) {
     return await invoke({
         method: 'tuple_strukt',

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/src/invoke.ts
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/src/invoke.ts
@@ -1,16 +1,8 @@
-import freighter from "@stellar/freighter-api";
-// working around ESM compatibility issues
-const {
-  isConnected,
-  isAllowed,
-  getUserInfo,
-  signTransaction,
-} = freighter;
 import * as SorobanClient from 'soroban-client'
 import type { Account, Memo, MemoType, Operation, Transaction } from 'soroban-client';
 import { NETWORK_PASSPHRASE, CONTRACT_ID } from './constants.js'
 import { Server } from './server.js'
-import { Options, ResponseTypes } from './method-options.js'
+import type { Options, ResponseTypes, Wallet } from './method-options.js'
 
 export type Tx = Transaction<Memo<MemoType>, Operation[]>
 
@@ -18,11 +10,11 @@ export type Tx = Transaction<Memo<MemoType>, Operation[]>
  * Get account details from the Soroban network for the publicKey currently
  * selected in Freighter. If not connected to Freighter, return null.
  */
-async function getAccount(): Promise<Account | null> {
-  if (!await isConnected() || !await isAllowed()) {
+async function getAccount(wallet: Wallet): Promise<Account | null> {
+  if (!await wallet.isConnected() || !await wallet.isAllowed()) {
     return null
   }
-  const { publicKey } = await getUserInfo()
+  const { publicKey } = await wallet.getUserInfo()
   if (!publicKey) {
     return null
   }
@@ -60,11 +52,13 @@ export async function invoke<R extends ResponseTypes, T = string>({
   responseType,
   parseResultXdr,
   secondsToWait = 10,
+  wallet,
 }: InvokeArgs<R, T>): Promise<T | string | SomeRpcResponse> {
-  const freighterAccount = await getAccount()
+  wallet = wallet ?? await import('@stellar/freighter-api')
+  const walletAccount = await getAccount(wallet)
 
   // use a placeholder null account if not yet connected to Freighter so that view calls can still work
-  const account = freighterAccount ?? new SorobanClient.Account('GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF', '0')
+  const account = walletAccount ?? new SorobanClient.Account('GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF', '0')
 
   const contract = new SorobanClient.Contract(CONTRACT_ID)
 
@@ -82,14 +76,15 @@ export async function invoke<R extends ResponseTypes, T = string>({
 
   // is it possible for `auths` to be present but empty? Probably not, but let's be safe.
   const auths = simulated.results?.[0]?.auth
-  let authsCount =  auths?.length ?? 0;
+  let authsCount = auths?.length ?? 0;
 
   const writeLength = SorobanClient.xdr.SorobanTransactionData.fromXDR(simulated.transactionData, 'base64').resources().footprint().readWrite().length
 
   const parse = parseResultXdr ?? (xdr => xdr)
 
-  // if VIEW ˅˅˅˅
-  if (authsCount === 0 && writeLength === 0) {
+  const isViewCall = authsCount === 0 && writeLength === 0
+
+  if (isViewCall) {
     if (responseType === 'full') return simulated
 
     const { results } = simulated
@@ -102,7 +97,6 @@ export async function invoke<R extends ResponseTypes, T = string>({
     return parse(results[0].xdr)
   }
 
-  // ^^^^ else, is CHANGE method ˅˅˅˅
   if (authsCount > 1) {
     throw new NotImplementedError("Multiple auths not yet supported")
   }
@@ -115,15 +109,16 @@ export async function invoke<R extends ResponseTypes, T = string>({
     //     }; Not yet supported`
     //   )
     // }
-
-    if (!freighterAccount) {
-      throw new Error('Not connected to Freighter')
-    }
-
-    tx = await signTx(
-      SorobanClient.assembleTransaction(tx, NETWORK_PASSPHRASE, simulated) as Tx
-    );
   }
+
+  if (!walletAccount) {
+    throw new Error('Not connected to Freighter')
+  }
+
+  tx = await signTx(
+    wallet,
+    SorobanClient.assembleTransaction(tx, NETWORK_PASSPHRASE, simulated) as Tx
+  );
 
   const raw = await sendTx(tx, secondsToWait);
 
@@ -149,8 +144,8 @@ export async function invoke<R extends ResponseTypes, T = string>({
  * or one of the exported contract methods, you may want to use this function
  * to sign the transaction with Freighter.
  */
-export async function signTx(tx: Tx): Promise<Tx> {
-  const signed = await signTransaction(tx.toXDR(), {
+export async function signTx(wallet: Wallet, tx: Tx): Promise<Tx> {
+  const signed = await wallet.signTransaction(tx.toXDR(), {
     networkPassphrase: NETWORK_PASSPHRASE,
   })
 

--- a/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/src/method-options.ts
+++ b/cmd/crates/soroban-spec-typescript/fixtures/test_custom_types/src/method-options.ts
@@ -2,16 +2,29 @@
 let responseTypes: 'simulated' | 'full' | undefined
 export type ResponseTypes = typeof responseTypes
 
+export type XDR_BASE64 = string
+
+export interface Wallet {
+  isConnected: () => Promise<boolean>,
+  isAllowed: () => Promise<boolean>,
+  getUserInfo: () => Promise<{ publicKey?: string }>,
+  signTransaction: (tx: XDR_BASE64, opts?: {
+    network?: string,
+    networkPassphrase?: string,
+    accountToSign?: string,
+  }) => Promise<XDR_BASE64>,
+}
+
 export type Options<R extends ResponseTypes> = {
   /**
    * The fee to pay for the transaction. Default: 100.
    */
   fee?: number
   /**
-   * What type of response to return. 
+   * What type of response to return.
    *
    *   - `undefined`, the default,  parses the returned XDR as `{RETURN_TYPE}`. Runs preflight, checks to see if auth/signing is required, and sends the transaction if so. If there's no error and `secondsToWait` is positive, awaits the finalized transaction.
-   *   - `'simulated'` will only simulate/preflight the transaction, even if it's a change/set method that requires auth/signing. Returns full preflight info. 
+   *   - `'simulated'` will only simulate/preflight the transaction, even if it's a change/set method that requires auth/signing. Returns full preflight info.
    *   - `'full'` return the full RPC response, meaning either 1. the preflight info, if it's a view/read method that doesn't require auth/signing, or 2. the `sendTransaction` response, if there's a problem with sending the transaction or if you set `secondsToWait` to 0, or 3. the `getTransaction` response, if it's a change method with no `sendTransaction` errors and a positive `secondsToWait`.
    */
   responseType?: R
@@ -19,4 +32,14 @@ export type Options<R extends ResponseTypes> = {
    * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
    */
   secondsToWait?: number
+  /**
+   * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+   *
+   * ```ts
+   * import freighter from "@stellar/freighter-api";
+   *
+   * // later, when calling this function:
+   *   wallet: freighter,
+   */
+  wallet?: Wallet
 }

--- a/cmd/crates/soroban-spec-typescript/src/lib.rs
+++ b/cmd/crates/soroban-spec-typescript/src/lib.rs
@@ -110,6 +110,16 @@ fn method_options(return_type: &String) -> String {
    * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {{@link SorobanClient.SorobanRpc.GetTransactionResponse}} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {{@link SorobanClient.SorobanRpc.SendTransactionResponse}} more quickly, before the transaction has time to be included in the ledger. Default: 10.
    */
   secondsToWait?: number
+  /**
+   * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+   *
+   * ```ts
+   * import freighter from "@stellar/freighter-api";
+   *
+   * // later, when calling this function:
+   *   wallet: freighter,
+   */
+  wallet?: Wallet
 }}"#
     )
 }

--- a/cmd/crates/soroban-spec-typescript/src/project_template/src/index.ts
+++ b/cmd/crates/soroban-spec-typescript/src/project_template/src/index.ts
@@ -3,7 +3,7 @@ import { xdr } from 'soroban-client';
 import { Buffer } from "buffer";
 import { scValStrToJs, scValToJs, addressToScVal, u128ToScVal, i128ToScVal, strToScVal } from './convert.js';
 import { invoke } from './invoke.js';
-import { ResponseTypes } from './method-options.js'
+import type { ResponseTypes, Wallet } from './method-options.js'
 
 export * from './constants.js'
 export * from './server.js'

--- a/cmd/crates/soroban-spec-typescript/src/project_template/src/method-options.ts
+++ b/cmd/crates/soroban-spec-typescript/src/project_template/src/method-options.ts
@@ -2,16 +2,29 @@
 let responseTypes: 'simulated' | 'full' | undefined
 export type ResponseTypes = typeof responseTypes
 
+export type XDR_BASE64 = string
+
+export interface Wallet {
+  isConnected: () => Promise<boolean>,
+  isAllowed: () => Promise<boolean>,
+  getUserInfo: () => Promise<{ publicKey?: string }>,
+  signTransaction: (tx: XDR_BASE64, opts?: {
+    network?: string,
+    networkPassphrase?: string,
+    accountToSign?: string,
+  }) => Promise<XDR_BASE64>,
+}
+
 export type Options<R extends ResponseTypes> = {
   /**
    * The fee to pay for the transaction. Default: 100.
    */
   fee?: number
   /**
-   * What type of response to return. 
+   * What type of response to return.
    *
    *   - `undefined`, the default,  parses the returned XDR as `{RETURN_TYPE}`. Runs preflight, checks to see if auth/signing is required, and sends the transaction if so. If there's no error and `secondsToWait` is positive, awaits the finalized transaction.
-   *   - `'simulated'` will only simulate/preflight the transaction, even if it's a change/set method that requires auth/signing. Returns full preflight info. 
+   *   - `'simulated'` will only simulate/preflight the transaction, even if it's a change/set method that requires auth/signing. Returns full preflight info.
    *   - `'full'` return the full RPC response, meaning either 1. the preflight info, if it's a view/read method that doesn't require auth/signing, or 2. the `sendTransaction` response, if there's a problem with sending the transaction or if you set `secondsToWait` to 0, or 3. the `getTransaction` response, if it's a change method with no `sendTransaction` errors and a positive `secondsToWait`.
    */
   responseType?: R
@@ -19,4 +32,14 @@ export type Options<R extends ResponseTypes> = {
    * If the simulation shows that this invocation requires auth/signing, `invoke` will wait `secondsToWait` seconds for the transaction to complete before giving up and returning the incomplete {@link SorobanClient.SorobanRpc.GetTransactionResponse} results (or attempting to parse their probably-missing XDR with `parseResultXdr`, depending on `responseType`). Set this to `0` to skip waiting altogether, which will return you {@link SorobanClient.SorobanRpc.SendTransactionResponse} more quickly, before the transaction has time to be included in the ledger. Default: 10.
    */
   secondsToWait?: number
+  /**
+   * A Wallet interface, such as Freighter, that has the methods `isConnected`, `isAllowed`, `getUserInfo`, and `signTransaction`. If not provided, will attempt to import and use Freighter. Example:
+   *
+   * ```ts
+   * import freighter from "@stellar/freighter-api";
+   *
+   * // later, when calling this function:
+   *   wallet: freighter,
+   */
+  wallet?: Wallet
 }


### PR DESCRIPTION
### What

By default, if you do not provide a `wallet` option to one of the
exported functions or `invoke`, then it will continue to import and use
Freighter.

But now you can also pass your own Wallet interface to any of these
functions.


### Why

This facilitates testing the generated libraries with Node, as well as
using them with other Wallet options.



### Known limitations

Does not yet offer similar injectability for network settings & contract
ID.