### PR TITLE
feat(bindings-ts)!: rm --contract-name, add --overwrite

### DIFF
--- a/cmd/soroban-cli/src/commands/contract/bindings/typescript.rs
+++ b/cmd/soroban-cli/src/commands/contract/bindings/typescript.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, path::PathBuf};
+use std::{ffi::OsString, fmt::Debug, path::PathBuf};
 
 use clap::{command, Parser};
 use soroban_spec_typescript::{self as typescript, boilerplate::Project};
@@ -22,13 +22,15 @@ pub struct Cmd {
     #[arg(long)]
     pub wasm: Option<std::path::PathBuf>,
 
-    /// where to place generated project
+    /// Where to place generated project
     #[arg(long)]
     output_dir: PathBuf,
 
+    /// Whether to overwrite output directory if it already exists
     #[arg(long)]
-    contract_name: String,
+    overwrite: bool,
 
+    /// The contract ID/address on the network
     #[arg(long, alias = "id")]
     contract_id: String,
 
@@ -46,8 +48,14 @@ pub enum Error {
     #[error(transparent)]
     Io(#[from] std::io::Error),
 
-    #[error("--root-dir cannot be a file: {0:?}")]
+    #[error("--output-dir cannot be a file: {0:?}")]
     IsFile(PathBuf),
+
+    #[error("--output-dir already exists and you did not specify --overwrite: {0:?}")]
+    OutputDirExists(PathBuf),
+
+    #[error("--output-dir filepath not representable as utf-8: {0:?}")]
+    NotUtf8(OsString),
 
     #[error(transparent)]
     Network(#[from] network::Error),
@@ -79,13 +87,15 @@ impl Cmd {
         if self.output_dir.is_file() {
             return Err(Error::IsFile(self.output_dir.clone()));
         }
-        let output_dir = if self.output_dir.exists() {
-            self.output_dir.join(&self.contract_name)
-        } else {
-            self.output_dir.clone()
-        };
-        std::fs::create_dir_all(&output_dir)?;
-        let p: Project = output_dir.clone().try_into()?;
+        if self.output_dir.exists() {
+            if self.overwrite {
+                std::fs::remove_dir_all(&self.output_dir)?;
+            } else {
+                return Err(Error::OutputDirExists(self.output_dir.clone()));
+            }
+        }
+        std::fs::create_dir_all(&self.output_dir)?;
+        let p: Project = self.output_dir.clone().try_into()?;
         let Network {
             rpc_url,
             network_passphrase,
@@ -94,8 +104,13 @@ impl Cmd {
             .get(&self.locator)
             .ok()
             .unwrap_or_else(Network::futurenet);
+        let absolute_path = self.output_dir.canonicalize()?;
+        let file_name = absolute_path.file_name().unwrap();
+        let contract_name = &file_name
+            .to_str()
+            .ok_or_else(|| Error::NotUtf8(file_name.to_os_string()))?;
         p.init(
-            &self.contract_name,
+            contract_name,
             &self.contract_id,
             &rpc_url,
             &network_passphrase,
@@ -103,13 +118,13 @@ impl Cmd {
         )?;
         std::process::Command::new("npm")
             .arg("install")
-            .current_dir(&output_dir)
+            .current_dir(&self.output_dir)
             .spawn()?
             .wait()?;
         std::process::Command::new("npm")
             .arg("run")
             .arg("build")
-            .current_dir(&output_dir)
+            .current_dir(&self.output_dir)
             .spawn()?
             .wait()?;
         Ok(())

--- a/docs/soroban-cli-full-docs.md
+++ b/docs/soroban-cli-full-docs.md
@@ -156,14 +156,14 @@ Generate Rust bindings
 
 Generate a TypeScript / JavaScript package
 
-**Usage:** `soroban contract bindings typescript [OPTIONS] --output-dir <OUTPUT_DIR> --contract-name <CONTRACT_NAME> --contract-id <CONTRACT_ID>`
+**Usage:** `soroban contract bindings typescript [OPTIONS] --output-dir <OUTPUT_DIR> --contract-id <CONTRACT_ID>`
 
 ###### **Options:**
 
 * `--wasm <WASM>` — Path to optional wasm binary
-* `--output-dir <OUTPUT_DIR>` — where to place generated project
-* `--contract-name <CONTRACT_NAME>`
-* `--contract-id <CONTRACT_ID>`
+* `--output-dir <OUTPUT_DIR>` — Where to place generated project
+* `--overwrite` — Whether to overwrite output directory if it already exists
+* `--contract-id <CONTRACT_ID>` — The contract ID/address on the network
 * `--global` — Use global config
 * `--config-dir <CONFIG_DIR>`
 * `--rpc-url <RPC_URL>` — RPC server endpoint


### PR DESCRIPTION
Fixes #752

Removes the `--contract-name` argument from `bindings typescript`, since
this was often confused with `--output-dir` and, really, just using the
file path from the end of `--output-dir` is sufficient.

Adds `--overwrite`. If you specify an `--output-dir` that already
exists, by default it will not be overwritten. Instead, a descriptive error
will be thrown, letting you know that you can add `--overwrite` to
overwrite the directory.

Previously, if you specified an `--output-dir` that already existed, it
would create a new directory with the same name inside this directory,
which can lead to confusing bugs.

This approach was arrived at with @tyvdh

### Known limitations

N/A