### PR TITLE
soroban-rpc: Add writethrough cache for Config ledger entries

### DIFF
--- a/cmd/soroban-rpc/internal/daemon/daemon.go
+++ b/cmd/soroban-rpc/internal/daemon/daemon.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stellar/go/clients/stellarcore"
 	"github.com/stellar/go/historyarchive"
 	"github.com/stellar/go/ingest/ledgerbackend"
-	dbsession "github.com/stellar/go/support/db"
 	supporthttp "github.com/stellar/go/support/http"
 	supportlog "github.com/stellar/go/support/log"
 
@@ -41,7 +40,7 @@ type Daemon struct {
 	core                *ledgerbackend.CaptiveStellarCore
 	coreClient          *CoreClientWithMetrics
 	ingestService       *ingest.Service
-	db                  dbsession.SessionInterface
+	db                  *db.DB
 	jsonRPCHandler      *internal.Handler
 	logger              *supportlog.Entry
 	preflightWorkerPool *preflight.PreflightWorkerPool
@@ -53,7 +52,7 @@ type Daemon struct {
 	metricsRegistry     *prometheus.Registry
 }
 
-func (d *Daemon) GetDB() dbsession.SessionInterface {
+func (d *Daemon) GetDB() *db.DB {
 	return d.db
 }
 
@@ -152,13 +151,11 @@ func MustNew(cfg *config.Config) *Daemon {
 		logger.WithError(err).Fatal("could not connect to history archive")
 	}
 
-	session, err := db.OpenSQLiteDB(cfg.SQLiteDBPath)
+	metricsRegistry := prometheus.NewRegistry()
+	dbConn, err := db.OpenSQLiteDBWithPrometheusMetrics(cfg.SQLiteDBPath, prometheusNamespace, "db", metricsRegistry)
 	if err != nil {
 		logger.WithError(err).Fatal("could not open database")
 	}
-	metricsRegistry := prometheus.NewRegistry()
-
-	dbConn := dbsession.RegisterMetrics(session, prometheusNamespace, "db", metricsRegistry)
 
 	daemon := &Daemon{
 		logger:          logger,
@@ -195,7 +192,7 @@ func MustNew(cfg *config.Config) *Daemon {
 	defer cancelReadTxMeta()
 	txmetas, err := db.NewLedgerReader(dbConn).GetAllLedgers(readTxMetaCtx)
 	if err != nil {
-		logger.WithError(err).Fatal("could obtain txmeta cache from the database")
+		logger.WithError(err).Fatal("could not obtain txmeta cache from the database")
 	}
 	for _, txmeta := range txmetas {
 		// NOTE: We could optimize this to avoid unnecessary ingestion calls

--- a/cmd/soroban-rpc/internal/db/db.go
+++ b/cmd/soroban-rpc/internal/db/db.go
@@ -6,9 +6,11 @@ import (
 	"embed"
 	"fmt"
 	"strconv"
+	"sync"
 
 	sq "github.com/Masterminds/squirrel"
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/prometheus/client_golang/prometheus"
 	migrate "github.com/rubenv/sql-migrate"
 
 	"github.com/stellar/go/support/db"
@@ -38,7 +40,13 @@ type WriteTx interface {
 	Rollback() error
 }
 
-func OpenSQLiteDB(dbFilePath string) (*db.Session, error) {
+type DB struct {
+	db.SessionInterface
+	ledgerEntryCache      map[string]string // Just like the DB: compress-encoded ledger key -> ledger entry XDR
+	ledgerEntryCacheMutex sync.RWMutex
+}
+
+func openSQLiteDB(dbFilePath string) (*db.Session, error) {
 	// 1. Use Write-Ahead Logging (WAL).
 	// 2. Disable WAL auto-checkpointing (we will do the checkpointing ourselves with wal_checkpoint pragmas
 	//    after every write transaction).
@@ -52,8 +60,31 @@ func OpenSQLiteDB(dbFilePath string) (*db.Session, error) {
 		_ = session.Close()
 		return nil, errors.Wrap(err, "could not run migrations")
 	}
-
 	return session, nil
+}
+
+func OpenSQLiteDBWithPrometheusMetrics(dbFilePath string, namespace string, sub db.Subservice, registry *prometheus.Registry) (*DB, error) {
+	session, err := openSQLiteDB(dbFilePath)
+	if err != nil {
+		return nil, err
+	}
+	result := DB{
+		SessionInterface: db.RegisterMetrics(session, namespace, sub, registry),
+		ledgerEntryCache: map[string]string{},
+	}
+	return &result, nil
+}
+
+func OpenSQLiteDB(dbFilePath string) (*DB, error) {
+	session, err := openSQLiteDB(dbFilePath)
+	if err != nil {
+		return nil, err
+	}
+	result := DB{
+		SessionInterface: session,
+		ledgerEntryCache: map[string]string{},
+	}
+	return &result, nil
 }
 
 func getLatestLedgerSequence(ctx context.Context, q db.SessionInterface) (uint32, error) {
@@ -79,7 +110,7 @@ func getLatestLedgerSequence(ctx context.Context, q db.SessionInterface) (uint32
 }
 
 type readWriter struct {
-	db                    db.SessionInterface
+	db                    *DB
 	maxBatchSize          int
 	ledgerRetentionWindow uint32
 }
@@ -88,7 +119,7 @@ type readWriter struct {
 // the size of ledger entry batches when writing ledger entries
 // and the retention window for how many historical ledgers are
 // recorded in the database.
-func NewReadWriter(db db.SessionInterface, maxBatchSize int, ledgerRetentionWindow uint32) ReadWriter {
+func NewReadWriter(db *DB, maxBatchSize int, ledgerRetentionWindow uint32) ReadWriter {
 	return &readWriter{
 		db:                    db,
 		maxBatchSize:          maxBatchSize,
@@ -108,6 +139,7 @@ func (rw *readWriter) NewTx(ctx context.Context) (WriteTx, error) {
 	stmtCache := sq.NewStmtCache(txSession.GetTx())
 	db := rw.db
 	return writeTx{
+		db: rw.db,
 		postCommit: func() error {
 			_, err := db.ExecRaw(ctx, "PRAGMA wal_checkpoint(TRUNCATE)")
 			return err
@@ -116,16 +148,18 @@ func (rw *readWriter) NewTx(ctx context.Context) (WriteTx, error) {
 		stmtCache:    stmtCache,
 		ledgerWriter: ledgerWriter{stmtCache: stmtCache},
 		ledgerEntryWriter: ledgerEntryWriter{
-			buffer:          xdr.NewEncodingBuffer(),
-			stmtCache:       stmtCache,
-			keyToEntryBatch: make(map[string]*string, rw.maxBatchSize),
-			maxBatchSize:    rw.maxBatchSize,
+			stmtCache:                     stmtCache,
+			buffer:                        xdr.NewEncodingBuffer(),
+			keyToEntryBatch:               make(map[string]*xdr.LedgerEntry, rw.maxBatchSize),
+			keyToEntryPendingCacheUpdates: map[string]*string{},
+			maxBatchSize:                  rw.maxBatchSize,
 		},
 		ledgerRetentionWindow: rw.ledgerRetentionWindow,
 	}, nil
 }
 
 type writeTx struct {
+	db                    *DB
 	postCommit            func() error
 	tx                    db.SessionInterface
 	stmtCache             *sq.StmtCache
@@ -157,8 +191,20 @@ func (w writeTx) Commit(ledgerSeq uint32) error {
 		return err
 	}
 
+	// TODO: is it worth locking around Commit()? The idea is to make the cache consistent with the
+	//       write transaction but it can cause contention.
+	w.db.ledgerEntryCacheMutex.Lock()
+	defer w.db.ledgerEntryCacheMutex.Unlock()
 	if err = w.tx.Commit(); err != nil {
 		return err
+	}
+
+	for key, entry := range w.ledgerEntryWriter.keyToEntryPendingCacheUpdates {
+		if entry == nil {
+			delete(w.db.ledgerEntryCache, key)
+		} else {
+			w.db.ledgerEntryCache[key] = *entry
+		}
 	}
 
 	return w.postCommit()

--- a/cmd/soroban-rpc/internal/db/db.go
+++ b/cmd/soroban-rpc/internal/db/db.go
@@ -151,7 +151,7 @@ func (rw *readWriter) NewTx(ctx context.Context) (WriteTx, error) {
 			stmtCache:                     stmtCache,
 			buffer:                        xdr.NewEncodingBuffer(),
 			keyToEntryBatch:               make(map[string]*xdr.LedgerEntry, rw.maxBatchSize),
-			keyToEntryPendingCacheUpdates: map[string]*string{},
+			keyToEntryPendingCacheUpdates: make(map[string]*string, rw.maxBatchSize),
 			maxBatchSize:                  rw.maxBatchSize,
 		},
 		ledgerRetentionWindow: rw.ledgerRetentionWindow,

--- a/cmd/soroban-rpc/internal/db/ledger.go
+++ b/cmd/soroban-rpc/internal/db/ledger.go
@@ -6,7 +6,6 @@ import (
 
 	sq "github.com/Masterminds/squirrel"
 
-	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/xdr"
 )
 
@@ -24,10 +23,10 @@ type LedgerWriter interface {
 }
 
 type ledgerReader struct {
-	db db.SessionInterface
+	db *DB
 }
 
-func NewLedgerReader(db db.SessionInterface) LedgerReader {
+func NewLedgerReader(db *DB) LedgerReader {
 	return ledgerReader{db: db}
 }
 

--- a/cmd/soroban-rpc/internal/db/ledgerentry.go
+++ b/cmd/soroban-rpc/internal/db/ledgerentry.go
@@ -39,8 +39,9 @@ type ledgerEntryWriter struct {
 	stmtCache *sq.StmtCache
 	buffer    *xdr.EncodingBuffer
 	// nil entries imply deletion
-	keyToEntryBatch map[string]*string
-	maxBatchSize    int
+	keyToEntryBatch               map[string]*xdr.LedgerEntry
+	keyToEntryPendingCacheUpdates map[string]*string
+	maxBatchSize                  int
 }
 
 func (l ledgerEntryWriter) ExtendLedgerEntry(key xdr.LedgerKey, expirationLedgerSeq xdr.Uint32) error {
@@ -58,12 +59,12 @@ func (l ledgerEntryWriter) ExtendLedgerEntry(key xdr.LedgerKey, expirationLedger
 	}
 
 	var entry xdr.LedgerEntry
-	var existing string
 	// See if we have a pending (unflushed) update for this key
 	queued := l.keyToEntryBatch[encodedKey]
-	if queued != nil && *queued != "" {
-		existing = *queued
+	if queued != nil {
+		entry = *queued
 	} else {
+		var existing string
 		// Nothing in the flush buffer. Load the entry from the db
 		err = sq.StatementBuilder.RunWith(l.stmtCache).Select("entry").From(ledgerEntriesTableName).Where(sq.Eq{"key": encodedKey}).QueryRow().Scan(&existing)
 		if err == sql.ErrNoRows {
@@ -71,11 +72,10 @@ func (l ledgerEntryWriter) ExtendLedgerEntry(key xdr.LedgerKey, expirationLedger
 		} else if err != nil {
 			return err
 		}
-	}
-
-	// Unmarshal the existing entry
-	if err := xdr.SafeUnmarshal([]byte(existing), &entry); err != nil {
-		return err
+		// Unmarshal the existing entry
+		if err := xdr.SafeUnmarshal([]byte(existing), &entry); err != nil {
+			return err
+		}
 	}
 
 	// Update the expiration
@@ -102,13 +102,8 @@ func (l ledgerEntryWriter) UpsertLedgerEntry(entry xdr.LedgerEntry) error {
 	if err != nil {
 		return err
 	}
-	// safe since we cast to string right away
-	encodedEntry, err := l.buffer.UnsafeMarshalBinary(&entry)
-	if err != nil {
-		return err
-	}
-	encodedEntryStr := string(encodedEntry)
-	l.keyToEntryBatch[encodedKey] = &encodedEntryStr
+
+	l.keyToEntryBatch[encodedKey] = &entry
 	return l.maybeFlush()
 }
 
@@ -133,24 +128,32 @@ func (l ledgerEntryWriter) flush() error {
 	upsertSQL := sq.StatementBuilder.RunWith(l.stmtCache).Replace(ledgerEntriesTableName)
 	var deleteKeys = make([]string, 0, len(l.keyToEntryBatch))
 
+	upsertCacheUpdates := make(map[string]*string, len(l.keyToEntryBatch))
 	for key, entry := range l.keyToEntryBatch {
 		if entry != nil {
-			upsertSQL = upsertSQL.Values(key, entry)
+			// safe since we cast to string right away
+			encodedEntry, err := l.buffer.UnsafeMarshalBinary(entry)
+			if err != nil {
+				return err
+			}
+			encodedEntryStr := string(encodedEntry)
+			upsertSQL = upsertSQL.Values(key, encodedEntryStr)
 			upsertCount += 1
+			// Only cache Config entries for now
+			if entry.Data.Type == xdr.LedgerEntryTypeConfigSetting {
+				upsertCacheUpdates[key] = &encodedEntryStr
+			}
 		} else {
 			deleteKeys = append(deleteKeys, key)
 		}
-		// Delete each entry instead of reassigning l.keyToEntryBatch
-		// to the empty map because the map was allocated with a
-		// capacity of: make(map[string]*string, rw.maxBatchSize).
-		// We want to reuse the hashtable buckets in subsequent
-		// calls to UpsertLedgerEntry / DeleteLedgerEntry.
-		delete(l.keyToEntryBatch, key)
 	}
 
 	if upsertCount > 0 {
 		if _, err := upsertSQL.Exec(); err != nil {
 			return err
+		}
+		for key, entry := range upsertCacheUpdates {
+			l.keyToEntryPendingCacheUpdates[key] = entry
 		}
 	}
 
@@ -159,15 +162,28 @@ func (l ledgerEntryWriter) flush() error {
 		if _, err := deleteSQL.Exec(); err != nil {
 			return err
 		}
+		for _, key := range deleteKeys {
+			l.keyToEntryPendingCacheUpdates[key] = nil
+		}
+	}
+
+	for key := range l.keyToEntryBatch {
+		// Delete each entry instead of reassigning l.keyToEntryBatch
+		// to the empty map because the map was allocated with a
+		// capacity of: make(map[string]*string, rw.maxBatchSize).
+		// We want to reuse the hashtable buckets in subsequent
+		// calls to UpsertLedgerEntry / DeleteLedgerEntry.
+		delete(l.keyToEntryBatch, key)
 	}
 
 	return nil
 }
 
 type ledgerEntryReadTx struct {
-	cachedLatestLedgerSeq uint32
-	tx                    db.SessionInterface
-	buffer                *xdr.EncodingBuffer
+	cachedLatestLedgerSeq    uint32
+	ledgerEntryCacheSnapshot map[string]string
+	tx                       db.SessionInterface
+	buffer                   *xdr.EncodingBuffer
 }
 
 func (l *ledgerEntryReadTx) GetLatestLedgerSequence() (uint32, error) {
@@ -181,28 +197,40 @@ func (l *ledgerEntryReadTx) GetLatestLedgerSequence() (uint32, error) {
 	return latestLedgerSeq, err
 }
 
-func (l *ledgerEntryReadTx) GetLedgerEntry(key xdr.LedgerKey, includeExpired bool) (bool, xdr.LedgerEntry, error) {
+func (l *ledgerEntryReadTx) getBinaryLedgerEntry(key xdr.LedgerKey) (bool, string, error) {
 	encodedKey, err := encodeLedgerKey(l.buffer, key)
 	if err != nil {
-		return false, xdr.LedgerEntry{}, err
+		return false, "", err
+	}
+
+	entry, ok := l.ledgerEntryCacheSnapshot[encodedKey]
+	if ok {
+		return ok, entry, nil
 	}
 
 	sql := sq.Select("entry").From(ledgerEntriesTableName).Where(sq.Eq{"key": encodedKey})
 	var results []string
 	if err = l.tx.Select(context.Background(), &results, sql); err != nil {
-		return false, xdr.LedgerEntry{}, err
+		return false, "", err
 	}
 	switch len(results) {
 	case 0:
-		return false, xdr.LedgerEntry{}, nil
+		return false, "", nil
 	case 1:
 		// expected length
 	default:
-		return false, xdr.LedgerEntry{}, fmt.Errorf("multiple entries (%d) for key %q in table %q", len(results), hex.EncodeToString([]byte(encodedKey)), ledgerEntriesTableName)
+		return false, "", fmt.Errorf("multiple entries (%d) for key %q in table %q", len(results), hex.EncodeToString([]byte(encodedKey)), ledgerEntriesTableName)
 	}
-	ledgerEntryBin := results[0]
+	return true, results[0], nil
+}
+
+func (l *ledgerEntryReadTx) GetLedgerEntry(key xdr.LedgerKey, includeExpired bool) (bool, xdr.LedgerEntry, error) {
+	found, ledgerEntryBin, err := l.getBinaryLedgerEntry(key)
+	if err != nil || !found {
+		return found, xdr.LedgerEntry{}, err
+	}
 	var result xdr.LedgerEntry
-	if err = xdr.SafeUnmarshal([]byte(ledgerEntryBin), &result); err != nil {
+	if err := xdr.SafeUnmarshal([]byte(ledgerEntryBin), &result); err != nil {
 		return false, xdr.LedgerEntry{}, err
 	}
 
@@ -230,10 +258,10 @@ func (l ledgerEntryReadTx) Done() error {
 }
 
 type ledgerEntryReader struct {
-	db db.SessionInterface
+	db *DB
 }
 
-func NewLedgerEntryReader(db db.SessionInterface) LedgerEntryReader {
+func NewLedgerEntryReader(db *DB) LedgerEntryReader {
 	return ledgerEntryReader{db: db}
 }
 
@@ -243,13 +271,24 @@ func (r ledgerEntryReader) GetLatestLedgerSequence(ctx context.Context) (uint32,
 
 func (r ledgerEntryReader) NewTx(ctx context.Context) (LedgerEntryReadTx, error) {
 	txSession := r.db.Clone()
+	// We need to copy the cached ledger entries locally when we start the transaction
+	// since otherwise we would break the consistency between the transaction and the cache.
+	// TODO: is it worth locking around BeginTx()? The idea is to make the cache consistent with the
+	//       write transaction but it can cause contention.
+	r.db.ledgerEntryCacheMutex.RLock()
+	defer r.db.ledgerEntryCacheMutex.RUnlock()
 	if err := txSession.BeginTx(ctx, &sql.TxOptions{ReadOnly: true}); err != nil {
 		return nil, err
 	}
+	localCache := map[string]string{}
+	for k, v := range r.db.ledgerEntryCache {
+		localCache[k] = v
+	}
 
 	return &ledgerEntryReadTx{
-		tx:     txSession,
-		buffer: xdr.NewEncodingBuffer(),
+		ledgerEntryCacheSnapshot: localCache,
+		tx:                       txSession,
+		buffer:                   xdr.NewEncodingBuffer(),
 	}, nil
 }
 

--- a/cmd/soroban-rpc/internal/db/ledgerentry.go
+++ b/cmd/soroban-rpc/internal/db/ledgerentry.go
@@ -280,7 +280,7 @@ func (r ledgerEntryReader) NewTx(ctx context.Context) (LedgerEntryReadTx, error)
 	if err := txSession.BeginTx(ctx, &sql.TxOptions{ReadOnly: true}); err != nil {
 		return nil, err
 	}
-	localCache := map[string]string{}
+	localCache := make(map[string]string, len(r.db.ledgerEntryCache))
 	for k, v := range r.db.ledgerEntryCache {
 		localCache[k] = v
 	}

--- a/cmd/soroban-rpc/internal/db/ledgerentry.go
+++ b/cmd/soroban-rpc/internal/db/ledgerentry.go
@@ -200,7 +200,7 @@ func (l *ledgerEntryReadTx) getBinaryLedgerEntry(key xdr.LedgerKey) (bool, strin
 		return false, "", err
 	}
 
-	entry, ok := l.ledgerEntryCacheReadTx[encodedKey]
+	entry, ok := l.ledgerEntryCacheReadTx.get(encodedKey)
 	if ok {
 		return ok, entry, nil
 	}

--- a/cmd/soroban-rpc/internal/db/transactionalcache.go
+++ b/cmd/soroban-rpc/internal/db/transactionalcache.go
@@ -1,0 +1,54 @@
+package db
+
+type transactionalCache struct {
+	entries map[string]string
+}
+
+func newTransactionalCache() transactionalCache {
+	return transactionalCache{entries: map[string]string{}}
+}
+
+func (c transactionalCache) newReadTx() transactionalCacheReadTx {
+	ret := make(transactionalCacheReadTx, len(c.entries))
+	for k, v := range c.entries {
+		ret[k] = v
+	}
+	return ret
+}
+
+func (c transactionalCache) newWriteTx(estimatedWriteCount int) transactionalCacheWriteTx {
+	return transactionalCacheWriteTx{
+		pendingUpdates: make(map[string]*string, estimatedWriteCount),
+		parent:         &c,
+	}
+}
+
+type transactionalCacheReadTx map[string]string
+
+func (r transactionalCacheReadTx) get(key string) (string, bool) {
+	val, ok := r[key]
+	return val, ok
+}
+
+type transactionalCacheWriteTx struct {
+	// nil indicates deletion
+	pendingUpdates map[string]*string
+	parent         *transactionalCache
+}
+
+func (w transactionalCacheWriteTx) upsert(key, val string) {
+	w.pendingUpdates[key] = &val
+}
+
+func (w transactionalCacheWriteTx) delete(key string) {
+	w.pendingUpdates[key] = nil
+}
+
+func (w transactionalCacheWriteTx) commit() {
+	for key, newValue := range w.pendingUpdates {
+		if newValue == nil {
+			delete(w.parent.entries, key)
+		}
+		w.parent.entries[key] = *newValue
+	}
+}

--- a/cmd/soroban-rpc/lib/preflight/src/fees.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/fees.rs
@@ -152,12 +152,6 @@ fn get_fee_configuration(
     ledger_storage: &ledger_storage::LedgerStorage,
     bucket_list_size: u64,
 ) -> Result<FeeConfiguration, Box<dyn error::Error>> {
-    // TODO: to improve the performance of this function (which is invoked every single preflight call) we can
-    //       1. modify ledger_storage.get() so that it can gather multiple entries at once
-    //       2. implement a write-through cache for the configuration ledger entries (i.e. the cache is written to at the
-    //          same time as the DB, ensuring they are always in memory).
-    //
-
     let ConfigSettingEntry::ContractComputeV0(compute) =
         ledger_storage.get_configuration_setting(ConfigSettingId::ContractComputeV0)?
     else {


### PR DESCRIPTION
After https://github.com/stellar/soroban-tools/pull/692 I noticed that the DB access to config ledger entries is a big part of the preflight computation.

This PR adds a writethrough cache for config ledger entries.

Before the cache:


```
goos: darwin
goarch: arm64
pkg: github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/preflight
BenchmarkGetPreflight
BenchmarkGetPreflight/In-memory_storage
BenchmarkGetPreflight/In-memory_storage-12         	    6112	    193728 ns/op
BenchmarkGetPreflight/DB_storage
BenchmarkGetPreflight/DB_storage-12                	    2766	    430002 ns/op
PASS
```


After adding the cache:

```
goos: darwin
goarch: arm64
pkg: github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/preflight
BenchmarkGetPreflight
BenchmarkGetPreflight/In-memory_storage
BenchmarkGetPreflight/In-memory_storage-12         	    6169	    192616 ns/op
BenchmarkGetPreflight/DB_storage
BenchmarkGetPreflight/DB_storage-12                	    3717	    324078 ns/op
PASS
```


I am not sure it's worth the extra complexity though, considering it brings us down from  `0.43` ms to `0.32` ms per (simple) preflight.




