### PR TITLE
soroban-rpc: refactor libpreflight

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.71"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "arbitrary"
@@ -1809,6 +1809,7 @@ dependencies = [
 name = "preflight"
 version = "0.9.4"
 dependencies = [
+ "anyhow",
  "base64 0.21.2",
  "libc",
  "sha2 0.10.7",

--- a/cmd/soroban-rpc/internal/preflight/preflight.go
+++ b/cmd/soroban-rpc/internal/preflight/preflight.go
@@ -132,7 +132,6 @@ func getFootprintExpirationPreflight(params PreflightParameters) (Preflight, err
 	defer handle.Delete()
 
 	latestLedger, err := params.LedgerEntryReadTx.GetLatestLedgerSequence()
-
 	if err != nil {
 		return Preflight{}, err
 	}

--- a/cmd/soroban-rpc/internal/preflight/preflight.go
+++ b/cmd/soroban-rpc/internal/preflight/preflight.go
@@ -132,6 +132,7 @@ func getFootprintExpirationPreflight(params PreflightParameters) (Preflight, err
 	defer handle.Delete()
 
 	latestLedger, err := params.LedgerEntryReadTx.GetLatestLedgerSequence()
+
 	if err != nil {
 		return Preflight{}, err
 	}

--- a/cmd/soroban-rpc/lib/preflight/Cargo.toml
+++ b/cmd/soroban-rpc/lib/preflight/Cargo.toml
@@ -7,10 +7,10 @@ publish = false
 crate-type = ["staticlib"]
 
 [dependencies]
-# TODO: base64 and thiserror are also used by the CLI,
-#       should we make them workspace dependencies?
+anyhow = "1.0.75"
 base64 = { workspace = true }
 thiserror = { workspace = true }
 libc = "0.2.147"
 sha2 = { workspace = true }
 soroban-env-host = { workspace = true }
+

--- a/cmd/soroban-rpc/lib/preflight/src/fees.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/fees.rs
@@ -172,8 +172,7 @@ fn get_fee_configurations(
     let ConfigSettingEntry::ContractLedgerCostV0(ledger_cost) =
         ledger_storage.get_configuration_setting(ConfigSettingId::ContractLedgerCostV0)?
     else {
-        bail!(
-           "unexpected config setting entry for LedgerCostV0 key");
+        bail!("unexpected config setting entry for LedgerCostV0 key");
     };
 
     let ConfigSettingEntry::ContractHistoricalDataV0(historical_data) =
@@ -253,7 +252,7 @@ fn calculate_event_size_bytes(events: &Vec<DiagnosticEvent>) -> Result<u32> {
     for e in events {
         let event_xdr = e
             .to_xdr()
-            .with_context(|| format!("cannot marshall event {e:?}"))?;
+            .with_context(|| format!("cannot marshal event {e:?}"))?;
         res += u32::try_from(event_xdr.len())?;
     }
     Ok(res)
@@ -313,7 +312,7 @@ pub(crate) fn compute_bump_footprint_exp_transaction_data_and_min_fee(
         ledgers_to_expire,
         current_ledger_seq,
     )
-    .context("cannot compute rent changes")?;
+    .context("cannot compute bump rent changes")?;
     let read_bytes = calculate_unmodified_ledger_entry_bytes(
         footprint.read_only.as_vec(),
         ledger_storage,
@@ -404,7 +403,7 @@ pub(crate) fn compute_restore_footprint_transaction_data_and_min_fee(
         state_expiration.min_persistent_entry_expiration,
         current_ledger_seq,
     )
-    .context("cannot compute rent changes")?;
+    .context("cannot compute restore rent changes")?;
     let write_bytes = calculate_unmodified_ledger_entry_bytes(
         footprint.read_write.as_vec(),
         ledger_storage,

--- a/cmd/soroban-rpc/lib/preflight/src/fees.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/fees.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, bail, Context, Error, Result};
+use anyhow::{bail, Context, Error, Result};
 use ledger_storage;
 use soroban_env_host::budget::Budget;
 use soroban_env_host::e2e_invoke::{extract_rent_changes, get_ledger_changes, LedgerEntryChange};

--- a/cmd/soroban-rpc/lib/preflight/src/fees.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/fees.rs
@@ -259,8 +259,8 @@ fn calculate_event_size_bytes(events: &Vec<DiagnosticEvent>) -> Result<u32> {
 }
 
 fn storage_footprint_to_ledger_footprint(foot: &Footprint) -> Result<LedgerFootprint, xdr::Error> {
-    let mut read_only: Vec<LedgerKey> = Vec::new();
-    let mut read_write: Vec<LedgerKey> = Vec::new();
+    let mut read_only: Vec<LedgerKey> = Vec::with_capacity(foot.0.len());
+    let mut read_write: Vec<LedgerKey> = Vec::with_capacity(foot.0.len());
     for (k, v) in &foot.0 {
         match v {
             AccessType::ReadOnly => read_only.push((**k).clone()),
@@ -359,7 +359,8 @@ fn compute_bump_footprint_rent_changes(
     ledgers_to_expire: u32,
     current_ledger_seq: u32,
 ) -> Result<Vec<LedgerEntryRentChange>> {
-    let mut rent_changes: Vec<LedgerEntryRentChange> = Vec::new();
+    let mut rent_changes: Vec<LedgerEntryRentChange> =
+        Vec::with_capacity(footprint.read_only.len());
     for key in (&footprint).read_only.as_vec() {
         let unmodified_entry = ledger_storage
             .get(key, false)
@@ -450,7 +451,8 @@ fn compute_restore_footprint_rent_changes(
     min_persistent_entry_expiration: u32,
     current_ledger_seq: u32,
 ) -> Result<Vec<LedgerEntryRentChange>> {
-    let mut rent_changes: Vec<LedgerEntryRentChange> = Vec::new();
+    let mut rent_changes: Vec<LedgerEntryRentChange> =
+        Vec::with_capacity(footprint.read_write.len());
     for key in footprint.read_write.as_vec() {
         let unmodified_entry = ledger_storage
             .get(key, true)

--- a/cmd/soroban-rpc/lib/preflight/src/ledger_storage.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/ledger_storage.rs
@@ -5,7 +5,7 @@ use soroban_env_host::xdr::{
     ConfigSettingEntry, ConfigSettingId, Error as XdrError, LedgerEntry, LedgerEntryData,
     LedgerKey, LedgerKeyConfigSetting, ReadXdr, ScError, ScErrorCode, WriteXdr,
 };
-use soroban_env_host::{Host, HostError};
+use soroban_env_host::HostError;
 use state_expiration::{restore_ledger_entry, ExpirableLedgerEntry};
 use std::cell::RefCell;
 use std::collections::HashSet;

--- a/cmd/soroban-rpc/lib/preflight/src/ledger_storage.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/ledger_storage.rs
@@ -88,7 +88,7 @@ impl EntryRestoreTracker {
         self.ledger_keys_requiring_restore
             .borrow_mut()
             .insert(key.clone());
-        return true;
+        true
     }
 }
 
@@ -128,7 +128,7 @@ impl LedgerStorage {
             ledger_keys_requiring_restore: RefCell::new(HashSet::new()),
             min_persistent_entry_expiration: state_expiration.min_persistent_entry_expiration,
         });
-        return Ok(ledger_storage);
+        Ok(ledger_storage)
     }
 
     fn get_xdr_base64(&self, key: &LedgerKey, include_expired: bool) -> Result<String, Error> {

--- a/cmd/soroban-rpc/lib/preflight/src/lib.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/lib.rs
@@ -196,7 +196,7 @@ fn catch_preflight_panic(op: Box<dyn Fn() -> Result<CPreflightResult>>) -> *mut 
     // catch panics before they reach foreign callers (which otherwise would result in
     // undefined behavior)
     let res: std::thread::Result<Result<CPreflightResult>> =
-        panic::catch_unwind(panic::AssertUnwindSafe(|| op()));
+        panic::catch_unwind(panic::AssertUnwindSafe(op));
     let c_preflight_result = match res {
         Err(panic) => match panic.downcast::<String>() {
             Ok(panic_msg) => preflight_error(format!("panic during preflight() call: {panic_msg}")),

--- a/cmd/soroban-rpc/lib/preflight/src/lib.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/lib.rs
@@ -263,7 +263,6 @@ fn vec_to_c_array<T>(mut v: Vec<T>) -> *mut T {
 /// .
 #[no_mangle]
 pub unsafe extern "C" fn free_preflight_result(result: *mut CPreflightResult) {
-    println!("gets to free_preflight_result");
     if result.is_null() {
         return;
     }

--- a/cmd/soroban-rpc/lib/preflight/src/lib.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/lib.rs
@@ -1,31 +1,23 @@
 mod fees;
 mod ledger_storage;
+mod preflight;
 mod state_expiration;
 
 extern crate base64;
 extern crate libc;
 extern crate sha2;
 extern crate soroban_env_host;
-
 use ledger_storage::LedgerStorage;
+use preflight::PreflightResult;
 use sha2::{Digest, Sha256};
-use soroban_env_host::auth::RecordedAuthPayload;
-use soroban_env_host::budget::Budget;
-use soroban_env_host::events::Events;
-use soroban_env_host::storage::Storage;
 use soroban_env_host::xdr::{
-    AccountId, ConfigSettingEntry, ConfigSettingId, DiagnosticEvent, InvokeHostFunctionOp,
-    LedgerFootprint, LedgerKey, OperationBody, ReadXdr, ScVal, SorobanAddressCredentials,
-    SorobanAuthorizationEntry, SorobanCredentials, VecM, WriteXdr,
+    AccountId, InvokeHostFunctionOp, LedgerFootprint, OperationBody, ReadXdr, WriteXdr,
 };
-use soroban_env_host::{DiagnosticLevel, Host, LedgerInfo};
+use soroban_env_host::LedgerInfo;
 use std::convert::{TryFrom, TryInto};
-use std::error::Error;
 use std::ffi::{CStr, CString};
-use std::iter::FromIterator;
 use std::panic;
 use std::ptr::null_mut;
-use std::rc::Rc;
 use std::{error, mem};
 
 #[repr(C)]
@@ -42,20 +34,22 @@ pub struct CLedgerInfo {
     pub autobump_ledgers: u32,
 }
 
-impl From<CLedgerInfo> for LedgerInfo {
-    fn from(c: CLedgerInfo) -> Self {
-        let network_passphrase_cstr = unsafe { CStr::from_ptr(c.network_passphrase) };
-        Self {
+impl TryFrom<CLedgerInfo> for LedgerInfo {
+    type Error = Box<dyn error::Error>;
+
+    fn try_from(c: CLedgerInfo) -> Result<Self, Self::Error> {
+        let network_passphrase = from_c_string(c.network_passphrase)?;
+        Ok(Self {
             protocol_version: c.protocol_version,
             sequence_number: c.sequence_number,
             timestamp: c.timestamp,
-            network_id: Sha256::digest(network_passphrase_cstr.to_str().unwrap().as_bytes()).into(),
+            network_id: Sha256::digest(network_passphrase).into(),
             base_reserve: c.base_reserve,
             min_temp_entry_expiration: c.min_temp_entry_expiration,
             min_persistent_entry_expiration: c.min_persistent_entry_expiration,
             max_entry_expiration: c.max_entry_expiration,
             autobump_ledgers: c.autobump_ledgers,
-        }
+        })
     }
 }
 
@@ -73,22 +67,31 @@ pub struct CPreflightResult {
     pub pre_restore_min_fee: i64, // Minimum recommended resource fee for a prerequired RestoreFootprint operation
 }
 
-fn preflight_error(str: String) -> *mut CPreflightResult {
-    let c_str = CString::new(str).unwrap();
-    // transfer ownership to caller
-    // caller needs to invoke free_preflight_result(result) when done
-    Box::into_raw(Box::new(CPreflightResult {
-        error: c_str.into_raw(),
-        auth: null_mut(),
-        result: null_mut(),
-        transaction_data: null_mut(),
-        min_fee: 0,
-        events: null_mut(),
-        cpu_instructions: 0,
-        memory_bytes: 0,
-        pre_restore_transaction_data: null_mut(),
-        pre_restore_min_fee: 0,
-    }))
+impl TryFrom<PreflightResult> for CPreflightResult {
+    type Error = Box<dyn error::Error>;
+
+    fn try_from(p: PreflightResult) -> Result<Self, Self::Error> {
+        let mut result = Self {
+            error: null_mut(),
+            auth: xdr_vec_to_base64_c_null_terminated_char_array(p.auth)?,
+            result: match p.result {
+                None => null_mut(),
+                Some(v) => xdr_to_base64_c(v)?,
+            },
+            transaction_data: xdr_to_base64_c(p.transaction_data)?,
+            min_fee: p.min_fee,
+            events: xdr_vec_to_base64_c_null_terminated_char_array(p.events)?,
+            cpu_instructions: p.cpu_instructions,
+            memory_bytes: p.memory_bytes,
+            pre_restore_transaction_data: null_mut(),
+            pre_restore_min_fee: 0,
+        };
+        if let Some(p) = p.restore_preamble {
+            result.pre_restore_min_fee = p.min_fee;
+            result.pre_restore_transaction_data = xdr_to_base64_c(p.transaction_data)?;
+        };
+        Ok(result)
+    }
 }
 
 #[no_mangle]
@@ -99,6 +102,7 @@ pub extern "C" fn preflight_invoke_hf_op(
     source_account: *const libc::c_char, // AccountId XDR in base64
     ledger_info: CLedgerInfo,
 ) -> *mut CPreflightResult {
+    println!("gets to top preflight_invoke_hf_op");
     catch_preflight_panic(Box::new(move || {
         preflight_invoke_hf_op_or_maybe_panic(
             handle,
@@ -117,137 +121,20 @@ fn preflight_invoke_hf_op_or_maybe_panic(
     source_account: *const libc::c_char, // AccountId XDR in base64
     ledger_info: CLedgerInfo,
 ) -> Result<CPreflightResult, Box<dyn error::Error>> {
-    let invoke_hf_op_cstr = unsafe { CStr::from_ptr(invoke_hf_op) };
-    let invoke_hf_op = InvokeHostFunctionOp::from_xdr_base64(invoke_hf_op_cstr.to_str()?)?;
-    let source_account_cstr = unsafe { CStr::from_ptr(source_account) };
-    let source_account = AccountId::from_xdr_base64(source_account_cstr.to_str()?)?;
-    let ledger_storage = Rc::new(LedgerStorage::with_restore_tracking(
-        handle,
-        ledger_info.sequence_number,
-    )?);
-    let budget = get_budget_from_network_config_params(&ledger_storage)?;
-    let storage = Storage::with_recording_footprint(ledger_storage.clone());
-    let host = Host::with_storage_and_budget(storage, budget);
-
-    // We make an assumption here:
-    // - if a transaction doesn't include any soroban authorization entries the client either
-    // doesn't know the authorization entries, or there are none. In either case it is best to
-    // record the authorization entries and return them to the client.
-    // - if a transaction *does* include soroban authorization entries, then the client *already*
-    // knows the needed entries, so we should try them in enforcing mode so that we can validate
-    // them, and return the correct fees and footprint.
-    let needs_auth_recording = invoke_hf_op.auth.is_empty();
-    if needs_auth_recording {
-        host.switch_to_recording_auth()?;
-    } else {
-        host.set_authorization_entries(invoke_hf_op.auth.to_vec())?;
-    }
-
-    host.set_diagnostic_level(DiagnosticLevel::Debug)?;
-    host.set_source_account(source_account)?;
-    host.set_ledger_info(ledger_info.into())?;
-
-    // Run the preflight.
-    let result = host.invoke_function(invoke_hf_op.host_function.clone())?;
-    let auths: VecM<SorobanAuthorizationEntry> = if needs_auth_recording {
-        let payloads = host.get_recorded_auth_payloads()?;
-        VecM::try_from(
-            payloads
-                .iter()
-                .map(recorded_auth_payload_to_xdr)
-                .collect::<Vec<_>>(),
-        )?
-    } else {
-        invoke_hf_op.auth
-    };
-
-    let budget = host.budget_cloned();
-    // Recover, convert and return the storage footprint and other values to C.
-    let (storage, events) = host.try_finish()?;
-
-    let diagnostic_events = host_events_to_diagnostic_events(&events);
-    let (transaction_data, min_fee) = fees::compute_host_function_transaction_data_and_min_fee(
-        &InvokeHostFunctionOp {
-            host_function: invoke_hf_op.host_function,
-            auth: auths.clone(),
-        },
-        &ledger_storage,
-        &storage,
-        &budget,
-        &diagnostic_events,
+    println!("gets to preflight_invoke_hf_op_or_maybe_panic");
+    let invoke_hf_op = InvokeHostFunctionOp::from_xdr_base64(from_c_string(invoke_hf_op)?)?;
+    let source_account = AccountId::from_xdr_base64(from_c_string(source_account)?)?;
+    let ledger_storage = LedgerStorage::with_restore_tracking(handle, ledger_info.sequence_number)?;
+    println!("gets to invoking preflight::preflight_invoke_hf_op");
+    let result = preflight::preflight_invoke_hf_op(
+        ledger_storage,
         bucket_list_size,
-        ledger_info.sequence_number,
+        invoke_hf_op,
+        source_account,
+        ledger_info.try_into()?,
     )?;
-
-    let entries = ledger_storage.get_ledger_keys_requiring_restore();
-    let (pre_restore_transaction_data, pre_restore_min_fee) = if entries.len() > 0 {
-        let read_write_vec: Vec<LedgerKey> = Vec::from_iter(entries);
-        let restore_footprint = LedgerFootprint {
-            read_only: VecM::default(),
-            read_write: read_write_vec.try_into()?,
-        };
-        let (transaction_data, min_fee) =
-            fees::compute_restore_footprint_transaction_data_and_min_fee(
-                restore_footprint,
-                &ledger_storage,
-                bucket_list_size,
-                ledger_info.sequence_number,
-            )?;
-        let transaction_data_cstr = CString::new(transaction_data.to_xdr_base64()?)?;
-        (transaction_data_cstr.into_raw(), min_fee)
-    } else {
-        (null_mut(), 0)
-    };
-
-    let transaction_data_cstr = CString::new(transaction_data.to_xdr_base64()?)?;
-    Ok(CPreflightResult {
-        error: null_mut(),
-        auth: recorded_auth_payloads_to_c(auths.to_vec())?,
-        result: CString::new(result.to_xdr_base64()?)?.into_raw(),
-        transaction_data: transaction_data_cstr.into_raw(),
-        min_fee,
-        events: diagnostic_events_to_c(diagnostic_events)?,
-        cpu_instructions: budget.get_cpu_insns_consumed()?,
-        memory_bytes: budget.get_mem_bytes_consumed()?,
-        pre_restore_transaction_data,
-        pre_restore_min_fee,
-    })
-}
-
-fn get_budget_from_network_config_params(
-    ledger_storage: &LedgerStorage,
-) -> Result<Budget, Box<dyn error::Error>> {
-    let ConfigSettingEntry::ContractComputeV0(compute) =
-        ledger_storage.get_configuration_setting(ConfigSettingId::ContractComputeV0)?
-    else {
-        return Err(
-            "get_budget_from_network_config_params((): unexpected config setting entry for ComputeV0 key".into(),
-        );
-    };
-
-    let ConfigSettingEntry::ContractCostParamsCpuInstructions(cost_params_cpu) = ledger_storage
-        .get_configuration_setting(ConfigSettingId::ContractCostParamsCpuInstructions)?
-    else {
-        return Err(
-            "get_budget_from_network_config_params((): unexpected config setting entry for ComputeV0 key".into(),
-        );
-    };
-
-    let ConfigSettingEntry::ContractCostParamsMemoryBytes(cost_params_memory) =
-        ledger_storage.get_configuration_setting(ConfigSettingId::ContractCostParamsMemoryBytes)?
-    else {
-        return Err(
-            "get_budget_from_network_config_params((): unexpected config setting entry for ComputeV0 key".into(),
-        );
-    };
-
-    let budget = Budget::try_from_configs(
-        compute.tx_max_instructions as u64,
-        compute.tx_memory_limit as u64,
-        cost_params_cpu,
-        cost_params_memory,
-    )?;
-    Ok(budget)
+    println!("returns from invoking preflight::preflight_invoke_hf_op");
+    result.try_into()
 }
 
 #[no_mangle]
@@ -276,88 +163,33 @@ fn preflight_footprint_expiration_op_or_maybe_panic(
     footprint: *const libc::c_char,
     current_ledger_seq: u32,
 ) -> Result<CPreflightResult, Box<dyn error::Error>> {
-    let op_body_cstr = unsafe { CStr::from_ptr(op_body) };
-    let op_body = OperationBody::from_xdr_base64(op_body_cstr.to_str()?)?;
-    let footprint_cstr = unsafe { CStr::from_ptr(footprint) };
-    let ledger_footprint = LedgerFootprint::from_xdr_base64(footprint_cstr.to_str()?)?;
+    let op_body = OperationBody::from_xdr_base64(from_c_string(op_body)?)?;
+    let footprint = LedgerFootprint::from_xdr_base64(from_c_string(footprint)?)?;
     let ledger_storage = &LedgerStorage::new(handle);
-    match op_body {
-        OperationBody::BumpFootprintExpiration(op) => preflight_bump_footprint_expiration(
-            ledger_footprint,
-            op.ledgers_to_expire,
-            ledger_storage,
-            bucket_list_size,
-            current_ledger_seq,
-        ),
-        OperationBody::RestoreFootprint(_) => preflight_restore_footprint(
-            ledger_footprint,
-            ledger_storage,
-            bucket_list_size,
-            current_ledger_seq,
-        ),
-        op => Err(format!(
-            "preflight_footprint_expiration_op(): unsupported operation type {}",
-            op.name()
-        )
-        .into()),
-    }
-}
-
-fn preflight_bump_footprint_expiration(
-    footprint: LedgerFootprint,
-    ledgers_to_expire: u32,
-    ledger_storage: &LedgerStorage,
-    bucket_list_size: u64,
-    current_ledger_seq: u32,
-) -> Result<CPreflightResult, Box<dyn Error>> {
-    let (transaction_data, min_fee) =
-        fees::compute_bump_footprint_exp_transaction_data_and_min_fee(
-            footprint,
-            ledgers_to_expire,
-            ledger_storage,
-            bucket_list_size,
-            current_ledger_seq,
-        )?;
-    let transaction_data_cstr = CString::new(transaction_data.to_xdr_base64()?)?;
-    Ok(CPreflightResult {
-        error: null_mut(),
-        auth: null_mut(),
-        result: null_mut(),
-        transaction_data: transaction_data_cstr.into_raw(),
-        min_fee,
-        events: null_mut(),
-        cpu_instructions: 0,
-        memory_bytes: 0,
-        pre_restore_transaction_data: null_mut(),
-        pre_restore_min_fee: 0,
-    })
-}
-
-fn preflight_restore_footprint(
-    footprint: LedgerFootprint,
-    ledger_storage: &LedgerStorage,
-    bucket_list_size: u64,
-    current_ledger_seq: u32,
-) -> Result<CPreflightResult, Box<dyn Error>> {
-    let (transaction_data, min_fee) = fees::compute_restore_footprint_transaction_data_and_min_fee(
-        footprint,
+    let result = preflight::preflight_footprint_expiration_op(
         ledger_storage,
         bucket_list_size,
+        op_body,
+        footprint,
         current_ledger_seq,
     )?;
-    let transaction_data_cstr = CString::new(transaction_data.to_xdr_base64()?)?;
-    Ok(CPreflightResult {
-        error: null_mut(),
+    result.try_into()
+}
+
+fn preflight_error(str: String) -> CPreflightResult {
+    let c_str = CString::new(str).unwrap();
+    CPreflightResult {
+        error: c_str.into_raw(),
         auth: null_mut(),
         result: null_mut(),
-        transaction_data: transaction_data_cstr.into_raw(),
-        min_fee,
+        transaction_data: null_mut(),
+        min_fee: 0,
         events: null_mut(),
         cpu_instructions: 0,
         memory_bytes: 0,
         pre_restore_transaction_data: null_mut(),
         pre_restore_min_fee: 0,
-    })
+    }
 }
 
 fn catch_preflight_panic(
@@ -366,71 +198,35 @@ fn catch_preflight_panic(
     // catch panics before they reach foreign callers (which otherwise would result in
     // undefined behavior)
     let res = panic::catch_unwind(panic::AssertUnwindSafe(|| op()));
-    match res {
+    let c_preflight_result = match res {
         Err(panic) => match panic.downcast::<String>() {
             Ok(panic_msg) => preflight_error(format!("panic during preflight() call: {panic_msg}")),
             Err(_) => preflight_error("panic during preflight() call: unknown cause".to_string()),
         },
-        // transfer ownership to caller
-        // caller needs to invoke free_preflight_result(result) when done
         Ok(r) => match r {
-            Ok(r2) => Box::into_raw(Box::new(r2)),
+            Ok(r2) => r2,
             Err(e) => preflight_error(format!("{e}")),
         },
-    }
+    };
+    // transfer ownership to caller
+    // caller needs to invoke free_preflight_result(result) when done
+    Box::into_raw(Box::new(c_preflight_result))
 }
 
-fn recorded_auth_payloads_to_c(
-    payloads: Vec<SorobanAuthorizationEntry>,
+fn xdr_to_base64_c(v: impl WriteXdr) -> Result<*mut libc::c_char, Box<dyn error::Error>> {
+    string_to_c(v.to_xdr_base64()?)
+}
+
+fn string_to_c(str: String) -> Result<*mut libc::c_char, Box<dyn error::Error>> {
+    Ok(CString::new(str)?.into_raw())
+}
+
+fn xdr_vec_to_base64_c_null_terminated_char_array(
+    payloads: Vec<impl WriteXdr>,
 ) -> Result<*mut *mut libc::c_char, Box<dyn error::Error>> {
     let xdr_base64_vec: Vec<String> = payloads
         .iter()
         .map(WriteXdr::to_xdr_base64)
-        .collect::<Result<Vec<_>, _>>()?;
-    string_vec_to_c_null_terminated_char_array(xdr_base64_vec)
-}
-
-fn recorded_auth_payload_to_xdr(payload: &RecordedAuthPayload) -> SorobanAuthorizationEntry {
-    match (payload.address.clone(), payload.nonce) {
-        (Some(address), Some(nonce)) => SorobanAuthorizationEntry {
-            credentials: SorobanCredentials::Address(SorobanAddressCredentials {
-                address,
-                nonce,
-                // signature is left empty. This is where the client will put their signatures when
-                // submitting the transaction.
-                signature_expiration_ledger: 0,
-                signature: ScVal::Void,
-            }),
-            root_invocation: payload.invocation.clone(),
-        },
-        (None, None) => SorobanAuthorizationEntry {
-            credentials: SorobanCredentials::SourceAccount,
-            root_invocation: payload.invocation.clone(),
-        },
-        // the address and the nonce can't be present independently
-        (a,n) =>
-            panic!("recorded_auth_payload_to_xdr: address and nonce present independently (address: {:?}, nonce: {:?})", a, n),
-    }
-}
-
-fn host_events_to_diagnostic_events(events: &Events) -> Vec<DiagnosticEvent> {
-    let mut res: Vec<DiagnosticEvent> = Vec::new();
-    for e in &events.0 {
-        let diagnostic_event = DiagnosticEvent {
-            in_successful_contract_call: !e.failed_call,
-            event: e.event.clone(),
-        };
-        res.push(diagnostic_event);
-    }
-    res
-}
-
-fn diagnostic_events_to_c(
-    events: Vec<DiagnosticEvent>,
-) -> Result<*mut *mut libc::c_char, Box<dyn error::Error>> {
-    let xdr_base64_vec: Vec<String> = events
-        .iter()
-        .map(DiagnosticEvent::to_xdr_base64)
         .collect::<Result<Vec<_>, _>>()?;
     string_vec_to_c_null_terminated_char_array(xdr_base64_vec)
 }
@@ -440,7 +236,7 @@ fn string_vec_to_c_null_terminated_char_array(
 ) -> Result<*mut *mut libc::c_char, Box<dyn error::Error>> {
     let mut out_vec: Vec<*mut libc::c_char> = Vec::new();
     for s in &v {
-        let c_str = CString::new(s.clone())?.into_raw();
+        let c_str = string_to_c(s.clone())?;
         out_vec.push(c_str);
     }
 
@@ -471,33 +267,32 @@ fn vec_to_c_array<T>(mut v: Vec<T>) -> *mut T {
 /// .
 #[no_mangle]
 pub unsafe extern "C" fn free_preflight_result(result: *mut CPreflightResult) {
+    println!("gets to free_preflight_result");
     if result.is_null() {
         return;
     }
+    let boxed = Box::from_raw(result);
+    free_c_string(boxed.error);
+    free_c_null_terminated_char_array(boxed.auth);
+    free_c_string(boxed.result);
+    free_c_string(boxed.transaction_data);
+    free_c_null_terminated_char_array(boxed.events);
+    free_c_string(boxed.pre_restore_transaction_data);
+}
+
+fn free_c_string(str: *mut libc::c_char) {
+    if str.is_null() {
+        return;
+    }
     unsafe {
-        if !(*result).error.is_null() {
-            _ = CString::from_raw((*result).error);
-        }
-
-        if !(*result).auth.is_null() {
-            free_c_null_terminated_char_array((*result).auth);
-        }
-
-        if !(*result).result.is_null() {
-            _ = CString::from_raw((*result).result);
-        }
-
-        if !(*result).transaction_data.is_null() {
-            _ = CString::from_raw((*result).transaction_data);
-        }
-        if !(*result).events.is_null() {
-            free_c_null_terminated_char_array((*result).events);
-        }
-        _ = Box::from_raw(result);
+        _ = CString::from_raw(str);
     }
 }
 
 fn free_c_null_terminated_char_array(array: *mut *mut libc::c_char) {
+    if array.is_null() {
+        return;
+    }
     unsafe {
         // Iterate until we find a null value
         let mut i: usize = 0;
@@ -513,4 +308,8 @@ fn free_c_null_terminated_char_array(array: *mut *mut libc::c_char) {
         // deallocate the containing vector
         _ = Vec::from_raw_parts(array, i + 1, i + 1);
     }
+}
+fn from_c_string(str: *const libc::c_char) -> Result<String, Box<dyn error::Error>> {
+    let c_str = unsafe { CStr::from_ptr(str) };
+    Ok(c_str.to_str()?.to_string())
 }

--- a/cmd/soroban-rpc/lib/preflight/src/lib.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/lib.rs
@@ -104,7 +104,6 @@ pub extern "C" fn preflight_invoke_hf_op(
     source_account: *const libc::c_char, // AccountId XDR in base64
     ledger_info: CLedgerInfo,
 ) -> *mut CPreflightResult {
-    println!("gets to top preflight_invoke_hf_op");
     catch_preflight_panic(Box::new(move || {
         preflight_invoke_hf_op_or_maybe_panic(
             handle,

--- a/cmd/soroban-rpc/lib/preflight/src/lib.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/lib.rs
@@ -8,7 +8,7 @@ extern crate base64;
 extern crate libc;
 extern crate sha2;
 extern crate soroban_env_host;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use ledger_storage::LedgerStorage;
 use preflight::PreflightResult;
 use sha2::{Digest, Sha256};
@@ -125,7 +125,8 @@ fn preflight_invoke_hf_op_or_maybe_panic(
 ) -> Result<CPreflightResult> {
     let invoke_hf_op = InvokeHostFunctionOp::from_xdr_base64(from_c_string(invoke_hf_op)?)?;
     let source_account = AccountId::from_xdr_base64(from_c_string(source_account)?)?;
-    let ledger_storage = LedgerStorage::with_restore_tracking(handle, ledger_info.sequence_number)?;
+    let ledger_storage = LedgerStorage::with_restore_tracking(handle, ledger_info.sequence_number)
+        .context("cannot create LedgerStorage")?;
     let result = preflight::preflight_invoke_hf_op(
         ledger_storage,
         bucket_list_size,

--- a/cmd/soroban-rpc/lib/preflight/src/lib.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/lib.rs
@@ -289,19 +289,22 @@ fn free_c_null_terminated_char_array(array: *mut *mut libc::c_char) {
         return;
     }
     unsafe {
-        // Iterate until we find a null value
         let mut i: usize = 0;
         loop {
             let c_char_ptr = *array.add(i);
             if c_char_ptr.is_null() {
+                // Iterate until we find the ending null value
                 break;
             }
             // deallocate each string
             _ = CString::from_raw(c_char_ptr);
             i += 1;
         }
+        // convert the last (NULL) element's index to the vector's length
+        let len = i + 1;
         // deallocate the containing vector
-        _ = Vec::from_raw_parts(array, i + 1, i + 1);
+        // (for which vec_to_c_array() ensured the same length and capacity)
+        _ = Vec::from_raw_parts(array, len, len);
     }
 }
 fn from_c_string(str: *const libc::c_char) -> Result<String> {

--- a/cmd/soroban-rpc/lib/preflight/src/preflight.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/preflight.rs
@@ -1,0 +1,279 @@
+use fees;
+use ledger_storage::LedgerStorage;
+use soroban_env_host::auth::RecordedAuthPayload;
+use soroban_env_host::budget::Budget;
+use soroban_env_host::events::Events;
+use soroban_env_host::storage::Storage;
+use soroban_env_host::xdr::{
+    AccountId, ConfigSettingEntry, ConfigSettingId, DiagnosticEvent, InvokeHostFunctionOp,
+    LedgerFootprint, LedgerKey, OperationBody, ScVal, SorobanAddressCredentials,
+    SorobanAuthorizationEntry, SorobanCredentials, SorobanTransactionData, VecM,
+};
+use soroban_env_host::{DiagnosticLevel, Host, LedgerInfo};
+use std::convert::{TryFrom, TryInto};
+use std::error;
+use std::iter::FromIterator;
+use std::rc::Rc;
+
+pub(crate) struct RestorePreamble {
+    pub(crate) transaction_data: SorobanTransactionData,
+    pub(crate) min_fee: i64,
+}
+
+pub(crate) struct PreflightResult {
+    pub(crate) auth: Vec<SorobanAuthorizationEntry>,
+    pub(crate) result: Option<ScVal>,
+    pub(crate) transaction_data: SorobanTransactionData,
+    pub(crate) min_fee: i64,
+    pub(crate) events: Vec<DiagnosticEvent>,
+    pub(crate) cpu_instructions: u64,
+    pub(crate) memory_bytes: u64,
+    pub(crate) restore_preamble: Option<RestorePreamble>,
+}
+
+pub(crate) fn preflight_invoke_hf_op(
+    ledger_storage: LedgerStorage,
+    bucket_list_size: u64,
+    invoke_hf_op: InvokeHostFunctionOp,
+    source_account: AccountId,
+    ledger_info: LedgerInfo,
+) -> Result<PreflightResult, Box<dyn error::Error>> {
+    let ledger_storage_rc = Rc::new(ledger_storage);
+    let budget = get_budget_from_network_config_params(&ledger_storage_rc)?;
+    let storage = Storage::with_recording_footprint(ledger_storage_rc.clone());
+    let host = Host::with_storage_and_budget(storage, budget);
+
+    // We make an assumption here:
+    // - if a transaction doesn't include any soroban authorization entries the client either
+    // doesn't know the authorization entries, or there are none. In either case it is best to
+    // record the authorization entries and return them to the client.
+    // - if a transaction *does* include soroban authorization entries, then the client *already*
+    // knows the needed entries, so we should try them in enforcing mode so that we can validate
+    // them, and return the correct fees and footprint.
+    let needs_auth_recording = invoke_hf_op.auth.is_empty();
+    if needs_auth_recording {
+        host.switch_to_recording_auth()?;
+    } else {
+        host.set_authorization_entries(invoke_hf_op.auth.to_vec())?;
+    }
+
+    host.set_diagnostic_level(DiagnosticLevel::Debug)?;
+    host.set_source_account(source_account.clone())?;
+    host.set_ledger_info(ledger_info.clone())?;
+
+    // Run the preflight.
+    let result = host.invoke_function(invoke_hf_op.host_function.clone())?;
+    let auths: VecM<SorobanAuthorizationEntry> = if needs_auth_recording {
+        let payloads = host.get_recorded_auth_payloads()?;
+        VecM::try_from(
+            payloads
+                .iter()
+                .map(recorded_auth_payload_to_xdr)
+                .collect::<Vec<_>>(),
+        )?
+    } else {
+        invoke_hf_op.auth
+    };
+
+    let budget = host.budget_cloned();
+    // Recover, convert and return the storage footprint and other values to C.
+    let (storage, events) = host.try_finish()?;
+
+    let diagnostic_events = host_events_to_diagnostic_events(&events);
+    let (transaction_data, min_fee) = fees::compute_host_function_transaction_data_and_min_fee(
+        &InvokeHostFunctionOp {
+            host_function: invoke_hf_op.host_function,
+            auth: auths.clone(),
+        },
+        &ledger_storage_rc,
+        &storage,
+        &budget,
+        &diagnostic_events,
+        bucket_list_size,
+        ledger_info.sequence_number,
+    )?;
+
+    let entries = ledger_storage_rc.get_ledger_keys_requiring_restore();
+    let restore_preamble = if entries.len() > 0 {
+        let read_write_vec: Vec<LedgerKey> = Vec::from_iter(entries);
+        let restore_footprint = LedgerFootprint {
+            read_only: VecM::default(),
+            read_write: read_write_vec.try_into()?,
+        };
+        let (transaction_data, min_fee) =
+            fees::compute_restore_footprint_transaction_data_and_min_fee(
+                restore_footprint,
+                &ledger_storage_rc,
+                bucket_list_size,
+                ledger_info.sequence_number,
+            )?;
+        Some(RestorePreamble {
+            transaction_data,
+            min_fee,
+        })
+    } else {
+        None
+    };
+
+    Ok(PreflightResult {
+        auth: auths.to_vec(),
+        result: Some(result),
+        transaction_data: transaction_data,
+        min_fee,
+        events: diagnostic_events,
+        cpu_instructions: budget.get_cpu_insns_consumed()?,
+        memory_bytes: budget.get_mem_bytes_consumed()?,
+        restore_preamble: restore_preamble,
+    })
+}
+
+fn recorded_auth_payload_to_xdr(payload: &RecordedAuthPayload) -> SorobanAuthorizationEntry {
+    match (payload.address.clone(), payload.nonce) {
+        (Some(address), Some(nonce)) => SorobanAuthorizationEntry {
+            credentials: SorobanCredentials::Address(SorobanAddressCredentials {
+                address,
+                nonce,
+                // signature is left empty. This is where the client will put their signatures when
+                // submitting the transaction.
+                signature_expiration_ledger: 0,
+                signature: ScVal::Void,
+            }),
+            root_invocation: payload.invocation.clone(),
+        },
+        (None, None) => SorobanAuthorizationEntry {
+            credentials: SorobanCredentials::SourceAccount,
+            root_invocation: payload.invocation.clone(),
+        },
+        // the address and the nonce can't be present independently
+        (a,n) =>
+            panic!("recorded_auth_payload_to_xdr: address and nonce present independently (address: {:?}, nonce: {:?})", a, n),
+    }
+}
+
+fn host_events_to_diagnostic_events(events: &Events) -> Vec<DiagnosticEvent> {
+    let mut res: Vec<DiagnosticEvent> = Vec::new();
+    for e in &events.0 {
+        let diagnostic_event = DiagnosticEvent {
+            in_successful_contract_call: !e.failed_call,
+            event: e.event.clone(),
+        };
+        res.push(diagnostic_event);
+    }
+    res
+}
+
+fn get_budget_from_network_config_params(
+    ledger_storage: &LedgerStorage,
+) -> Result<Budget, Box<dyn error::Error>> {
+    let ConfigSettingEntry::ContractComputeV0(compute) =
+        ledger_storage.get_configuration_setting(ConfigSettingId::ContractComputeV0)?
+        else {
+            return Err(
+                "get_budget_from_network_config_params((): unexpected config setting entry for ComputeV0 key".into(),
+            );
+        };
+
+    let ConfigSettingEntry::ContractCostParamsCpuInstructions(cost_params_cpu) = ledger_storage
+        .get_configuration_setting(ConfigSettingId::ContractCostParamsCpuInstructions)?
+        else {
+            return Err(
+                "get_budget_from_network_config_params((): unexpected config setting entry for ComputeV0 key".into(),
+            );
+        };
+
+    let ConfigSettingEntry::ContractCostParamsMemoryBytes(cost_params_memory) =
+        ledger_storage.get_configuration_setting(ConfigSettingId::ContractCostParamsMemoryBytes)?
+        else {
+            return Err(
+                "get_budget_from_network_config_params((): unexpected config setting entry for ComputeV0 key".into(),
+            );
+        };
+
+    let budget = Budget::try_from_configs(
+        compute.tx_max_instructions as u64,
+        compute.tx_memory_limit as u64,
+        cost_params_cpu,
+        cost_params_memory,
+    )?;
+    Ok(budget)
+}
+
+pub(crate) fn preflight_footprint_expiration_op(
+    ledger_storage: &LedgerStorage,
+    bucket_list_size: u64,
+    op_body: OperationBody,
+    footprint: LedgerFootprint,
+    current_ledger_seq: u32,
+) -> Result<PreflightResult, Box<dyn error::Error>> {
+    match op_body {
+        OperationBody::BumpFootprintExpiration(op) => preflight_bump_footprint_expiration(
+            footprint,
+            op.ledgers_to_expire,
+            ledger_storage,
+            bucket_list_size,
+            current_ledger_seq,
+        ),
+        OperationBody::RestoreFootprint(_) => preflight_restore_footprint(
+            footprint,
+            ledger_storage,
+            bucket_list_size,
+            current_ledger_seq,
+        ),
+        op => Err(format!(
+            "preflight_footprint_expiration_op(): unsupported operation type {}",
+            op.name()
+        )
+        .into()),
+    }
+}
+
+fn preflight_bump_footprint_expiration(
+    footprint: LedgerFootprint,
+    ledgers_to_expire: u32,
+    ledger_storage: &LedgerStorage,
+    bucket_list_size: u64,
+    current_ledger_seq: u32,
+) -> Result<PreflightResult, Box<dyn error::Error>> {
+    let (transaction_data, min_fee) =
+        fees::compute_bump_footprint_exp_transaction_data_and_min_fee(
+            footprint,
+            ledgers_to_expire,
+            ledger_storage,
+            bucket_list_size,
+            current_ledger_seq,
+        )?;
+    Ok(PreflightResult {
+        auth: vec![],
+        result: None,
+        transaction_data,
+        min_fee,
+        events: vec![],
+        cpu_instructions: 0,
+        memory_bytes: 0,
+        restore_preamble: None,
+    })
+}
+
+fn preflight_restore_footprint(
+    footprint: LedgerFootprint,
+    ledger_storage: &LedgerStorage,
+    bucket_list_size: u64,
+    current_ledger_seq: u32,
+) -> Result<PreflightResult, Box<dyn error::Error>> {
+    let (transaction_data, min_fee) = fees::compute_restore_footprint_transaction_data_and_min_fee(
+        footprint,
+        ledger_storage,
+        bucket_list_size,
+        current_ledger_seq,
+    )?;
+    Ok(PreflightResult {
+        auth: vec![],
+        result: None,
+        transaction_data,
+        min_fee,
+        events: vec![],
+        cpu_instructions: 0,
+        memory_bytes: 0,
+        restore_preamble: None,
+    })
+}

--- a/cmd/soroban-rpc/lib/preflight/src/preflight.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/preflight.rs
@@ -118,12 +118,12 @@ pub(crate) fn preflight_invoke_hf_op(
     Ok(PreflightResult {
         auth: auths.to_vec(),
         result: Some(result),
-        transaction_data: transaction_data,
+        transaction_data,
         min_fee,
         events: diagnostic_events,
         cpu_instructions: budget.get_cpu_insns_consumed()?,
         memory_bytes: budget.get_mem_bytes_consumed()?,
-        restore_preamble: restore_preamble,
+        restore_preamble,
     })
 }
 

--- a/cmd/soroban-rpc/lib/preflight/src/preflight.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/preflight.rs
@@ -104,7 +104,9 @@ pub(crate) fn preflight_invoke_hf_op(
     .context("cannot compute resources and fees")?;
 
     let entries = ledger_storage_rc.get_ledger_keys_requiring_restore();
-    let restore_preamble = if entries.len() > 0 {
+    let restore_preamble = if entries.is_empty() {
+        None
+    } else {
         let read_write_vec: Vec<LedgerKey> = Vec::from_iter(entries);
         let restore_footprint = LedgerFootprint {
             read_only: VecM::default(),
@@ -122,8 +124,6 @@ pub(crate) fn preflight_invoke_hf_op(
             transaction_data,
             min_fee,
         })
-    } else {
-        None
     };
 
     Ok(PreflightResult {

--- a/cmd/soroban-rpc/lib/preflight/src/state_expiration.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/state_expiration.rs
@@ -40,7 +40,7 @@ impl<'a> TryInto<Box<dyn ExpirableLedgerEntry + 'a>> for &'a LedgerEntry {
             LedgerEntryData::ContractData(d) => Ok(Box::new(d)),
             LedgerEntryData::ContractCode(c) => Ok(Box::new(c)),
             _ => Err(format!(
-                "Incorrect ledger entry type ({}) in footprint",
+                "ledger entry type ({}) is not expirable",
                 self.data.name()
             )),
         }


### PR DESCRIPTION
* Split out FFI conversions from actual preflight computations. I added a new file `preflight.rs` which contains the actual preflight computations, separate from the `Go<->Rust` ffi interfacing (which is the only thing left in `lib.rs`).
* Use the [`anyhow`](https://docs.rs/anyhow/latest/anyhow/) crate to:
   * Make error handling more readable (`Result<R, Box<dyn Error>>` vs `Result<R>`)
   * Add context to errors ( Closes https://github.com/stellar/soroban-tools/issues/858).
* Some other minor changes, making the code more idiomatic/readable.
* Fix a couple of memory leaks in `free_preflight_result()`