### PR TITLE
Update wasm-opt to 0.114

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3249,9 +3249,9 @@ checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wasm-opt"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65a2799e08026234b07b44da6363703974e75be21430cef00756bbc438c8ff8a"
+checksum = "d984c9ca0fd8dc99c85920c73d1707d0c2104b5cb8f368fce73b3dbf4424b22b"
 dependencies = [
  "anyhow",
  "libc",
@@ -3265,9 +3265,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-opt-cxx-sys"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d26f86d1132245e8bcea8fac7f02b10fb885b6696799969c94d7d3c14db5e1"
+checksum = "e754ce2f058a43fa604c588d111cfdc963131ad66d9f96c061d76a4f1a4a4eb0"
 dependencies = [
  "anyhow",
  "cxx",
@@ -3277,9 +3277,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-opt-sys"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497d069cd3420cdd52154a320b901114a20946878e2de62c670f9d906e472370"
+checksum = "b7283687ca12943aa186bba3d2ec43e87039098450c4701420eabd0a770e9b69"
 dependencies = [
  "anyhow",
  "cc",

--- a/cmd/soroban-cli/Cargo.toml
+++ b/cmd/soroban-cli/Cargo.toml
@@ -71,7 +71,7 @@ jsonrpsee-http-client = "0.18.1"
 jsonrpsee-core = "0.18.1"
 http = "0.2.9"
 regex = "1.6.0"
-wasm-opt = { version = "0.113.0", optional = true }
+wasm-opt = { version = "0.114.0", optional = true }
 chrono = "0.4.23"
 rpassword = "7.2.0"
 dirs = "4.0.0"


### PR DESCRIPTION
### What

Upgrade wasm-opt to 0.114

### Why

Just keeping wasm-opt updated.

There isn't much to be aware of in the binaryen 114 release notes:
https://github.com/WebAssembly/binaryen/blob/main/CHANGELOG.md#v114

### Known limitations

na