### PR TITLE
fix(CLI): move plugin logic to Root and pass clap error if plugin's name is close to a built-in subcommand

### DIFF
--- a/cmd/crates/soroban-test/tests/it/plugin.rs
+++ b/cmd/crates/soroban-test/tests/it/plugin.rs
@@ -31,6 +31,7 @@ fn list() {
 }
 
 #[test]
+#[cfg(not(unix))]
 fn has_no_path() {
     // Call soroban with the PATH variable set to include just target/bin directory
     assert_cmd::Command::cargo_bin("soroban")
@@ -47,7 +48,6 @@ fn has_no_path_failure() {
     assert_cmd::Command::cargo_bin("soroban")
         .unwrap_or_else(|_| assert_cmd::Command::new("soroban"))
         .arg("hello")
-        .env("PATH", "")
         .assert()
         .stderr(predicates::str::contains("error: no such command: `hello`"));
 }

--- a/cmd/crates/soroban-test/tests/it/plugin.rs
+++ b/cmd/crates/soroban-test/tests/it/plugin.rs
@@ -4,8 +4,33 @@ is correct. The PATH environment variable is set to include the target/bin
 directory, so that the soroban executable can be found.
 */
 
+use std::ffi::OsString;
+
 #[test]
 fn soroban_hello() {
+    // Add the target/bin directory to the iterator of paths
+    let paths = get_paths();
+    // Call soroban with the PATH variable set to include the target/bin directory
+    assert_cmd::Command::cargo_bin("soroban")
+        .unwrap_or_else(|_| assert_cmd::Command::new("soroban"))
+        .arg("hello")
+        .env("PATH", &paths)
+        .assert()
+        .stdout("Hello, world!\n");
+}
+
+#[test]
+fn list() {
+    // Call `soroban --list` with the PATH variable set to include the target/bin directory
+    assert_cmd::Command::cargo_bin("soroban")
+        .unwrap_or_else(|_| assert_cmd::Command::new("soroban"))
+        .arg("--list")
+        .env("PATH", get_paths())
+        .assert()
+        .stdout(predicates::str::contains("hello"));
+}
+
+fn get_paths() -> OsString {
     // Get the current working directory
     let current_dir = std::env::current_dir().unwrap();
     // Create a path to the target/bin directory
@@ -14,22 +39,5 @@ fn soroban_hello() {
     let path_key = std::env::var_os("PATH").unwrap();
     // Create an iterator of paths from the PATH environment variable
     let current_paths = std::env::split_paths(&path_key);
-    // Add the target/bin directory to the iterator of paths
-    let paths = std::env::join_paths(current_paths.chain(vec![target_bin_path])).unwrap();
-
-    // Call soroban with the PATH variable set to include the target/bin directory
-    assert_cmd::Command::cargo_bin("soroban")
-        .unwrap_or_else(|_| assert_cmd::Command::new("soroban"))
-        .arg("hello")
-        .env("PATH", &paths)
-        .assert()
-        .stdout("Hello, world!\n");
-
-    // Call `soroban --list` with the PATH variable set to include the target/bin directory
-    assert_cmd::Command::cargo_bin("soroban")
-        .unwrap_or_else(|_| assert_cmd::Command::new("soroban"))
-        .arg("--list")
-        .env("PATH", paths)
-        .assert()
-        .stdout(predicates::str::contains("hello"));
+    std::env::join_paths(current_paths.chain(vec![target_bin_path])).unwrap()
 }

--- a/cmd/crates/soroban-test/tests/it/plugin.rs
+++ b/cmd/crates/soroban-test/tests/it/plugin.rs
@@ -57,7 +57,10 @@ fn target_bin() -> PathBuf {
     let current_dir = std::env::current_dir().unwrap();
 
     // Create a path to the target/bin directory
-    current_dir.join("../../../target/bin")
+    current_dir
+        .join("../../../target/bin")
+        .canonicalize()
+        .unwrap()
 }
 
 fn get_paths() -> OsString {

--- a/cmd/crates/soroban-test/tests/it/plugin.rs
+++ b/cmd/crates/soroban-test/tests/it/plugin.rs
@@ -30,13 +30,28 @@ fn list() {
         .stdout(predicates::str::contains("hello"));
 }
 
+#[test]
+fn has_no_path() {
+    std::env::remove_var("PATH");
+    // Add the target/bin directory to the iterator of paths
+    let paths = get_paths();
+    // Call soroban with the PATH variable set to include the target/bin directory
+    assert_cmd::Command::cargo_bin("soroban")
+        .unwrap_or_else(|_| assert_cmd::Command::new("soroban"))
+        .arg("hello")
+        .env("PATH", &paths)
+        .assert()
+        .stdout("Hello, world!\n");
+}
+
 fn get_paths() -> OsString {
     // Get the current working directory
     let current_dir = std::env::current_dir().unwrap();
+
     // Create a path to the target/bin directory
     let target_bin_path = current_dir.join("../../../target/bin");
     // Get the current PATH environment variable
-    let path_key = std::env::var_os("PATH").unwrap();
+    let path_key = std::env::var_os("PATH").unwrap_or_default();
     // Create an iterator of paths from the PATH environment variable
     let current_paths = std::env::split_paths(&path_key);
     std::env::join_paths(current_paths.chain(vec![target_bin_path])).unwrap()

--- a/cmd/soroban-cli/src/commands/plugin.rs
+++ b/cmd/soroban-cli/src/commands/plugin.rs
@@ -1,7 +1,9 @@
 use std::process::Command;
+
+use clap::CommandFactory;
 use which::which;
 
-use crate::utils;
+use crate::{utils, Root};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -10,7 +12,7 @@ pub enum Error {
     #[error(transparent)]
     IO(#[from] std::io::Error),
     #[error(
-        r#"no such command: `{0}`
+        r#"error: no such command: `{0}`
         
         {1}View all installed plugins with `soroban --list`"#
     )]
@@ -19,18 +21,31 @@ pub enum Error {
     Which(#[from] which::Error),
 }
 
+const SUBCOMMAND_TOLERANCE: f64 = 0.75;
+const PLUGIN_TOLERANCE: f64 = 0.75;
+
+/// Tries to run a plugin, if the plugin's name is similar enough to any of the current subcommands return Ok.
+/// Otherwise only errors can be returned because this process will exit with the plugin.
 pub fn run() -> Result<(), Error> {
     let (name, args) = {
         let mut args = std::env::args().skip(1);
         let name = args.next().ok_or(Error::MissingSubcommand)?;
         (name, args)
     };
+
+    if Root::command().get_subcommands().any(|c| {
+        let sc_name = c.get_name();
+        sc_name.starts_with(&name) || strsim::jaro(sc_name, &name) >= SUBCOMMAND_TOLERANCE
+    }) {
+        return Ok(());
+    }
+
     let bin = which(format!("soroban-{name}")).map_err(|_| {
         let suggestion = if let Ok(bins) = list() {
             let suggested_name = bins
                 .iter()
                 .map(|b| (b, strsim::jaro_winkler(&name, b)))
-                .filter(|(_, i)| *i > 0.5f64)
+                .filter(|(_, i)| *i > PLUGIN_TOLERANCE)
                 .min_by(|a, b| a.1.total_cmp(&b.1))
                 .map(|(a, _)| a.to_string())
                 .unwrap_or_default();

--- a/cmd/soroban-cli/src/commands/plugin.rs
+++ b/cmd/soroban-cli/src/commands/plugin.rs
@@ -23,6 +23,7 @@ pub enum Error {
 
 const SUBCOMMAND_TOLERANCE: f64 = 0.75;
 const PLUGIN_TOLERANCE: f64 = 0.75;
+const MIN_LENGTH: usize = 4;
 
 /// Tries to run a plugin, if the plugin's name is similar enough to any of the current subcommands return Ok.
 /// Otherwise only errors can be returned because this process will exit with the plugin.
@@ -35,7 +36,8 @@ pub fn run() -> Result<(), Error> {
 
     if Root::command().get_subcommands().any(|c| {
         let sc_name = c.get_name();
-        sc_name.starts_with(&name) || strsim::jaro(sc_name, &name) >= SUBCOMMAND_TOLERANCE
+        sc_name.starts_with(&name)
+            || (name.len() >= MIN_LENGTH && strsim::jaro(sc_name, &name) >= SUBCOMMAND_TOLERANCE)
     }) {
         return Ok(());
     }


### PR DESCRIPTION
fixes #866

### What

[TODO: Short statement about what is changing.]

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
