### PR TITLE
soroban-rpc: Cache all ledger entries queried from DB in read transaction

### DIFF
--- a/cmd/soroban-rpc/internal/db/ledgerentry.go
+++ b/cmd/soroban-rpc/internal/db/ledgerentry.go
@@ -218,7 +218,9 @@ func (l *ledgerEntryReadTx) getBinaryLedgerEntry(key xdr.LedgerKey) (bool, strin
 	default:
 		return false, "", fmt.Errorf("multiple entries (%d) for key %q in table %q", len(results), hex.EncodeToString([]byte(encodedKey)), ledgerEntriesTableName)
 	}
-	return true, results[0], nil
+	result := results[0]
+	l.ledgerEntryCacheReadTx.upsert(encodedKey, result)
+	return true, result, nil
 }
 
 func (l *ledgerEntryReadTx) GetLedgerEntry(key xdr.LedgerKey, includeExpired bool) (bool, xdr.LedgerEntry, error) {

--- a/cmd/soroban-rpc/internal/db/transactionalcache.go
+++ b/cmd/soroban-rpc/internal/db/transactionalcache.go
@@ -29,6 +29,9 @@ func (r transactionalCacheReadTx) get(key string) (string, bool) {
 	val, ok := r[key]
 	return val, ok
 }
+func (r transactionalCacheReadTx) upsert(key, value string) {
+	r[key] = value
+}
 
 type transactionalCacheWriteTx struct {
 	// nil indicates deletion

--- a/cmd/soroban-rpc/internal/db/transactionalcache.go
+++ b/cmd/soroban-rpc/internal/db/transactionalcache.go
@@ -11,7 +11,8 @@ func newTransactionalCache() transactionalCache {
 func (c transactionalCache) newReadTx() transactionalCacheReadTx {
 	ret := make(transactionalCacheReadTx, len(c.entries))
 	for k, v := range c.entries {
-		ret[k] = v
+		localV := v
+		ret[k] = &localV
 	}
 	return ret
 }
@@ -23,13 +24,17 @@ func (c transactionalCache) newWriteTx(estimatedWriteCount int) transactionalCac
 	}
 }
 
-type transactionalCacheReadTx map[string]string
+// nil indicates not present in the underlying storage
+type transactionalCacheReadTx map[string]*string
 
-func (r transactionalCacheReadTx) get(key string) (string, bool) {
+// nil indicates not present in the underlying storage
+func (r transactionalCacheReadTx) get(key string) (*string, bool) {
 	val, ok := r[key]
 	return val, ok
 }
-func (r transactionalCacheReadTx) upsert(key, value string) {
+
+// nil indicates not present in the underlying storage
+func (r transactionalCacheReadTx) upsert(key string, value *string) {
 	r[key] = value
 }
 

--- a/cmd/soroban-rpc/internal/methods/get_latest_ledger_test.go
+++ b/cmd/soroban-rpc/internal/methods/get_latest_ledger_test.go
@@ -34,6 +34,10 @@ func (entryReader *ConstantLedgerEntryReader) NewTx(ctx context.Context) (db.Led
 	return ConstantLedgerEntryReaderTx{}, nil
 }
 
+func (entryReader *ConstantLedgerEntryReader) NewCachedTx(ctx context.Context) (db.LedgerEntryReadTx, error) {
+	return ConstantLedgerEntryReaderTx{}, nil
+}
+
 func (entryReaderTx ConstantLedgerEntryReaderTx) GetLatestLedgerSequence() (uint32, error) {
 	return expectedLatestLedgerSequence, nil
 }

--- a/cmd/soroban-rpc/internal/methods/simulate_transaction.go
+++ b/cmd/soroban-rpc/internal/methods/simulate_transaction.go
@@ -84,7 +84,7 @@ func NewSimulateTransactionHandler(logger *log.Entry, ledgerEntryReader db.Ledge
 			}
 		}
 
-		readTx, err := ledgerEntryReader.NewTx(ctx)
+		readTx, err := ledgerEntryReader.NewCachedTx(ctx)
 		if err != nil {
 			return SimulateTransactionResponse{
 				Error: "Cannot create read transaction",

--- a/cmd/soroban-rpc/internal/preflight/preflight_test.go
+++ b/cmd/soroban-rpc/internal/preflight/preflight_test.go
@@ -271,7 +271,7 @@ func getPreflightParameters(t testing.TB, inMemory bool) PreflightParameters {
 		}
 		err = tx.Commit(2)
 		require.NoError(t, err)
-		ledgerEntryReadTx, err = db.NewLedgerEntryReader(dbInstance).NewTx(context.Background())
+		ledgerEntryReadTx, err = db.NewLedgerEntryReader(dbInstance).NewCachedTx(context.Background())
 		require.NoError(t, err)
 	}
 	argSymbol := xdr.ScSymbol("world")


### PR DESCRIPTION
### What

As a followup to #837 , also cache all entries queried from the DB in a read transaction.

To have finer control over caching, a new contructor (`NewCachedTx`) has been added. This allows disabling caching in situations in which the cache size could grow out of hand.

### Why

The preflight library (which in turn depends on rs-env-host) sometimes queries the same entry more than once.

### Result

The performance improvement is not huge, but it allows us to be more flexible on the preflight library, not needing to be careful about querying the same entry multiple times.
 
Also note that the benchmark is pretty naive and doesn't query a lot of ledger entries from the DB.

Before:

```
goos: darwin
goarch: arm64
pkg: github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/preflight
BenchmarkGetPreflight
BenchmarkGetPreflight/In-memory_storage
BenchmarkGetPreflight/In-memory_storage-12         	    5709	    211948 ns/op
BenchmarkGetPreflight/DB_storage
BenchmarkGetPreflight/DB_storage-12                	    3009	    383341 ns/op
PASS
```

After:

```
goos: darwin
goarch: arm64
pkg: github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/preflight
BenchmarkGetPreflight
BenchmarkGetPreflight/In-memory_storage
BenchmarkGetPreflight/In-memory_storage-12         	    5658	    207791 ns/op
BenchmarkGetPreflight/DB_storage
BenchmarkGetPreflight/DB_storage-12                	    3591	    315048 ns/op
PASS
```

### Known limitations

N/A

