### PR TITLE
soroban-rpc: expand getpreflight benchmarks

### DIFF
--- a/cmd/soroban-rpc/internal/preflight/preflight_test.go
+++ b/cmd/soroban-rpc/internal/preflight/preflight_test.go
@@ -276,6 +276,7 @@ func getPreflightParameters(t testing.TB, config benchmarkConfig) PreflightParam
 		err = tx.Commit(2)
 		require.NoError(t, err)
 		if config.useDB.restartDB {
+			// Restarting the DB resets the ledger entries write-through cache
 			dbInstance.Close()
 			dbInstance, err = db.OpenSQLiteDB(dbPath)
 			require.NoError(t, err)


### PR DESCRIPTION
Also, clean up the benchmark configuration and remove unrealistic reuse of DB read transactions between invocations