### PR TITLE
Feat(CLI) restore/bump --wash_hash

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/bump.rs
+++ b/cmd/soroban-cli/src/commands/contract/bump.rs
@@ -160,10 +160,10 @@ impl Cmd {
             .prepare_and_send_transaction(&tx, &key, &network.network_passphrase, None)
             .await?;
 
-        tracing::debug!(?result);
-        tracing::debug!(?meta);
+        tracing::trace!(?result);
+        tracing::trace!(?meta);
         if !events.is_empty() {
-            tracing::debug!(?events);
+            tracing::info!("Events:\n {events:#?}");
         }
 
         // The transaction from core will succeed regardless of whether it actually found & bumped

--- a/cmd/soroban-cli/src/commands/contract/bump.rs
+++ b/cmd/soroban-cli/src/commands/contract/bump.rs
@@ -8,10 +8,10 @@ use clap::{command, Parser};
 use soroban_env_host::xdr::{
     BumpFootprintExpirationOp, ContractCodeEntry, ContractDataEntry, ContractEntryBodyType,
     Error as XdrError, ExtensionPoint, Hash, LedgerEntry, LedgerEntryChange, LedgerEntryData,
-    LedgerFootprint, LedgerKey, LedgerKeyContractData, Memo, MuxedAccount, Operation,
-    OperationBody, Preconditions, ReadXdr, ScAddress, ScSpecTypeDef, ScVal, SequenceNumber,
-    SorobanResources, SorobanTransactionData, Transaction, TransactionExt, TransactionMeta,
-    TransactionMetaV3, Uint256,
+    LedgerFootprint, LedgerKey, LedgerKeyContractCode, LedgerKeyContractData, Memo, MuxedAccount,
+    Operation, OperationBody, Preconditions, ReadXdr, ScAddress, ScSpecTypeDef, ScVal,
+    SequenceNumber, SorobanResources, SorobanTransactionData, Transaction, TransactionExt,
+    TransactionMeta, TransactionMetaV3, Uint256,
 };
 use stellar_strkey::DecodeError;
 
@@ -27,7 +27,11 @@ use crate::{
 pub struct Cmd {
     /// Contract ID to which owns the data entries.
     /// If no keys provided the Contract's instance will be bumped
-    #[arg(long = "id", required_unless_present = "wasm")]
+    #[arg(
+        long = "id",
+        required_unless_present = "wasm",
+        required_unless_present = "wasm_hash"
+    )]
     contract_id: Option<String>,
     /// Storage key (symbols only)
     #[arg(long = "key", conflicts_with = "key_xdr")]
@@ -40,9 +44,19 @@ pub struct Cmd {
         long,
         conflicts_with = "contract_id",
         conflicts_with = "key",
-        conflicts_with = "key_xdr"
+        conflicts_with = "key_xdr",
+        conflicts_with = "wasm_hash"
     )]
     wasm: Option<PathBuf>,
+    /// Path to Wasm file of contract code to bump
+    #[arg(
+        long,
+        conflicts_with = "contract_id",
+        conflicts_with = "key",
+        conflicts_with = "key_xdr",
+        conflicts_with = "wasm"
+    )]
+    wasm_hash: Option<String>,
     /// Storage entry durability
     #[arg(long, value_enum, required = true)]
     durability: Durability,
@@ -239,11 +253,6 @@ impl Cmd {
         Ok(new_expiration_ledger_seq)
     }
 
