### PR TITLE
soroban-rpc: Rust dependency updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1809,7 +1809,7 @@ dependencies = [
 name = "preflight"
 version = "0.9.4"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.2",
  "libc",
  "sha2 0.10.7",
  "soroban-env-host",
@@ -2433,7 +2433,7 @@ version = "0.9.4"
 dependencies = [
  "assert_cmd",
  "assert_fs",
- "base64 0.13.1",
+ "base64 0.21.2",
  "cargo_metadata",
  "chrono",
  "clap",
@@ -2664,7 +2664,7 @@ dependencies = [
 name = "soroban-spec-tools"
 version = "0.9.4"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.2",
  "ethnum",
  "hex",
  "itertools",
@@ -2682,7 +2682,7 @@ dependencies = [
 name = "soroban-spec-typescript"
 version = "0.9.4"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.2",
  "heck",
  "include_dir",
  "itertools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2921,18 +2921,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.41"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c16a64ba9387ef3fdae4f9c1a7f07a0997fce91985c0336f1ddc1822b3b37802"
+checksum = "d9207952ae1a003f42d3d5e892dac3c6ba42aa6ac0c79a6a91a2b5cb4253e75c"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.41"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d14928354b01c4d6a4f0e549069adef399a284e7995c7ccca94e8a07a5346c59"
+checksum = "f1728216d3244de4f14f14f8c15c79be1a7c67867d28d69b719690e2a19fb445"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ rev = "4876e5eb20016caebbd13bcf6401626dc6073b8e"
 default-features = false
 
 [workspace.dependencies]
-base64 = "0.13.0"
+base64 = "0.21.2"
 ethnum = "1.3.2"
 hex = "0.4.3"
 itertools = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,8 @@ default-features = false
 
 [workspace.dependencies]
 base64 = "0.21.2"
+thiserror = "1.0.46"
+sha2 = "0.10.7"
 ethnum = "1.3.2"
 hex = "0.4.3"
 itertools = "0.10.0"

--- a/cmd/crates/soroban-spec-tools/src/utils.rs
+++ b/cmd/crates/soroban-spec-tools/src/utils.rs
@@ -1,5 +1,5 @@
+use base64::{engine::general_purpose::STANDARD as base64, Engine as _};
 use hex::FromHexError;
-
 use std::{
     fmt::Display,
     io::{self, Cursor},
@@ -59,7 +59,7 @@ impl ContractSpec {
 
         let mut env_meta_base64 = None;
         let env_meta = if let Some(env_meta) = env_meta {
-            env_meta_base64 = Some(base64::encode(env_meta));
+            env_meta_base64 = Some(base64.encode(env_meta));
             let cursor = Cursor::new(env_meta);
             let mut depth_limit_read = DepthLimitedRead::new(cursor, 100);
             ScEnvMetaEntry::read_xdr_iter(&mut depth_limit_read)
@@ -70,7 +70,7 @@ impl ContractSpec {
 
         let mut meta_base64 = None;
         let meta = if let Some(meta) = meta {
-            meta_base64 = Some(base64::encode(meta));
+            meta_base64 = Some(base64.encode(meta));
             let cursor = Cursor::new(meta);
             let mut depth_limit_read = DepthLimitedRead::new(cursor, 100);
             ScMetaEntry::read_xdr_iter(&mut depth_limit_read)
@@ -81,7 +81,7 @@ impl ContractSpec {
 
         let mut spec_base64 = None;
         let spec = if let Some(spec) = spec {
-            spec_base64 = Some(base64::encode(spec));
+            spec_base64 = Some(base64.encode(spec));
             let cursor = Cursor::new(spec);
             let mut depth_limit_read = DepthLimitedRead::new(cursor, 100);
             ScSpecEntry::read_xdr_iter(&mut depth_limit_read)

--- a/cmd/soroban-cli/Cargo.toml
+++ b/cmd/soroban-cli/Cargo.toml
@@ -51,7 +51,7 @@ clap = { version = "4.1.8", features = [
     "string",
 ] }
 base64 = { workspace = true }
-thiserror = "1.0.31"
+thiserror = { workspace = true }
 serde = "1.0.82"
 serde_derive = "1.0.82"
 serde_json = "1.0.82"
@@ -64,7 +64,7 @@ termcolor_output = "1.0.1"
 clap_complete = "4.1.4"
 rand = "0.8.5"
 wasmparser = { workspace = true }
-sha2 = "0.10.6"
+sha2 = { workspace = true }
 csv = "1.1.6"
 ed25519-dalek = "1.0.1"
 jsonrpsee-http-client = "0.18.1"

--- a/cmd/soroban-cli/src/utils/contract_spec.rs
+++ b/cmd/soroban-cli/src/utils/contract_spec.rs
@@ -1,3 +1,4 @@
+use base64::{engine::general_purpose::STANDARD as base64, Engine as _};
 use std::{
     fmt::Display,
     io::{self, Cursor},
@@ -57,7 +58,7 @@ impl ContractSpec {
 
         let mut env_meta_base64 = None;
         let env_meta = if let Some(env_meta) = env_meta {
-            env_meta_base64 = Some(base64::encode(env_meta));
+            env_meta_base64 = Some(base64.encode(env_meta));
             let cursor = Cursor::new(env_meta);
             let mut depth_limit_read = DepthLimitedRead::new(cursor, 100);
             ScEnvMetaEntry::read_xdr_iter(&mut depth_limit_read)
@@ -68,7 +69,7 @@ impl ContractSpec {
 
         let mut meta_base64 = None;
         let meta = if let Some(meta) = meta {
-            meta_base64 = Some(base64::encode(meta));
+            meta_base64 = Some(base64.encode(meta));
             let cursor = Cursor::new(meta);
             let mut depth_limit_read = DepthLimitedRead::new(cursor, 100);
             ScMetaEntry::read_xdr_iter(&mut depth_limit_read)
@@ -79,7 +80,7 @@ impl ContractSpec {
 
         let mut spec_base64 = None;
         let spec = if let Some(spec) = spec {
-            spec_base64 = Some(base64::encode(spec));
+            spec_base64 = Some(base64.encode(spec));
             let cursor = Cursor::new(spec);
             let mut depth_limit_read = DepthLimitedRead::new(cursor, 100);
             ScSpecEntry::read_xdr_iter(&mut depth_limit_read)

--- a/cmd/soroban-rpc/lib/preflight/Cargo.toml
+++ b/cmd/soroban-rpc/lib/preflight/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["staticlib"]
 [dependencies]
 # TODO: base64 and thiserror are also used by the CLI,
 #       should we make them workspace dependencies?
-base64 = "0.13.0"
+base64 = { workspace = true }
 thiserror = "1.0.31"
 libc = "0.2.2"
 sha2 = "0.10.6"

--- a/cmd/soroban-rpc/lib/preflight/Cargo.toml
+++ b/cmd/soroban-rpc/lib/preflight/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["staticlib"]
 # TODO: base64 and thiserror are also used by the CLI,
 #       should we make them workspace dependencies?
 base64 = { workspace = true }
-thiserror = "1.0.31"
-libc = "0.2.2"
-sha2 = "0.10.6"
+thiserror = { workspace = true }
+libc = "0.2.147"
+sha2 = { workspace = true }
 soroban-env-host = { workspace = true }

--- a/cmd/soroban-rpc/lib/preflight/src/ledger_storage.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/ledger_storage.rs
@@ -1,4 +1,4 @@
-use base64::DecodeError;
+use base64::{engine::general_purpose::STANDARD as base64, DecodeError, Engine as _};
 use ledger_storage::Error::UnexpectedConfigLedgerEntryType;
 use soroban_env_host::storage::SnapshotSource;
 use soroban_env_host::xdr::{
@@ -87,7 +87,7 @@ impl LedgerStorage {
 
     pub fn get_xdr(&self, key: &LedgerKey, include_expired: bool) -> Result<Vec<u8>, Error> {
         let base64_str = self.get_xdr_base64(key, include_expired)?;
-        Ok(base64::decode(base64_str)?)
+        Ok(base64.decode(base64_str)?)
     }
 
     pub fn get_configuration_setting(


### PR DESCRIPTION
### What

Review & Update the RPC's rust dependencies

### Why

Part of https://github.com/stellar/soroban-tools/issues/791

### Updates

#### base64 v0.13.1

Upgraded this repo to 0.21.2. Moved to a workspace dep since it is shared with
CLI.

Need to update stellar-xdr to match.

#### libc v0.2.147

FFI bindings. Already on latest

#### thiserror v1.0.31

Updated to 1.0.46. Moved to a workspace dep since it is shared with CLI.

#### sha2 v0.10.6

Updated to 0.10.7. Moved to a workspace dep since it is shared with CLI.

Note: We only use this to convert the network_passphrase to the network_id. So we could do that in go and remove this dependency, but not sure it is worth it, since the CLI anyway.

#### soroban-env-host

To update separately.
