### PR TITLE
Revert "soroban-rpc: Fix ledgerentry visibility bug"

### DIFF
--- a/cmd/soroban-rpc/internal/db/ledgerentry.go
+++ b/cmd/soroban-rpc/internal/db/ledgerentry.go
@@ -253,8 +253,7 @@ func (l *ledgerEntryReadTx) GetLedgerEntry(key xdr.LedgerKey, includeExpired boo
 			if err != nil {
 				return false, xdr.LedgerEntry{}, err
 			}
-			currentLedger := latestClosedLedger + 1
-			if expirationLedgerSeq < xdr.Uint32(currentLedger) {
+			if expirationLedgerSeq < xdr.Uint32(latestClosedLedger) {
 				return false, xdr.LedgerEntry{}, nil
 			}
 		}

--- a/cmd/soroban-rpc/internal/db/ledgerentry_test.go
+++ b/cmd/soroban-rpc/internal/db/ledgerentry_test.go
@@ -357,17 +357,14 @@ func TestGetLedgerEntryHidesExpiredContractDataEntries(t *testing.T) {
 	}{
 		{21, true},
 		{22, true},
-		{23, false},
+		{23, true},
 		{24, false},
+		{25, false},
 	} {
 		// ffwd to the ledger sequence
 		tx, err := NewReadWriter(db, 0, 15).NewTx(context.Background())
 		assert.NoError(t, err)
-		// Close the ledger N
 		assert.NoError(t, tx.Commit(c.ledgerSequence))
-
-		// Now, ledger N is our latestClosedLedger, so any preflights should act as
-		// though it is currently ledger N+1
 
 		// Try to read the entry back, and check it disappears when expected
 		present, _, obtainedLedgerSequence := getLedgerEntryAndLatestLedgerSequence(t, db, key)
@@ -407,17 +404,14 @@ func TestGetLedgerEntryHidesExpiredContractCodeEntries(t *testing.T) {
 	}{
 		{21, true},
 		{22, true},
-		{23, false},
+		{23, true},
 		{24, false},
+		{25, false},
 	} {
 		// ffwd to the ledger sequence
 		tx, err := NewReadWriter(db, 0, 15).NewTx(context.Background())
 		assert.NoError(t, err)
-		// Close the ledger N
 		assert.NoError(t, tx.Commit(c.ledgerSequence))
-
-		// Now, ledger N is our latestClosedLedger, so any preflights should act as
-		// though it is currently ledger N+1
 
 		// Try to read the entry back, and check it disappears when expected
 		present, _, obtainedLedgerSequence := getLedgerEntryAndLatestLedgerSequence(t, db, key)

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -750,7 +750,7 @@ func TestSimulateTransactionBumpAndRestoreFootprint(t *testing.T) {
 				break
 			}
 			assert.NoError(t, xdr.SafeUnmarshalBase64(getLedgerEntryResult.XDR, &entry))
-			t.Log("waiting for ledger entry to expire at ledger", entry.MustContractData().ExpirationLedgerSeq)
+			t.Log("waiting for ledger entry to expire at ledger", entry.MustContractData().ExpirationLedgerSeq+1)
 			time.Sleep(time.Second)
 		}
 		require.True(t, expired)


### PR DESCRIPTION
Reverts stellar/soroban-tools#871

Revert it until we figure out why the integration tests are failing.