### PR TITLE
soroban-rpc: Add restore footprint test (now that expiration is tunable)

### DIFF
--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -107,7 +107,7 @@ jobs:
     env:
       SOROBAN_RPC_INTEGRATION_TESTS_ENABLED: true
       SOROBAN_RPC_INTEGRATION_TESTS_CAPTIVE_CORE_BIN: /usr/bin/stellar-core
-      PROTOCOL_20_CORE_DEBIAN_PKG_VERSION: 19.12.1-1399.c2599d622.focal~soroban
+      PROTOCOL_20_CORE_DEBIAN_PKG_VERSION: 19.12.1-1416.9215e8d7a.focal~soroban
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -107,7 +107,7 @@ jobs:
     env:
       SOROBAN_RPC_INTEGRATION_TESTS_ENABLED: true
       SOROBAN_RPC_INTEGRATION_TESTS_CAPTIVE_CORE_BIN: /usr/bin/stellar-core
-      PROTOCOL_20_CORE_DEBIAN_PKG_VERSION: 19.12.1-1416.9215e8d7a.focal~soroban
+      PROTOCOL_20_CORE_DEBIAN_PKG_VERSION: 19.12.1-1419.0ad2053d5.focal~soroban
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/cmd/crates/soroban-test/tests/fixtures/test-wasms/hello_world/src/lib.rs
+++ b/cmd/crates/soroban-test/tests/fixtures/test-wasms/hello_world/src/lib.rs
@@ -31,14 +31,14 @@ impl Contract {
     }
 
     pub fn inc(env: Env) {
-        let mut count: u32 = env.storage().temporary().get(&COUNTER).unwrap_or(0); // Panic if the value of COUNTER is not u32.
+        let mut count: u32 = env.storage().persistent().get(&COUNTER).unwrap_or(0); // Panic if the value of COUNTER is not u32.
         log!(&env, "count: {}", count);
 
         // Increment the count.
         count += 1;
 
         // Save the count.
-        env.storage().temporary().set(&COUNTER, &count);
+        env.storage().persistent().set(&COUNTER, &count);
     }
 
     #[allow(unused_variables)]

--- a/cmd/soroban-rpc/internal/test/captive-core-integration-tests.cfg
+++ b/cmd/soroban-rpc/internal/test/captive-core-integration-tests.cfg
@@ -5,6 +5,9 @@ UNSAFE_QUORUM=true
 FAILURE_SAFETY=0
 
 ENABLE_SOROBAN_DIAGNOSTIC_EVENTS=true
+# Lower the expiration of persistent ledger entries
+# so that ledger expiration/restoring becomes testeable
+TESTING_MINIMUM_PERSISTENT_ENTRY_LIFETIME=20
 
 [[VALIDATORS]]
 NAME="local_core"

--- a/cmd/soroban-rpc/internal/test/core-start.sh
+++ b/cmd/soroban-rpc/internal/test/core-start.sh
@@ -26,4 +26,4 @@ if [ "$1" = "standalone" ]; then
   popd
 fi
 
-exec stellar-core run
+exec stellar-core run --console

--- a/cmd/soroban-rpc/internal/test/docker-compose.yml
+++ b/cmd/soroban-rpc/internal/test/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     # Note: Please keep the image pinned to an immutable tag matching the Captive Core version.
     #       This avoid implicit updates which break compatibility between
     #       the Core container and captive core.
-    image: ${CORE_IMAGE:-2opremio/stellar-core:19.12.1-1399.c2599d622.focal-soroban}
+    image: ${CORE_IMAGE:-2opremio/stellar-core:19.12.1-1416.9215e8d7a.focal-soroban}
     depends_on:
       - core-postgres
     restart: on-failure

--- a/cmd/soroban-rpc/internal/test/docker-compose.yml
+++ b/cmd/soroban-rpc/internal/test/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     # Note: Please keep the image pinned to an immutable tag matching the Captive Core version.
     #       This avoid implicit updates which break compatibility between
     #       the Core container and captive core.
-    image: ${CORE_IMAGE:-2opremio/stellar-core:19.12.1-1416.9215e8d7a.focal-soroban}
+    image: ${CORE_IMAGE:-2opremio/stellar-core:19.12.1-1419.0ad2053d5.focal-soroban}
     depends_on:
       - core-postgres
     restart: on-failure

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -805,5 +805,4 @@ func TestSimulateTransactionBumpAndRestoreFootprint(t *testing.T) {
 	tx, err = txnbuild.NewTransaction(params)
 	assert.NoError(t, err)
 	sendSuccessfulTransaction(t, client, sourceAccount, tx)
-
 }

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -740,7 +740,7 @@ func TestSimulateTransactionBumpAndRestoreFootprint(t *testing.T) {
 		IncrementSequenceNum: true,
 		Operations: []txnbuild.Operation{
 			&txnbuild.BumpFootprintExpiration{
-				LedgersToExpire: 10,
+				LedgersToExpire: 20,
 				Ext: xdr.TransactionExt{
 					V: 1,
 					SorobanData: &xdr.SorobanTransactionData{

--- a/cmd/soroban-rpc/internal/test/stellar-core-integration-tests.cfg
+++ b/cmd/soroban-rpc/internal/test/stellar-core-integration-tests.cfg
@@ -15,6 +15,9 @@ FAILURE_SAFETY=0
 DATABASE="postgresql://user=postgres password=mysecretpassword host=core-postgres port=5641 dbname=stellar"
 
 ENABLE_SOROBAN_DIAGNOSTIC_EVENTS=true
+# Lower the expiration of persistent ledger entries
+# so that ledger expiration/restoring becomes testeable
+TESTING_MINIMUM_PERSISTENT_ENTRY_LIFETIME=20
 
 [QUORUM_SET]
 THRESHOLD_PERCENT=100


### PR DESCRIPTION
Second attempt at #757 now that Core provided `TESTING_MINIMUM_PERSISTENT_ENTRY_LIFETIME` to make it testeable.