### PR TITLE
feat(CLI): `config identity fund` to fund accounts on networks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1629,6 +1629,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.27.0+1.1.1v"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06e8f197c82d7511c5b014030c9b1efeda40d7d5f99d23b4ceed3524a5e63f02"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1636,6 +1645,7 @@ checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -2443,6 +2453,7 @@ dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-http-client",
  "num-bigint",
+ "openssl",
  "pathdiff",
  "predicates 2.1.5",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,6 +871,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1148,6 +1163,19 @@ dependencies = [
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -1463,6 +1491,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1551,10 +1597,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "openssl"
+version = "0.10.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.90"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "output_vt100"
@@ -1656,6 +1740,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "ppv-lite86"
@@ -2348,6 +2438,7 @@ dependencies = [
  "hex",
  "http",
  "hyper",
+ "hyper-tls",
  "itertools",
  "jsonrpsee-core",
  "jsonrpsee-http-client",
@@ -2951,6 +3042,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3134,6 +3235,12 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2347,6 +2347,7 @@ dependencies = [
  "heck",
  "hex",
  "http",
+ "hyper",
  "itertools",
  "jsonrpsee-core",
  "jsonrpsee-http-client",

--- a/cmd/crates/soroban-test/tests/it/invoke_sandbox.rs
+++ b/cmd/crates/soroban-test/tests/it/invoke_sandbox.rs
@@ -186,13 +186,14 @@ fn invoke_auth() {
         .success();
 }
 
-#[test]
-fn invoke_auth_with_identity() {
+#[tokio::test]
+async fn invoke_auth_with_identity() {
     let sandbox = TestEnv::default();
 
     sandbox
         .cmd::<identity::generate::Cmd>("test -d ")
         .run()
+        .await
         .unwrap();
     sandbox
         .new_assert_cmd("contract")

--- a/cmd/soroban-cli/Cargo.toml
+++ b/cmd/soroban-cli/Cargo.toml
@@ -70,6 +70,7 @@ ed25519-dalek = "1.0.1"
 jsonrpsee-http-client = "0.18.1"
 jsonrpsee-core = "0.18.1"
 hyper   = "0.14.27"
+hyper-tls = "0.5"
 http = "0.2.9"
 regex = "1.6.0"
 wasm-opt = { version = "0.114.0", optional = true }

--- a/cmd/soroban-cli/Cargo.toml
+++ b/cmd/soroban-cli/Cargo.toml
@@ -91,6 +91,8 @@ tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 cargo_metadata = "0.15.4"
 pathdiff = "0.2.1"
+# For hyper-tls
+openssl = { version = "0.10.55", features = ["vendored"] }
 
 [build-dependencies]
 crate-git-revision = "0.0.4"

--- a/cmd/soroban-cli/Cargo.toml
+++ b/cmd/soroban-cli/Cargo.toml
@@ -92,6 +92,7 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 cargo_metadata = "0.15.4"
 pathdiff = "0.2.1"
 # For hyper-tls
+[target.'cfg(unix)'.dependencies]
 openssl = { version = "0.10.55", features = ["vendored"] }
 
 [build-dependencies]

--- a/cmd/soroban-cli/Cargo.toml
+++ b/cmd/soroban-cli/Cargo.toml
@@ -69,6 +69,7 @@ csv = "1.1.6"
 ed25519-dalek = "1.0.1"
 jsonrpsee-http-client = "0.18.1"
 jsonrpsee-core = "0.18.1"
+hyper   = "0.14.27"
 http = "0.2.9"
 regex = "1.6.0"
 wasm-opt = { version = "0.114.0", optional = true }

--- a/cmd/soroban-cli/src/commands/config/identity/address.rs
+++ b/cmd/soroban-cli/src/commands/config/identity/address.rs
@@ -36,14 +36,11 @@ impl Cmd {
     }
 
     pub fn public_key(&self) -> Result<stellar_strkey::ed25519::PublicKey, Error> {
-        let res = if let Some(name) = &self.name {
+        Ok(if let Some(name) = &self.name {
             self.locator.read_identity(name)?
         } else {
             Secret::test_seed_phrase()?
-        };
-        let key = res.key_pair(self.hd_path)?;
-        Ok(stellar_strkey::ed25519::PublicKey::from_payload(
-            key.public.as_bytes(),
-        )?)
+        }
+        .public_key(self.hd_path)?)
     }
 }

--- a/cmd/soroban-cli/src/commands/config/identity/address.rs
+++ b/cmd/soroban-cli/src/commands/config/identity/address.rs
@@ -31,7 +31,7 @@ pub struct Cmd {
 
 impl Cmd {
     pub fn run(&self) -> Result<(), Error> {
-        println!("{}", self.public_key()?.to_string());
+        println!("{}", self.public_key()?);
         Ok(())
     }
 

--- a/cmd/soroban-cli/src/commands/config/identity/fund.rs
+++ b/cmd/soroban-cli/src/commands/config/identity/fund.rs
@@ -1,9 +1,8 @@
 use clap::command;
 
 use crate::commands::config::network;
-use crate::rpc::{self, fund_address};
 
-use super::config::identity::address;
+use super::address;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -11,10 +10,6 @@ pub enum Error {
     Address(#[from] address::Error),
     #[error(transparent)]
     Network(#[from] network::Error),
-    #[error(transparent)]
-    Rpc(#[from] rpc::Error),
-    #[error(transparent)]
-    Strkey(#[from] stellar_strkey::DecodeError),
 }
 
 #[derive(Debug, clap::Parser, Clone)]
@@ -29,9 +24,8 @@ pub struct Cmd {
 
 impl Cmd {
     pub async fn run(&self) -> Result<(), Error> {
-        let network = self.network.get(&self.address.locator)?;
         let addr = self.address.public_key()?;
-        fund_address(&network.helper_url(&addr.to_string())).await?;
+        self.network.get(&self.address.locator)?.fund_address(&addr).await?;
         Ok(())
     }
 }

--- a/cmd/soroban-cli/src/commands/config/identity/fund.rs
+++ b/cmd/soroban-cli/src/commands/config/identity/fund.rs
@@ -25,7 +25,10 @@ pub struct Cmd {
 impl Cmd {
     pub async fn run(&self) -> Result<(), Error> {
         let addr = self.address.public_key()?;
-        self.network.get(&self.address.locator)?.fund_address(&addr).await?;
+        self.network
+            .get(&self.address.locator)?
+            .fund_address(&addr)
+            .await?;
         Ok(())
     }
 }

--- a/cmd/soroban-cli/src/commands/config/identity/mod.rs
+++ b/cmd/soroban-cli/src/commands/config/identity/mod.rs
@@ -2,6 +2,7 @@ use clap::Parser;
 
 pub mod add;
 pub mod address;
+pub mod fund;
 pub mod generate;
 pub mod ls;
 pub mod rm;
@@ -13,6 +14,8 @@ pub enum Cmd {
     Add(add::Cmd),
     /// Given an identity return its address (public key)
     Address(address::Cmd),
+    /// Fund an identity on a test network
+    Fund(fund::Cmd),
     /// Generate a new identity with a seed phrase, currently 12 words
     Generate(generate::Cmd),
     /// List identities
@@ -30,6 +33,8 @@ pub enum Error {
 
     #[error(transparent)]
     Address(#[from] address::Error),
+    #[error(transparent)]
+    Fund(#[from] fund::Error),
 
     #[error(transparent)]
     Generate(#[from] generate::Error),
@@ -43,11 +48,12 @@ pub enum Error {
 }
 
 impl Cmd {
-    pub fn run(&self) -> Result<(), Error> {
+    pub async fn run(&self) -> Result<(), Error> {
         match self {
             Cmd::Add(cmd) => cmd.run()?,
             Cmd::Address(cmd) => cmd.run()?,
-            Cmd::Generate(cmd) => cmd.run()?,
+            Cmd::Fund(cmd) => cmd.run().await?,
+            Cmd::Generate(cmd) => cmd.run().await?,
             Cmd::Ls(cmd) => cmd.run()?,
             Cmd::Rm(cmd) => cmd.run()?,
             Cmd::Show(cmd) => cmd.run()?,

--- a/cmd/soroban-cli/src/commands/config/identity/mod.rs
+++ b/cmd/soroban-cli/src/commands/config/identity/mod.rs
@@ -34,10 +34,10 @@ pub enum Error {
     #[error(transparent)]
     Generate(#[from] generate::Error),
     #[error(transparent)]
+    Rm(#[from] rm::Error),
+    #[error(transparent)]
     Ls(#[from] ls::Error),
 
-    #[error(transparent)]
-    Rm(#[from] rm::Error),
     #[error(transparent)]
     Show(#[from] show::Error),
 }
@@ -47,9 +47,9 @@ impl Cmd {
         match self {
             Cmd::Add(cmd) => cmd.run()?,
             Cmd::Address(cmd) => cmd.run()?,
-            Cmd::Rm(cmd) => cmd.run()?,
-            Cmd::Ls(cmd) => cmd.run()?,
             Cmd::Generate(cmd) => cmd.run()?,
+            Cmd::Ls(cmd) => cmd.run()?,
+            Cmd::Rm(cmd) => cmd.run()?,
             Cmd::Show(cmd) => cmd.run()?,
         };
         Ok(())

--- a/cmd/soroban-cli/src/commands/config/mod.rs
+++ b/cmd/soroban-cli/src/commands/config/mod.rs
@@ -45,9 +45,9 @@ pub enum Error {
 }
 
 impl Cmd {
-    pub fn run(&self) -> Result<(), Error> {
+    pub async fn run(&self) -> Result<(), Error> {
         match &self {
-            Cmd::Identity(identity) => identity.run()?,
+            Cmd::Identity(identity) => identity.run().await?,
             Cmd::Network(network) => network.run()?,
         }
         Ok(())

--- a/cmd/soroban-cli/src/commands/config/network/mod.rs
+++ b/cmd/soroban-cli/src/commands/config/network/mod.rs
@@ -52,6 +52,8 @@ pub enum Error {
     InvalidUrl(String),
     #[error("Inproper response {0}")]
     InproperResponse(String),
+    #[error("Currently not supported on windows. Please visit:\n{0}")]
+    WindowsNotSupported(String),
 }
 
 impl Cmd {
@@ -153,11 +155,18 @@ impl Network {
         let response = match uri.scheme_str() {
             Some("http") => hyper::Client::new().get(uri.clone()).await?,
             Some("https") => {
-                let https = hyper_tls::HttpsConnector::new();
-                hyper::Client::builder()
-                    .build::<_, hyper::Body>(https)
-                    .get(uri.clone())
-                    .await?
+                #[cfg(target_os = "windows")]
+                {
+                    return Err(Error::WindowsNotSupported(uri.to_string()));
+                }
+                #[cfg(not(target_os = "windows"))]
+                {
+                    let https = hyper_tls::HttpsConnector::new();
+                    hyper::Client::builder()
+                        .build::<_, hyper::Body>(https)
+                        .get(uri.clone())
+                        .await?
+                }
             }
             _ => {
                 return Err(Error::InvalidUrl(uri.to_string()));

--- a/cmd/soroban-cli/src/commands/config/network/mod.rs
+++ b/cmd/soroban-cli/src/commands/config/network/mod.rs
@@ -5,7 +5,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use stellar_strkey::ed25519::PublicKey;
 
-use crate::{commands::HEADING_RPC, rpc::{self, Client}};
+use crate::{
+    commands::HEADING_RPC,
+    rpc::{self, Client},
+};
 
 use super::locator;
 
@@ -137,7 +140,8 @@ impl Network {
         tracing::debug!("address {addr:?}");
         let client = Client::new(&self.rpc_url)?;
         let helper_url_root = client.friendbot_url().await?;
-        let uri = http::Uri::from_str(&helper_url_root).map_err(|_|Error::InvalidUrl(helper_url_root.to_string()))?;
+        let uri = http::Uri::from_str(&helper_url_root)
+            .map_err(|_| Error::InvalidUrl(helper_url_root.to_string()))?;
         http::Uri::from_str(&format!("{uri:?}?addr={addr}"))
             .map_err(|_| Error::InvalidUrl(helper_url_root.to_string()))
     }
@@ -178,7 +182,7 @@ impl Network {
     pub fn futurenet() -> Self {
         Network {
             rpc_url: "https://rpc-futurenet.stellar.org:443".to_owned(),
-            network_passphrase: "Test SDF Future Network ; October 2022".to_owned()
+            network_passphrase: "Test SDF Future Network ; October 2022".to_owned(),
         }
     }
 }

--- a/cmd/soroban-cli/src/commands/config/secret.rs
+++ b/cmd/soroban-cli/src/commands/config/secret.rs
@@ -1,7 +1,7 @@
 use clap::arg;
 use serde::{Deserialize, Serialize};
 use std::{io::Write, str::FromStr};
-use stellar_strkey::ed25519::PrivateKey;
+use stellar_strkey::ed25519::{PrivateKey, PublicKey};
 
 use crate::utils;
 
@@ -100,6 +100,13 @@ impl Secret {
                 .from_path_index(index.unwrap_or_default(), None)?
                 .private(),
         })
+    }
+
+    pub fn public_key(&self, index: Option<usize>) -> Result<PublicKey, Error> {
+        let key = self.key_pair(index)?;
+        Ok(stellar_strkey::ed25519::PublicKey::from_payload(
+            key.public.as_bytes(),
+        )?)
     }
 
     pub fn key_pair(&self, index: Option<usize>) -> Result<ed25519_dalek::Keypair, Error> {

--- a/cmd/soroban-cli/src/commands/contract/bindings/typescript.rs
+++ b/cmd/soroban-cli/src/commands/contract/bindings/typescript.rs
@@ -89,6 +89,7 @@ impl Cmd {
         let Network {
             rpc_url,
             network_passphrase,
+            ..
         } = self
             .network
             .get(&self.locator)

--- a/cmd/soroban-cli/src/commands/fund.rs
+++ b/cmd/soroban-cli/src/commands/fund.rs
@@ -1,0 +1,37 @@
+use clap::command;
+
+use crate::commands::config::network;
+use crate::rpc::{self, fund_address};
+
+use super::config::identity::address;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Address(#[from] address::Error),
+    #[error(transparent)]
+    Network(#[from] network::Error),
+    #[error(transparent)]
+    Rpc(#[from] rpc::Error),
+    #[error(transparent)]
+    Strkey(#[from] stellar_strkey::DecodeError),
+}
+
+#[derive(Debug, clap::Parser, Clone)]
+#[group(skip)]
+pub struct Cmd {
+    #[command(flatten)]
+    pub network: network::Args,
+    /// Address to fund
+    #[command(flatten)]
+    pub address: address::Cmd,
+}
+
+impl Cmd {
+    pub async fn run(&self) -> Result<(), Error> {
+        let network = self.network.get(&self.address.locator)?;
+        let addr = self.address.public_key()?;
+        fund_address(&network.helper_url(&addr.to_string())).await?;
+        Ok(())
+    }
+}

--- a/cmd/soroban-cli/src/commands/mod.rs
+++ b/cmd/soroban-cli/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod completion;
 pub mod config;
 pub mod contract;
 pub mod events;
+pub mod fund;
 pub mod global;
 pub mod lab;
 pub mod plugin;
@@ -73,12 +74,13 @@ impl Root {
     }
     pub async fn run(&mut self) -> Result<(), Error> {
         match &mut self.cmd {
-            Cmd::Contract(contract) => contract.run().await?,
-            Cmd::Events(events) => events.run().await?,
-            Cmd::Lab(lab) => lab.run().await?,
-            Cmd::Version(version) => version.run(),
             Cmd::Completion(completion) => completion.run(),
             Cmd::Config(config) => config.run()?,
+            Cmd::Contract(contract) => contract.run().await?,
+            Cmd::Events(events) => events.run().await?,
+            Cmd::Fund(fund) => fund.run().await?,
+            Cmd::Lab(lab) => lab.run().await?,
+            Cmd::Version(version) => version.run(),
         };
         Ok(())
     }
@@ -94,6 +96,9 @@ impl FromStr for Root {
 
 #[derive(Parser, Debug)]
 pub enum Cmd {
+    /// Print shell completion code for the specified shell.
+    #[command(long_about = completion::LONG_ABOUT)]
+    Completion(completion::Cmd),
     /// Tools for smart contract developers
     #[command(subcommand)]
     Contract(contract::Cmd),
@@ -102,14 +107,13 @@ pub enum Cmd {
     Config(config::Cmd),
     /// Watch the network for contract events
     Events(events::Cmd),
+    /// Fund an identity on a test network
+    Fund(fund::Cmd),
     /// Experiment with early features and expert tools
     #[command(subcommand)]
     Lab(lab::Cmd),
     /// Print version information
     Version(version::Cmd),
-    /// Print shell completion code for the specified shell.
-    #[command(long_about = completion::LONG_ABOUT)]
-    Completion(completion::Cmd),
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -124,4 +128,6 @@ pub enum Error {
     Lab(#[from] lab::Error),
     #[error(transparent)]
     Config(#[from] config::Error),
+    #[error(transparent)]
+    Fund(#[from] fund::Error),
 }

--- a/cmd/soroban-cli/src/commands/mod.rs
+++ b/cmd/soroban-cli/src/commands/mod.rs
@@ -6,7 +6,6 @@ pub mod completion;
 pub mod config;
 pub mod contract;
 pub mod events;
-pub mod fund;
 pub mod global;
 pub mod lab;
 pub mod plugin;
@@ -75,10 +74,9 @@ impl Root {
     pub async fn run(&mut self) -> Result<(), Error> {
         match &mut self.cmd {
             Cmd::Completion(completion) => completion.run(),
-            Cmd::Config(config) => config.run()?,
+            Cmd::Config(config) => config.run().await?,
             Cmd::Contract(contract) => contract.run().await?,
             Cmd::Events(events) => events.run().await?,
-            Cmd::Fund(fund) => fund.run().await?,
             Cmd::Lab(lab) => lab.run().await?,
             Cmd::Version(version) => version.run(),
         };
@@ -107,8 +105,6 @@ pub enum Cmd {
     Config(config::Cmd),
     /// Watch the network for contract events
     Events(events::Cmd),
-    /// Fund an identity on a test network
-    Fund(fund::Cmd),
     /// Experiment with early features and expert tools
     #[command(subcommand)]
     Lab(lab::Cmd),
@@ -128,6 +124,4 @@ pub enum Error {
     Lab(#[from] lab::Error),
     #[error(transparent)]
     Config(#[from] config::Error),
-    #[error(transparent)]
-    Fund(#[from] fund::Error),
 }

--- a/cmd/soroban-cli/src/rpc/mod.rs
+++ b/cmd/soroban-cli/src/rpc/mod.rs
@@ -53,6 +53,8 @@ pub enum Error {
     InvalidRpcUrl(http::uri::InvalidUri),
     #[error("invalid rpc url: {0}")]
     InvalidRpcUrlFromUriParts(http::uri::InvalidUriParts),
+    #[error("invalid friendbot url: {0}")]
+    InvalidUrl(String),
     #[error("jsonrpc error: {0}")]
     JsonRpc(#[from] jsonrpsee_core::Error),
     #[error("json decoding error: {0}")]
@@ -91,6 +93,8 @@ pub enum Error {
     Spec(#[from] soroban_spec::read::FromWasmError),
     #[error(transparent)]
     SpecBase64(#[from] soroban_spec::read::ParseSpecBase64Error),
+    #[error(transparent)]
+    Hyper(#[from] hyper::Error),
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug)]
@@ -943,4 +947,13 @@ mod tests {
             }
         }
     }
+}
+
+pub async fn fund_address(url: &str) -> Result<(), Error> {
+    let client = hyper::Client::new();
+    let url = url.parse().map_err(|_| Error::InvalidUrl(url.to_owned()))?;
+    tracing::debug!("URL {:?}", url);
+    let response = client.get(url).await?;
+    tracing::debug!("{:?}", response);
+    Ok(())
 }

--- a/cmd/soroban-cli/src/rpc/mod.rs
+++ b/cmd/soroban-cli/src/rpc/mod.rs
@@ -93,8 +93,6 @@ pub enum Error {
     Spec(#[from] soroban_spec::read::FromWasmError),
     #[error(transparent)]
     SpecBase64(#[from] soroban_spec::read::ParseSpecBase64Error),
-    #[error(transparent)]
-    Hyper(#[from] hyper::Error),
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug)]
@@ -947,13 +945,4 @@ mod tests {
             }
         }
     }
-}
-
-pub async fn fund_address(url: &str) -> Result<(), Error> {
-    let client = hyper::Client::new();
-    let url = url.parse().map_err(|_| Error::InvalidUrl(url.to_owned()))?;
-    tracing::debug!("URL {:?}", url);
-    let response = client.get(url).await?;
-    tracing::debug!("{:?}", response);
-    Ok(())
 }

--- a/cmd/soroban-cli/src/rpc/mod.rs
+++ b/cmd/soroban-cli/src/rpc/mod.rs
@@ -427,6 +427,17 @@ impl Client {
             .build(url)?)
     }
 
+    pub async fn friendbot_url(&self) -> Result<String, Error> {
+        let network = self.get_network().await?;
+        tracing::trace!("{network:#?}");
+        network.friendbot_url.ok_or_else(|| {
+            Error::NotFound(
+                "Friendbot".to_string(),
+                "Friendbot is not available on this network".to_string(),
+            )
+        })
+    }
+
     pub async fn verify_network_passphrase(&self, expected: Option<&str>) -> Result<String, Error> {
         let server = self.get_network().await?.passphrase;
         if expected.is_some() && expected != Some(&server) {

--- a/cmd/soroban-cli/src/rpc/mod.rs
+++ b/cmd/soroban-cli/src/rpc/mod.rs
@@ -454,10 +454,15 @@ impl Client {
         let response = self.get_ledger_entries(keys).await?;
         let entries = response.entries.unwrap_or_default();
         if entries.is_empty() {
-            return Err(Error::NotFound("Account".to_string(), format!(r#"{address}
+            return Err(Error::NotFound(
+                "Account".to_string(),
+                format!(
+                    r#"{address}
 Might need to fund account like:
 soroban config identity fund {address} --network <name>
-soroban config identity fund {address} --helper-url <url>"#)));
+soroban config identity fund {address} --helper-url <url>"#
+                ),
+            ));
         }
         let ledger_entry = &entries[0];
         let mut depth_limit_read = DepthLimitedRead::new(ledger_entry.xdr.as_bytes(), 100);

--- a/cmd/soroban-cli/src/rpc/mod.rs
+++ b/cmd/soroban-cli/src/rpc/mod.rs
@@ -454,7 +454,10 @@ impl Client {
         let response = self.get_ledger_entries(keys).await?;
         let entries = response.entries.unwrap_or_default();
         if entries.is_empty() {
-            return Err(Error::NotFound("Account".to_string(), address.to_string()));
+            return Err(Error::NotFound("Account".to_string(), format!(r#"{address}
+Might need to fund account like:
+soroban config identity fund {address} --network <name>
+soroban config identity fund {address} --helper-url <url>"#)));
         }
         let ledger_entry = &entries[0];
         let mut depth_limit_read = DepthLimitedRead::new(ledger_entry.xdr.as_bytes(), 100);

--- a/docs/soroban-cli-full-docs.md
+++ b/docs/soroban-cli-full-docs.md
@@ -193,7 +193,6 @@ Generate a TypeScript / JavaScript package
 * `--config-dir <CONFIG_DIR>`
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `--helper-url <HELPER_URL>` — Helper URL to use for funding accounts on test networks
 * `--network <NETWORK>` — Name of network to use from config
 
 
@@ -251,7 +250,6 @@ If no keys are specified the contract itself is bumped.
 * `--ledgers-to-expire <LEDGERS_TO_EXPIRE>` — Number of ledgers to extend the entries
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `--helper-url <HELPER_URL>` — Helper URL to use for funding accounts on test networks
 * `--network <NETWORK>` — Name of network to use from config
 * `--ledger-file <LEDGER_FILE>` — File to persist ledger state, default is `.soroban/ledger.json`
 * `--source-account <SOURCE_ACCOUNT>` — Account that signs the final transaction. Alias `source`. Can be an identity (--source alice), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). Default: `identity generate --default-seed`
@@ -278,7 +276,6 @@ Deploy a contract
 * `--salt <SALT>` — Custom salt 32-byte salt for the token id
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `--helper-url <HELPER_URL>` — Helper URL to use for funding accounts on test networks
 * `--network <NETWORK>` — Name of network to use from config
 * `--ledger-file <LEDGER_FILE>` — File to persist ledger state, default is `.soroban/ledger.json`
 * `--source-account <SOURCE_ACCOUNT>` — Account that signs the final transaction. Alias `source`. Can be an identity (--source alice), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). Default: `identity generate --default-seed`
@@ -305,7 +302,6 @@ Fetch a contract's Wasm binary from a network or local sandbox
 * `--config-dir <CONFIG_DIR>`
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `--helper-url <HELPER_URL>` — Helper URL to use for funding accounts on test networks
 * `--network <NETWORK>` — Name of network to use from config
 * `--ledger-file <LEDGER_FILE>` — File to persist ledger state, default is `.soroban/ledger.json`
 
@@ -347,7 +343,6 @@ Install a WASM file to the ledger without creating a contract instance
 
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `--helper-url <HELPER_URL>` — Helper URL to use for funding accounts on test networks
 * `--network <NETWORK>` — Name of network to use from config
 * `--ledger-file <LEDGER_FILE>` — File to persist ledger state, default is `.soroban/ledger.json`
 * `--source-account <SOURCE_ACCOUNT>` — Account that signs the final transaction. Alias `source`. Can be an identity (--source alice), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). Default: `identity generate --default-seed`
@@ -383,7 +378,6 @@ soroban contract invoke ... -- --help
 * `--unlimited-budget` — Run with an unlimited budget
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `--helper-url <HELPER_URL>` — Helper URL to use for funding accounts on test networks
 * `--network <NETWORK>` — Name of network to use from config
 * `--ledger-file <LEDGER_FILE>` — File to persist ledger state, default is `.soroban/ledger.json`
 * `--source-account <SOURCE_ACCOUNT>` — Account that signs the final transaction. Alias `source`. Can be an identity (--source alice), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). Default: `identity generate --default-seed`
@@ -443,7 +437,6 @@ Print the current value of a contract-data ledger entry
 
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `--helper-url <HELPER_URL>` — Helper URL to use for funding accounts on test networks
 * `--network <NETWORK>` — Name of network to use from config
 * `--ledger-file <LEDGER_FILE>` — File to persist ledger state, default is `.soroban/ledger.json`
 * `--source-account <SOURCE_ACCOUNT>` — Account that signs the final transaction. Alias `source`. Can be an identity (--source alice), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). Default: `identity generate --default-seed`
@@ -470,7 +463,6 @@ If no keys are specificed the contract itself is restored.
 * `--wasm-hash <WASM_HASH>` — Hash of contract code to restore
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `--helper-url <HELPER_URL>` — Helper URL to use for funding accounts on test networks
 * `--network <NETWORK>` — Name of network to use from config
 * `--ledger-file <LEDGER_FILE>` — File to persist ledger state, default is `.soroban/ledger.json`
 * `--source-account <SOURCE_ACCOUNT>` — Account that signs the final transaction. Alias `source`. Can be an identity (--source alice), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). Default: `identity generate --default-seed`
@@ -565,7 +557,6 @@ Fund an identity on a test network
 
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `--helper-url <HELPER_URL>` — Helper URL to use for funding accounts on test networks
 * `--network <NETWORK>` — Name of network to use from config
 * `--hd-path <HD_PATH>` — If identity is a seed phrase use this hd path, default is 0
 * `--global` — Use global config
@@ -593,7 +584,6 @@ Generate a new identity with a seed phrase, currently 12 words
 * `-d`, `--default-seed` — Generate the default seed phrase. Useful for testing. Equivalent to --seed 0000000000000000
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `--helper-url <HELPER_URL>` — Helper URL to use for funding accounts on test networks
 * `--network <NETWORK>` — Name of network to use from config
 
 
@@ -674,7 +664,6 @@ Add a new network
 
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `--helper-url <HELPER_URL>` — Network passphrase to sign the transaction sent to the rpc server
 * `--global` — Use global config
 * `--config-dir <CONFIG_DIR>`
 
@@ -748,7 +737,6 @@ Watch the network for contract events
 * `--config-dir <CONFIG_DIR>`
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `--helper-url <HELPER_URL>` — Helper URL to use for funding accounts on test networks
 * `--network <NETWORK>` — Name of network to use from config
 * `--events-file <PATH>` — File to persist events, default is `.soroban/events.json`
 
@@ -791,7 +779,6 @@ Deploy a token contract to wrap an existing Stellar classic asset for smart cont
 * `--asset <ASSET>` — ID of the Stellar classic asset to wrap, e.g. "USDC:G...5"
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `--helper-url <HELPER_URL>` — Helper URL to use for funding accounts on test networks
 * `--network <NETWORK>` — Name of network to use from config
 * `--ledger-file <LEDGER_FILE>` — File to persist ledger state, default is `.soroban/ledger.json`
 * `--source-account <SOURCE_ACCOUNT>` — Account that signs the final transaction. Alias `source`. Can be an identity (--source alice), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). Default: `identity generate --default-seed`
@@ -815,7 +802,6 @@ Compute the expected contract id for the given asset
 * `--asset <ASSET>` — ID of the Stellar classic asset to wrap, e.g. "USDC:G...5"
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
-* `--helper-url <HELPER_URL>` — Helper URL to use for funding accounts on test networks
 * `--network <NETWORK>` — Name of network to use from config
 * `--ledger-file <LEDGER_FILE>` — File to persist ledger state, default is `.soroban/ledger.json`
 * `--source-account <SOURCE_ACCOUNT>` — Account that signs the final transaction. Alias `source`. Can be an identity (--source alice), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). Default: `identity generate --default-seed`

--- a/docs/soroban-cli-full-docs.md
+++ b/docs/soroban-cli-full-docs.md
@@ -5,6 +5,7 @@ This document contains the help content for the `soroban` command-line program.
 **Command Overview:**
 
 * [`soroban`↴](#soroban)
+* [`soroban completion`↴](#soroban-completion)
 * [`soroban contract`↴](#soroban-contract)
 * [`soroban contract bindings`↴](#soroban-contract-bindings)
 * [`soroban contract bindings json`↴](#soroban-contract-bindings-json)
@@ -24,6 +25,7 @@ This document contains the help content for the `soroban` command-line program.
 * [`soroban config identity`↴](#soroban-config-identity)
 * [`soroban config identity add`↴](#soroban-config-identity-add)
 * [`soroban config identity address`↴](#soroban-config-identity-address)
+* [`soroban config identity fund`↴](#soroban-config-identity-fund)
 * [`soroban config identity generate`↴](#soroban-config-identity-generate)
 * [`soroban config identity ls`↴](#soroban-config-identity-ls)
 * [`soroban config identity rm`↴](#soroban-config-identity-rm)
@@ -40,7 +42,6 @@ This document contains the help content for the `soroban` command-line program.
 * [`soroban lab xdr`↴](#soroban-lab-xdr)
 * [`soroban lab xdr dec`↴](#soroban-lab-xdr-dec)
 * [`soroban version`↴](#soroban-version)
-* [`soroban completion`↴](#soroban-completion)
 
 ## `soroban`
 
@@ -73,12 +74,12 @@ Full CLI reference: https://github.com/stellar/soroban-tools/tree/main/docs/soro
 
 ###### **Subcommands:**
 
+* `completion` — Print shell completion code for the specified shell
 * `contract` — Tools for smart contract developers
 * `config` — Read and update config
 * `events` — Watch the network for contract events
 * `lab` — Experiment with early features and expert tools
 * `version` — Print version information
-* `completion` — Print shell completion code for the specified shell
 
 ###### **Options:**
 
@@ -89,6 +90,30 @@ Full CLI reference: https://github.com/stellar/soroban-tools/tree/main/docs/soro
 * `-v`, `--verbose` — Log DEBUG events
 * `--very-verbose` — Log DEBUG and TRACE events
 * `--list` — List installed plugins. E.g. `soroban-hello`
+
+
+
+## `soroban completion`
+
+Print shell completion code for the specified shell
+
+Ensure the completion package for your shell is installed,
+e.g., bash-completion for bash.
+
+To enable autocomplete in the current bash shell, run:
+  source <(soroban completion --shell bash)
+
+To enable autocomplete permanently, run:
+  echo "source <(soroban completion --shell bash)" >> ~/.bashrc
+
+**Usage:** `soroban completion --shell <SHELL>`
+
+###### **Options:**
+
+* `--shell <SHELL>` — The shell type
+
+  Possible values: `bash`, `elvish`, `fish`, `powershell`, `zsh`
+
 
 
 
@@ -168,6 +193,7 @@ Generate a TypeScript / JavaScript package
 * `--config-dir <CONFIG_DIR>`
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+* `--helper-url <HELPER_URL>` — Helper URL to use for funding accounts on test networks
 * `--network <NETWORK>` — Name of network to use from config
 
 
@@ -225,6 +251,7 @@ If no keys are specified the contract itself is bumped.
 * `--ledgers-to-expire <LEDGERS_TO_EXPIRE>` — Number of ledgers to extend the entries
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+* `--helper-url <HELPER_URL>` — Helper URL to use for funding accounts on test networks
 * `--network <NETWORK>` — Name of network to use from config
 * `--ledger-file <LEDGER_FILE>` — File to persist ledger state, default is `.soroban/ledger.json`
 * `--source-account <SOURCE_ACCOUNT>` — Account that signs the final transaction. Alias `source`. Can be an identity (--source alice), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). Default: `identity generate --default-seed`
@@ -251,6 +278,7 @@ Deploy a contract
 * `--salt <SALT>` — Custom salt 32-byte salt for the token id
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+* `--helper-url <HELPER_URL>` — Helper URL to use for funding accounts on test networks
 * `--network <NETWORK>` — Name of network to use from config
 * `--ledger-file <LEDGER_FILE>` — File to persist ledger state, default is `.soroban/ledger.json`
 * `--source-account <SOURCE_ACCOUNT>` — Account that signs the final transaction. Alias `source`. Can be an identity (--source alice), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). Default: `identity generate --default-seed`
@@ -277,6 +305,7 @@ Fetch a contract's Wasm binary from a network or local sandbox
 * `--config-dir <CONFIG_DIR>`
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+* `--helper-url <HELPER_URL>` — Helper URL to use for funding accounts on test networks
 * `--network <NETWORK>` — Name of network to use from config
 * `--ledger-file <LEDGER_FILE>` — File to persist ledger state, default is `.soroban/ledger.json`
 
@@ -318,6 +347,7 @@ Install a WASM file to the ledger without creating a contract instance
 
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+* `--helper-url <HELPER_URL>` — Helper URL to use for funding accounts on test networks
 * `--network <NETWORK>` — Name of network to use from config
 * `--ledger-file <LEDGER_FILE>` — File to persist ledger state, default is `.soroban/ledger.json`
 * `--source-account <SOURCE_ACCOUNT>` — Account that signs the final transaction. Alias `source`. Can be an identity (--source alice), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). Default: `identity generate --default-seed`
@@ -353,6 +383,7 @@ soroban contract invoke ... -- --help
 * `--unlimited-budget` — Run with an unlimited budget
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+* `--helper-url <HELPER_URL>` — Helper URL to use for funding accounts on test networks
 * `--network <NETWORK>` — Name of network to use from config
 * `--ledger-file <LEDGER_FILE>` — File to persist ledger state, default is `.soroban/ledger.json`
 * `--source-account <SOURCE_ACCOUNT>` — Account that signs the final transaction. Alias `source`. Can be an identity (--source alice), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). Default: `identity generate --default-seed`
@@ -412,6 +443,7 @@ Print the current value of a contract-data ledger entry
 
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+* `--helper-url <HELPER_URL>` — Helper URL to use for funding accounts on test networks
 * `--network <NETWORK>` — Name of network to use from config
 * `--ledger-file <LEDGER_FILE>` — File to persist ledger state, default is `.soroban/ledger.json`
 * `--source-account <SOURCE_ACCOUNT>` — Account that signs the final transaction. Alias `source`. Can be an identity (--source alice), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). Default: `identity generate --default-seed`
@@ -438,6 +470,7 @@ If no keys are specificed the contract itself is restored.
 * `--wasm-hash <WASM_HASH>` — Hash of contract code to restore
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+* `--helper-url <HELPER_URL>` — Helper URL to use for funding accounts on test networks
 * `--network <NETWORK>` — Name of network to use from config
 * `--ledger-file <LEDGER_FILE>` — File to persist ledger state, default is `.soroban/ledger.json`
 * `--source-account <SOURCE_ACCOUNT>` — Account that signs the final transaction. Alias `source`. Can be an identity (--source alice), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). Default: `identity generate --default-seed`
@@ -473,6 +506,7 @@ Configure different identities to sign transactions
 
 * `add` — Add a new identity (keypair, ledger, macOS keychain)
 * `address` — Given an identity return its address (public key)
+* `fund` — Fund an identity on a test network
 * `generate` — Generate a new identity with a seed phrase, currently 12 words
 * `ls` — List identities
 * `rm` — Remove an identity
@@ -517,6 +551,28 @@ Given an identity return its address (public key)
 
 
 
+## `soroban config identity fund`
+
+Fund an identity on a test network
+
+**Usage:** `soroban config identity fund [OPTIONS] [NAME]`
+
+###### **Arguments:**
+
+* `<NAME>` — Name of identity to lookup, default test identity used if not provided
+
+###### **Options:**
+
+* `--rpc-url <RPC_URL>` — RPC server endpoint
+* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+* `--helper-url <HELPER_URL>` — Helper URL to use for funding accounts on test networks
+* `--network <NETWORK>` — Name of network to use from config
+* `--hd-path <HD_PATH>` — If identity is a seed phrase use this hd path, default is 0
+* `--global` — Use global config
+* `--config-dir <CONFIG_DIR>`
+
+
+
 ## `soroban config identity generate`
 
 Generate a new identity with a seed phrase, currently 12 words
@@ -535,6 +591,10 @@ Generate a new identity with a seed phrase, currently 12 words
 * `--config-dir <CONFIG_DIR>`
 * `--hd-path <HD_PATH>` — When generating a secret key, which hd_path should be used from the original seed_phrase
 * `-d`, `--default-seed` — Generate the default seed phrase. Useful for testing. Equivalent to --seed 0000000000000000
+* `--rpc-url <RPC_URL>` — RPC server endpoint
+* `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+* `--helper-url <HELPER_URL>` — Helper URL to use for funding accounts on test networks
+* `--network <NETWORK>` — Name of network to use from config
 
 
 
@@ -614,6 +674,7 @@ Add a new network
 
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+* `--helper-url <HELPER_URL>` — Network passphrase to sign the transaction sent to the rpc server
 * `--global` — Use global config
 * `--config-dir <CONFIG_DIR>`
 
@@ -687,6 +748,7 @@ Watch the network for contract events
 * `--config-dir <CONFIG_DIR>`
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+* `--helper-url <HELPER_URL>` — Helper URL to use for funding accounts on test networks
 * `--network <NETWORK>` — Name of network to use from config
 * `--events-file <PATH>` — File to persist events, default is `.soroban/events.json`
 
@@ -729,6 +791,7 @@ Deploy a token contract to wrap an existing Stellar classic asset for smart cont
 * `--asset <ASSET>` — ID of the Stellar classic asset to wrap, e.g. "USDC:G...5"
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+* `--helper-url <HELPER_URL>` — Helper URL to use for funding accounts on test networks
 * `--network <NETWORK>` — Name of network to use from config
 * `--ledger-file <LEDGER_FILE>` — File to persist ledger state, default is `.soroban/ledger.json`
 * `--source-account <SOURCE_ACCOUNT>` — Account that signs the final transaction. Alias `source`. Can be an identity (--source alice), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). Default: `identity generate --default-seed`
@@ -752,6 +815,7 @@ Compute the expected contract id for the given asset
 * `--asset <ASSET>` — ID of the Stellar classic asset to wrap, e.g. "USDC:G...5"
 * `--rpc-url <RPC_URL>` — RPC server endpoint
 * `--network-passphrase <NETWORK_PASSPHRASE>` — Network passphrase to sign the transaction sent to the rpc server
+* `--helper-url <HELPER_URL>` — Helper URL to use for funding accounts on test networks
 * `--network <NETWORK>` — Name of network to use from config
 * `--ledger-file <LEDGER_FILE>` — File to persist ledger state, default is `.soroban/ledger.json`
 * `--source-account <SOURCE_ACCOUNT>` — Account that signs the final transaction. Alias `source`. Can be an identity (--source alice), a secret key (--source SC36…), or a seed phrase (--source "kite urban…"). Default: `identity generate --default-seed`
@@ -803,30 +867,6 @@ Decode XDR
 Print version information
 
 **Usage:** `soroban version`
-
-
-
-## `soroban completion`
-
-Print shell completion code for the specified shell
-
-Ensure the completion package for your shell is installed,
-e.g., bash-completion for bash.
-
-To enable autocomplete in the current bash shell, run:
-  source <(soroban completion --shell bash)
-
-To enable autocomplete permanently, run:
-  echo "source <(soroban completion --shell bash)" >> ~/.bashrc
-
-**Usage:** `soroban completion --shell <SHELL>`
-
-###### **Options:**
-
-* `--shell <SHELL>` — The shell type
-
-  Possible values: `bash`, `elvish`, `fish`, `powershell`, `zsh`
-
 
 
 


### PR DESCRIPTION
### What

And new subcommand for funding accounts. And allow funding accounts when using `soroban config identity generate`

### Why

Remove the dependency on using tools like curl.

### Known limitations

[TODO or N/A]
