### PR TITLE
soroban-rpc: Add missing config settings in ledger entry cache on reads

### DIFF
--- a/cmd/soroban-rpc/internal/db/ledgerentry.go
+++ b/cmd/soroban-rpc/internal/db/ledgerentry.go
@@ -235,6 +235,8 @@ func (l *ledgerEntryReadTx) getBinaryLedgerEntry(key xdr.LedgerKey) (bool, strin
 		// (after which don't process past config setting updates)
 		if key.Type == xdr.LedgerEntryTypeConfigSetting {
 			l.db.ledgerEntryCacheMutex.Lock()
+			// Only udpate the cache if the entry is missing, otherwise
+			// we may end up overwriting the entry with an older version
 			if _, ok := l.db.ledgerEntryCache.entries[encodedKey]; !ok {
 				l.db.ledgerEntryCache.entries[encodedKey] = result
 			}

--- a/cmd/soroban-rpc/internal/db/transactionalcache.go
+++ b/cmd/soroban-rpc/internal/db/transactionalcache.go
@@ -9,12 +9,12 @@ func newTransactionalCache() transactionalCache {
 }
 
 func (c transactionalCache) newReadTx() transactionalCacheReadTx {
-	ret := make(transactionalCacheReadTx, len(c.entries))
+	entries := make(map[string]*string, len(c.entries))
 	for k, v := range c.entries {
 		localV := v
-		ret[k] = &localV
+		entries[k] = &localV
 	}
-	return ret
+	return transactionalCacheReadTx{entries: entries}
 }
 
 func (c transactionalCache) newWriteTx(estimatedWriteCount int) transactionalCacheWriteTx {
@@ -25,17 +25,19 @@ func (c transactionalCache) newWriteTx(estimatedWriteCount int) transactionalCac
 }
 
 // nil indicates not present in the underlying storage
-type transactionalCacheReadTx map[string]*string
+type transactionalCacheReadTx struct {
+	entries map[string]*string
+}
 
 // nil indicates not present in the underlying storage
 func (r transactionalCacheReadTx) get(key string) (*string, bool) {
-	val, ok := r[key]
+	val, ok := r.entries[key]
 	return val, ok
 }
 
 // nil indicates not present in the underlying storage
 func (r transactionalCacheReadTx) upsert(key string, value *string) {
-	r[key] = value
+	r.entries[key] = value
 }
 
 type transactionalCacheWriteTx struct {

--- a/cmd/soroban-rpc/internal/preflight/preflight_test.go
+++ b/cmd/soroban-rpc/internal/preflight/preflight_test.go
@@ -330,6 +330,7 @@ func TestGetPreflight(t *testing.T) {
 	params := getPreflightParameters(t, nil)
 	_, err := GetPreflight(context.Background(), params)
 	require.NoError(t, err)
+	params.LedgerEntryReadTx.Done()
 
 	// using a restarted db with caching and
 	getDB(t, true)
@@ -340,6 +341,8 @@ func TestGetPreflight(t *testing.T) {
 	params = getPreflightParameters(t, dbConfig)
 	_, err = GetPreflight(context.Background(), params)
 	require.NoError(t, err)
+	params.LedgerEntryReadTx.Done()
+	dbConfig.dbInstance.Close()
 }
 
 type benchmarkDBConfig struct {

--- a/cmd/soroban-rpc/internal/preflight/preflight_test.go
+++ b/cmd/soroban-rpc/internal/preflight/preflight_test.go
@@ -341,8 +341,8 @@ func TestGetPreflight(t *testing.T) {
 	params = getPreflightParameters(t, dbConfig)
 	_, err = GetPreflight(context.Background(), params)
 	require.NoError(t, err)
-	params.LedgerEntryReadTx.Done()
-	dbConfig.dbInstance.Close()
+	require.NoError(t, params.LedgerEntryReadTx.Done())
+	require.NoError(t, dbConfig.dbInstance.Close())
 }
 
 type benchmarkDBConfig struct {
@@ -369,10 +369,10 @@ func benchmark(b *testing.B, config benchmarkConfig) {
 		_, err := GetPreflight(context.Background(), params)
 		b.StopTimer()
 		require.NoError(b, err)
-		params.LedgerEntryReadTx.Done()
+		require.NoError(b, params.LedgerEntryReadTx.Done())
 	}
 	if dbConfig != nil {
-		dbConfig.dbInstance.Close()
+		require.NoError(b, dbConfig.dbInstance.Close())
 	}
 }
 


### PR DESCRIPTION
The current ledger-entry write-through cache is not very useful as it stands because it's only updated when we process updates in config settings.

Updates in config settings will be infrequent, this means once we restart soroban-rpc after a network reset, the cache will be empty.

To solve this, we also update the missing setting ledger entries on reads

before:

```
goos: darwin
goarch: arm64
pkg: github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/preflight
BenchmarkGetPreflight
BenchmarkGetPreflight/In-memory_storage
BenchmarkGetPreflight/In-memory_storage-12                  4950            238374 ns/op
BenchmarkGetPreflight/DB_storage
BenchmarkGetPreflight/DB_storage-12                         3723            305137 ns/op
BenchmarkGetPreflight/DB_storage,_restarting
BenchmarkGetPreflight/DB_storage,_restarting-12             2814            404981 ns/op
BenchmarkGetPreflight/DB_storage,_no_cache
BenchmarkGetPreflight/DB_storage,_no_cache-12               2200            529218 ns/op
PASS
```


after:

```
goos: darwin
goarch: arm64
pkg: github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/preflight
BenchmarkGetPreflight
BenchmarkGetPreflight/In-memory_storage
BenchmarkGetPreflight/In-memory_storage-12         	    4802	    239106 ns/op
BenchmarkGetPreflight/DB_storage
BenchmarkGetPreflight/DB_storage-12                	    3680	    304496 ns/op
BenchmarkGetPreflight/DB_storage,_restarting
BenchmarkGetPreflight/DB_storage,_restarting-12    	    3664	    304327 ns/op
BenchmarkGetPreflight/DB_storage,_no_cache
BenchmarkGetPreflight/DB_storage,_no_cache-12      	    2146	    527755 ns/op
PASS
```

