### PR TITLE
feat(CLI/bindings/ts): allow fetching contract from network

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/bindings.rs
+++ b/cmd/soroban-cli/src/commands/contract/bindings.rs
@@ -27,11 +27,11 @@ pub enum Error {
 }
 
 impl Cmd {
-    pub fn run(&self) -> Result<(), Error> {
+    pub async fn run(&self) -> Result<(), Error> {
         match &self {
             Cmd::Json(json) => json.run()?,
             Cmd::Rust(rust) => rust.run()?,
-            Cmd::Typescript(ts) => ts.run()?,
+            Cmd::Typescript(ts) => ts.run().await?,
         }
         Ok(())
     }

--- a/cmd/soroban-cli/src/commands/contract/bindings/typescript.rs
+++ b/cmd/soroban-cli/src/commands/contract/bindings/typescript.rs
@@ -3,15 +3,17 @@ use std::{fmt::Debug, path::PathBuf};
 use clap::{command, Parser};
 use soroban_spec_typescript::{self as typescript, boilerplate::Project};
 
-use crate::{commands::{
-    config::{
-        locator,
-        network::{self, Network},
-        ledger_file,
-    },
-    contract::{self, fetch},
-}, utils::contract_spec::{ContractSpec, self}};
 use crate::wasm;
+use crate::{
+    commands::{
+        config::{
+            ledger_file, locator,
+            network::{self, Network},
+        },
+        contract::{self, fetch},
+    },
+    utils::contract_spec::{self, ContractSpec},
+};
 
 #[derive(Parser, Debug, Clone)]
 #[group(skip)]

--- a/cmd/soroban-cli/src/commands/contract/mod.rs
+++ b/cmd/soroban-cli/src/commands/contract/mod.rs
@@ -96,7 +96,7 @@ pub enum Error {
 impl Cmd {
     pub async fn run(&self) -> Result<(), Error> {
         match &self {
-            Cmd::Bindings(bindings) => bindings.run()?,
+            Cmd::Bindings(bindings) => bindings.run().await?,
             Cmd::Build(build) => build.run()?,
             Cmd::Bump(bump) => bump.run().await?,
             Cmd::Deploy(deploy) => deploy.run().await?,

--- a/cmd/soroban-cli/src/wasm.rs
+++ b/cmd/soroban-cli/src/wasm.rs
@@ -1,6 +1,9 @@
 use clap::arg;
 use soroban_env_host::xdr::{self, ContractEntryBodyType, LedgerKey, LedgerKeyContractCode};
-use std::{fs, io, path::Path};
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
 
 use crate::utils::{self, contract_spec::ContractSpec};
 
@@ -30,7 +33,7 @@ pub enum Error {
 pub struct Args {
     /// Path to wasm binary
     #[arg(long)]
-    pub wasm: std::path::PathBuf,
+    pub wasm: PathBuf,
 }
 
 impl Args {
@@ -60,6 +63,12 @@ impl Args {
     pub fn parse(&self) -> Result<ContractSpec, Error> {
         let contents = self.read()?;
         Ok(ContractSpec::new(&contents)?)
+    }
+}
+
+impl From<&PathBuf> for Args {
+    fn from(wasm: &PathBuf) -> Self {
+        Self { wasm: wasm.clone() }
     }
 }
 

--- a/docs/soroban-cli-full-docs.md
+++ b/docs/soroban-cli-full-docs.md
@@ -156,11 +156,11 @@ Generate Rust bindings
 
 Generate a TypeScript / JavaScript package
 
-**Usage:** `soroban contract bindings typescript [OPTIONS] --wasm <WASM> --output-dir <OUTPUT_DIR> --contract-name <CONTRACT_NAME> --contract-id <CONTRACT_ID>`
+**Usage:** `soroban contract bindings typescript [OPTIONS] --output-dir <OUTPUT_DIR> --contract-name <CONTRACT_NAME> --contract-id <CONTRACT_ID>`
 
 ###### **Options:**
 
-* `--wasm <WASM>` — Path to wasm binary
+* `--wasm <WASM>` — Path to optional wasm binary
 * `--output-dir <OUTPUT_DIR>` — where to place generated project
 * `--contract-name <CONTRACT_NAME>`
 * `--contract-id <CONTRACT_ID>`


### PR DESCRIPTION
### What

Makes passing the wasm optional otherwise fetches the contract from the network.

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
