### PR TITLE
feat: allow passing `true` and `false` to boolean types

### DIFF
--- a/cmd/crates/soroban-test/tests/it/custom_types.rs
+++ b/cmd/crates/soroban-test/tests/it/custom_types.rs
@@ -401,8 +401,34 @@ fn boolean() {
         );
 }
 #[test]
+fn boolean_two() {
+    invoke(&TestEnv::default(), "boolean")
+        .arg("--boolean")
+        .arg("true")
+        .assert()
+        .success()
+        .stdout(
+            r#"true
+"#,
+        );
+}
+
+#[test]
 fn boolean_no_flag() {
     invoke(&TestEnv::default(), "boolean")
+        .assert()
+        .success()
+        .stdout(
+            r#"false
+"#,
+        );
+}
+
+#[test]
+fn boolean_false() {
+    invoke(&TestEnv::default(), "boolean")
+        .arg("--boolean")
+        .arg("false")
         .assert()
         .success()
         .stdout(

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -539,7 +539,11 @@ fn build_custom_cmd(name: &str, spec: &Spec) -> Result<clap::Command, Error> {
 
         // Set up special-case arg rules
         arg = match type_ {
-            xdr::ScSpecTypeDef::Bool => arg.num_args(0).required(false),
+            xdr::ScSpecTypeDef::Bool => arg
+                .num_args(0..1)
+                .default_missing_value("true")
+                .default_value("false")
+                .num_args(0..=1),
             xdr::ScSpecTypeDef::Option(_val) => arg.required(false),
             xdr::ScSpecTypeDef::I256
             | xdr::ScSpecTypeDef::I128


### PR DESCRIPTION
### What

Since the boolean type is used else where in the CLI as `true`/`false` the CLI should accept --flag, as `--flag true/false` too.

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