-    fn contract_id(&self) -> Result<[u8; 32], Error> {
-        utils::contract_id_from_str(self.contract_id.as_ref().unwrap())
-            .map_err(|e| Error::CannotParseContractId(self.contract_id.clone().unwrap(), e))
-    }
-
     fn parse_key(&self) -> Result<LedgerKey, Error> {
         let key = if let Some(key) = &self.key {
             soroban_spec_tools::from_string_primitive(key, &ScSpecTypeDef::Symbol).map_err(|e| {
@@ -259,10 +268,18 @@ impl Cmd {
             })?
         } else if let Some(wasm) = &self.wasm {
             return Ok(crate::wasm::Args { wasm: wasm.clone() }.try_into()?);
+        } else if let Some(wasm_hash) = &self.wasm_hash {
+            return Ok(LedgerKey::ContractCode(LedgerKeyContractCode {
+                hash: Hash(
+                    utils::contract_id_from_str(wasm_hash)
+                        .map_err(|e| Error::CannotParseContractId(wasm_hash.clone(), e))?,
+                ),
+                body_type: ContractEntryBodyType::DataEntry,
+            }));
         } else {
             ScVal::LedgerKeyContractInstance
         };
-        let contract_id = self.contract_id()?;
+        let contract_id = contract_id(self.contract_id.as_ref().unwrap())?;
 
         Ok(LedgerKey::ContractData(LedgerKeyContractData {
             contract: ScAddress::Contract(Hash(contract_id)),
@@ -284,4 +301,8 @@ fn bump_entry(v: &LedgerEntry, ledgers_to_expire: u32) -> (LedgerEntry, u32) {
         new_expiration_ledger_seq = code.expiration_ledger_seq;
     }
     (new_v, new_expiration_ledger_seq)
+}
+
+fn contract_id(s: &str) -> Result<[u8; 32], Error> {
+    utils::contract_id_from_str(s).map_err(|e| Error::CannotParseContractId(s.to_string(), e))
 }

--- a/cmd/soroban-cli/src/commands/contract/install.rs
+++ b/cmd/soroban-cli/src/commands/contract/install.rs
@@ -114,6 +114,7 @@ impl Cmd {
                 key: vec![],
                 key_xdr: vec![],
                 wasm: Some(self.wasm.wasm.clone()),
+                wasm_hash: None,
                 config: self.config.clone(),
                 fee: self.fee.clone(),
             }

--- a/cmd/soroban-cli/src/commands/contract/restore.rs
+++ b/cmd/soroban-cli/src/commands/contract/restore.rs
@@ -184,10 +184,10 @@ impl Cmd {
             return Err(Error::LedgerEntryNotFound);
         }
 
-        if operations[0].changes.len() != 1 {
+        if operations[0].changes.len() != 2 {
             return Err(Error::LedgerEntryNotFound);
         }
-        match operations[0].changes[0] {
+        match operations[0].changes[1] {
             LedgerEntryChange::Updated(LedgerEntry {
                 data:
                     LedgerEntryData::ContractData(ContractDataEntry {

--- a/cmd/soroban-cli/src/commands/contract/restore.rs
+++ b/cmd/soroban-cli/src/commands/contract/restore.rs
@@ -8,10 +8,10 @@ use clap::{command, Parser};
 use soroban_env_host::xdr::{
     ContractCodeEntry, ContractDataDurability, ContractDataEntry, ContractEntryBodyType,
     Error as XdrError, ExtensionPoint, Hash, LedgerEntry, LedgerEntryChange, LedgerEntryData,
-    LedgerFootprint, LedgerKey, LedgerKeyContractData, Memo, MuxedAccount, Operation,
-    OperationBody, Preconditions, ReadXdr, RestoreFootprintOp, ScAddress, ScSpecTypeDef, ScVal,
-    SequenceNumber, SorobanResources, SorobanTransactionData, Transaction, TransactionExt,
-    TransactionMeta, TransactionMetaV3, Uint256,
+    LedgerFootprint, LedgerKey, LedgerKeyContractCode, LedgerKeyContractData, Memo, MuxedAccount,
+    Operation, OperationBody, OperationMeta, Preconditions, ReadXdr, RestoreFootprintOp, ScAddress,
+    ScSpecTypeDef, ScVal, SequenceNumber, SorobanResources, SorobanTransactionData, Transaction,
+    TransactionExt, TransactionMeta, TransactionMetaV3, Uint256,
 };
 use stellar_strkey::DecodeError;
 
@@ -26,7 +26,11 @@ use crate::{
 pub struct Cmd {
     /// Contract ID to which owns the data entries.
     /// If no keys provided the Contract's instance will be restored
-    #[arg(long = "id", required_unless_present = "wasm")]
+    #[arg(
+        long = "id",
+        required_unless_present = "wasm",
+        required_unless_present = "wasm_hash"
+    )]
     pub contract_id: Option<String>,
     /// Storage key (symbols only)
     #[arg(long = "key")]
@@ -39,9 +43,20 @@ pub struct Cmd {
         long,
         conflicts_with = "key",
         conflicts_with = "key_xdr",
-        conflicts_with = "contract_id"
+        conflicts_with = "contract_id",
+        conflicts_with = "wasm_hash"
     )]
     pub wasm: Option<PathBuf>,
+
+    /// Hash of contract code to restore
+    #[arg(
+        long = "wasm-hash",
+        conflicts_with = "key",
+        conflicts_with = "key_xdr",
+        conflicts_with = "contract_id",
+        conflicts_with = "wasm"
+    )]
+    pub wasm_hash: Option<String>,
 
     #[command(flatten)]
     pub config: config::Args,
@@ -112,6 +127,14 @@ impl Cmd {
         tracing::trace!(?network);
         let entry_keys = if let Some(wasm) = &self.wasm {
             vec![crate::wasm::Args { wasm: wasm.clone() }.try_into()?]
+        } else if let Some(wasm_hash) = &self.wasm_hash {
+            vec![LedgerKey::ContractCode(LedgerKeyContractCode {
+                hash: Hash(
+                    utils::contract_id_from_str(wasm_hash)
+                        .map_err(|e| Error::CannotParseContractId(wasm_hash.clone(), e))?,
+                ),
+                body_type: ContractEntryBodyType::DataEntry,
+            })]
         } else {
             let contract_id = self.contract_id()?;
             self.parse_keys(contract_id)?
@@ -183,39 +206,7 @@ impl Cmd {
                 operations[0].changes.len()
             );
         }
-
-        operations
-            .get(0)
-            .and_then(|op| {
-                op.changes.iter().find_map(|entry| match entry {
-                    LedgerEntryChange::Updated(LedgerEntry {
-                        data:
-                            LedgerEntryData::ContractData(ContractDataEntry {
-                                expiration_ledger_seq,
-                                ..
-                            })
-                            | LedgerEntryData::ContractCode(ContractCodeEntry {
-                                expiration_ledger_seq,
-                                ..
-                            }),
-                        ..
-                    })
-                    | LedgerEntryChange::Created(LedgerEntry {
-                        data:
-                            LedgerEntryData::ContractData(ContractDataEntry {
-                                expiration_ledger_seq,
-                                ..
-                            })
-                            | LedgerEntryData::ContractCode(ContractCodeEntry {
-                                expiration_ledger_seq,
-                                ..
-                            }),
-                        ..
-                    }) => Some(*expiration_ledger_seq),
-                    _ => None,
-                })
-            })
-            .ok_or(Error::MissingOperationResult)
+        parse_operations(&operations).ok_or(Error::MissingOperationResult)
     }
 
     pub fn run_in_sandbox(&self) -> Result<u32, Error> {
@@ -266,4 +257,36 @@ impl Cmd {
             })
             .collect())
     }
+}
+
+fn parse_operations(ops: &[OperationMeta]) -> Option<u32> {
+    ops.get(0).and_then(|op| {
+        op.changes.iter().find_map(|entry| match entry {
+            LedgerEntryChange::Updated(LedgerEntry {
+                data:
+                    LedgerEntryData::ContractData(ContractDataEntry {
+                        expiration_ledger_seq,
+                        ..
+                    })
+                    | LedgerEntryData::ContractCode(ContractCodeEntry {
+                        expiration_ledger_seq,
+                        ..
+                    }),
+                ..
+            })
+            | LedgerEntryChange::Created(LedgerEntry {
+                data:
+                    LedgerEntryData::ContractData(ContractDataEntry {
+                        expiration_ledger_seq,
+                        ..
+                    })
+                    | LedgerEntryData::ContractCode(ContractCodeEntry {
+                        expiration_ledger_seq,
+                        ..
+                    }),
+                ..
+            }) => Some(*expiration_ledger_seq),
+            _ => None,
+        })
+    })
 }

--- a/cmd/soroban-cli/src/commands/contract/restore.rs
+++ b/cmd/soroban-cli/src/commands/contract/restore.rs
@@ -29,18 +29,10 @@ pub struct Cmd {
     #[arg(long = "id", required_unless_present = "wasm")]
     pub contract_id: Option<String>,
     /// Storage key (symbols only)
-    #[arg(
-        long = "key",
-        required_unless_present = "key_xdr",
-        required_unless_present = "wasm"
-    )]
+    #[arg(long = "key")]
     pub key: Vec<String>,
     /// Storage key (base64-encoded XDR)
-    #[arg(
-        long = "key-xdr",
-        required_unless_present = "key",
-        required_unless_present = "wasm"
-    )]
+    #[arg(long = "key-xdr")]
     pub key_xdr: Vec<String>,
     /// Path to Wasm file of contract code to restore
     #[arg(

--- a/cmd/soroban-cli/src/wasm.rs
+++ b/cmd/soroban-cli/src/wasm.rs
@@ -65,7 +65,6 @@ impl Args {
 
 impl TryInto<LedgerKey> for Args {
     type Error = Error;
-
     fn try_into(self) -> Result<LedgerKey, Self::Error> {
         Ok(LedgerKey::ContractCode(LedgerKeyContractCode {
             hash: utils::contract_hash(&self.read()?)?,

--- a/docs/soroban-cli-full-docs.md
+++ b/docs/soroban-cli-full-docs.md
@@ -213,6 +213,7 @@ If no keys are specified the contract itself is bumped.
 * `--key <KEY>` — Storage key (symbols only)
 * `--key-xdr <KEY_XDR>` — Storage key (base64-encoded XDR)
 * `--wasm <WASM>` — Path to Wasm file of contract code to bump
+* `--wasm-hash <WASM_HASH>` — Path to Wasm file of contract code to bump
 * `--durability <DURABILITY>` — Storage entry durability
 
   Possible values:
@@ -422,6 +423,7 @@ If no keys are specificed the contract itself is restored.
 * `--key <KEY>` — Storage key (symbols only)
 * `--key-xdr <KEY_XDR>` — Storage key (base64-encoded XDR)
 * `--wasm <WASM>` — Path to Wasm file of contract code to restore
+* `--wasm-hash <WASM_HASH>` — Hash of contract code to restore
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
 * `--network <NETWORK>` — Name of network to use from config


### PR DESCRIPTION
### What

Allow passing a wasm hash when using bump/restore.

Allow restore to take multiple changes per operation.

Also fix issue with trying to store a contract instance (the key flags shouldn't be required).

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

Still currently only support one operation.