### PR TITLE
soroban-rpc: Fix ledgerentry visibility bug

### DIFF
--- a/cmd/soroban-rpc/internal/db/ledgerentry.go
+++ b/cmd/soroban-rpc/internal/db/ledgerentry.go
@@ -253,7 +253,8 @@ func (l *ledgerEntryReadTx) GetLedgerEntry(key xdr.LedgerKey, includeExpired boo
 			if err != nil {
 				return false, xdr.LedgerEntry{}, err
 			}
-			if expirationLedgerSeq < xdr.Uint32(latestClosedLedger) {
+			currentLedger := latestClosedLedger + 1
+			if expirationLedgerSeq < xdr.Uint32(currentLedger) {
 				return false, xdr.LedgerEntry{}, nil
 			}
 		}

--- a/cmd/soroban-rpc/internal/db/ledgerentry_test.go
+++ b/cmd/soroban-rpc/internal/db/ledgerentry_test.go
@@ -357,14 +357,17 @@ func TestGetLedgerEntryHidesExpiredContractDataEntries(t *testing.T) {
 	}{
 		{21, true},
 		{22, true},
-		{23, true},
+		{23, false},
 		{24, false},
-		{25, false},
 	} {
 		// ffwd to the ledger sequence
 		tx, err := NewReadWriter(db, 0, 15).NewTx(context.Background())
 		assert.NoError(t, err)
+		// Close the ledger N
 		assert.NoError(t, tx.Commit(c.ledgerSequence))
+
+		// Now, ledger N is our latestClosedLedger, so any preflights should act as
+		// though it is currently ledger N+1
 
 		// Try to read the entry back, and check it disappears when expected
 		present, _, obtainedLedgerSequence := getLedgerEntryAndLatestLedgerSequence(t, db, key)
@@ -404,14 +407,17 @@ func TestGetLedgerEntryHidesExpiredContractCodeEntries(t *testing.T) {
 	}{
 		{21, true},
 		{22, true},
-		{23, true},
+		{23, false},
 		{24, false},
-		{25, false},
 	} {
 		// ffwd to the ledger sequence
 		tx, err := NewReadWriter(db, 0, 15).NewTx(context.Background())
 		assert.NoError(t, err)
+		// Close the ledger N
 		assert.NoError(t, tx.Commit(c.ledgerSequence))
+
+		// Now, ledger N is our latestClosedLedger, so any preflights should act as
+		// though it is currently ledger N+1
 
 		// Try to read the entry back, and check it disappears when expected
 		present, _, obtainedLedgerSequence := getLedgerEntryAndLatestLedgerSequence(t, db, key)

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -779,7 +779,7 @@ func TestSimulateTransactionBumpAndRestoreFootprint(t *testing.T) {
 			break
 		}
 		assert.NoError(t, xdr.SafeUnmarshalBase64(result.XDR, &entry))
-		t.Log("waiting for ledger entry to expire at ledger", entry.MustContractData().ExpirationLedgerSeq+1)
+		t.Log("waiting for ledger entry to expire at ledger", entry.MustContractData().ExpirationLedgerSeq)
 		time.Sleep(time.Second)
 	}
 	require.True(t, expired)


### PR DESCRIPTION
### What

Fix a ledger entry visibility bug introduced in #846.

### Why

Ledger Entries should be visible when `currentLedger == expirationLedgerSeq` (according to https://soroban.stellar.org/docs/fundamentals-and-concepts/state-expiration#expiration-ledger). But the code previously made it a bit unclear which ledger was LatestClosed vs Current (which led to the bug).

### Known limitations

[TODO or N/A]
