### PR TITLE
soroban-rpc: Fix upstert  bug in DB cache

### DIFF
--- a/cmd/soroban-rpc/internal/db/ledgerentry_test.go
+++ b/cmd/soroban-rpc/internal/db/ledgerentry_test.go
@@ -767,6 +767,6 @@ func NewTestDB(tb testing.TB) *DB {
 	})
 	return &DB{
 		SessionInterface: db,
-		ledgerEntryCache: map[string]string{},
+		ledgerEntryCache: newTransactionalCache(),
 	}
 }

--- a/cmd/soroban-rpc/internal/db/transactionalcache.go
+++ b/cmd/soroban-rpc/internal/db/transactionalcache.go
@@ -48,7 +48,8 @@ func (w transactionalCacheWriteTx) commit() {
 	for key, newValue := range w.pendingUpdates {
 		if newValue == nil {
 			delete(w.parent.entries, key)
+		} else {
+			w.parent.entries[key] = *newValue
 		}
-		w.parent.entries[key] = *newValue
 	}
 }


### PR DESCRIPTION
Leftover from #837 

BTW, the fact that the system tests are failing all the time gets the eye used to seeing red-crosses in CI. This lets problems like this leak through the cracks.

We should probably make the unit tests mandatory for merging although I would prefer for the system tests not to be broken so often (CC @tsachiherman @sreuland )
