### PR TITLE
soroban-rpc: libpreflight: Remove base64 encoding between Go and Rust

### DIFF
--- a/cmd/soroban-rpc/lib/preflight.h
+++ b/cmd/soroban-rpc/lib/preflight.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-typedef struct CLedgerInfo {
+typedef struct ledger_info_t {
   uint32_t protocol_version;
   uint32_t sequence_number;
   uint64_t timestamp;
@@ -13,37 +13,47 @@ typedef struct CLedgerInfo {
   uint32_t min_persistent_entry_expiration;
   uint32_t max_entry_expiration;
   uint32_t auto_bump_ledgers;
-} CLedgerInfo;
+} ledger_info_t;
+
+typedef struct xdr_t {
+    unsigned char *xdr;
+    size_t        len;
+} xdr_t;
+
+typedef struct xdr_vector_t {
+    xdr_t  *array;
+    size_t len;
+} xdr_vector_t;
+
+typedef struct preflight_result_t {
+    char          *error; // Error string in case of error, otherwise null
+    xdr_vector_t  auth; // array of SorobanAuthorizationEntries
+    xdr_t         result; // XDR SCVal
+    xdr_t         transaction_data;
+    int64_t       min_fee; // Minimum recommended resource fee
+    xdr_vector_t  events; // array of XDR DiagnosticEvents
+    uint64_t      cpu_instructions;
+    uint64_t      memory_bytes;
+    xdr_t         pre_restore_transaction_data; // SorobanTransactionData XDR for a prerequired RestoreFootprint operation
+    int64_t       pre_restore_min_fee; // Minimum recommended resource fee for a prerequired RestoreFootprint operation
+} preflight_result_t;
+
+preflight_result_t *preflight_invoke_hf_op(uintptr_t handle, // Go Handle to forward to SnapshotSourceGet
+                                           uint64_t bucket_list_size, // Bucket list size of current ledger
+                                           const xdr_t invoke_hf_op, // InvokeHostFunctionOp XDR
+                                           const xdr_t source_account, // AccountId XDR
+                                           const ledger_info_t ledger_info);
+
+preflight_result_t *preflight_footprint_expiration_op(uintptr_t   handle, // Go Handle to forward to SnapshotSourceGet
+                                                      uint64_t bucket_list_size, // Bucket list size of current ledger
+                                                      const xdr_t op_body, // OperationBody XDR
+                                                      const xdr_t footprint, // LedgerFootprint XDR
+                                                      uint32_t    current_ledger_seq); // Current ledger sequence
 
 
-typedef struct CPreflightResult {
-    char *error; // Error string in case of error, otherwise null
-    char **auth; // NULL terminated array of XDR SorobanAuthorizationEntrys in base64
-    char *result; // XDR SCVal in base64
-    char *transaction_data; // SorobanTransactionData XDR in base64
-    int64_t min_fee; // Minimum recommended resource fee
-    char **events; // NULL terminated array of XDR DiagnosticEvents in base64
-    uint64_t cpu_instructions;
-    uint64_t memory_bytes;
-    char *pre_restore_transaction_data; // SorobanTransactionData XDR in base64 for a prerequired RestoreFootprint operation
-    int64_t pre_restore_min_fee; // Minimum recommended resource fee for a prerequired RestoreFootprint operation
-} CPreflightResult;
+// LedgerKey XDR to LedgerEntry XDR
+extern xdr_t SnapshotSourceGet(uintptr_t handle, xdr_t ledger_key, int include_expired);
 
-CPreflightResult *preflight_invoke_hf_op(uintptr_t handle, // Go Handle to forward to SnapshotSourceGet and SnapshotSourceHas
-                                         uint64_t bucket_list_size, // Bucket list size of current ledger
-                                         const char *invoke_hf_op, // InvokeHostFunctionOp XDR in base64
-                                         const char *source_account, // AccountId XDR in base64
-                                         const struct CLedgerInfo ledger_info);
+void free_preflight_result(preflight_result_t *result);
 
-CPreflightResult *preflight_footprint_expiration_op(uintptr_t handle, // Go Handle to forward to SnapshotSourceGet and SnapshotSourceHas
-                                                    uint64_t bucket_list_size, // Bucket list size of current ledger
-                                                    const char *op_body, // OperationBody XDR in base64
-                                                    const char *footprint, // LedgerFootprint XDR in base64
-                                                    uint32_t current_ledger_seq); // Current ledger sequence
-
-// LedgerKey XDR in base64 string to LedgerEntry XDR in base64 string
-extern char *SnapshotSourceGet(uintptr_t handle, char *ledger_key, int include_expired);
-
-void free_preflight_result(CPreflightResult *result);
-
-extern void FreeGoCString(char *str);
+extern void FreeGoXDR(xdr_t xdr);

--- a/cmd/soroban-rpc/lib/preflight/src/ledger_storage.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/ledger_storage.rs
@@ -1,4 +1,3 @@
-use base64::{engine::general_purpose::STANDARD as base64, DecodeError, Engine as _};
 use soroban_env_host::storage::SnapshotSource;
 use soroban_env_host::xdr::ContractDataDurability::Persistent;
 use soroban_env_host::xdr::{
@@ -10,20 +9,21 @@ use state_expiration::{restore_ledger_entry, ExpirableLedgerEntry};
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::convert::TryInto;
-use std::ffi::{CStr, CString, NulError};
+use std::ffi::NulError;
 use std::rc::Rc;
 use std::str::Utf8Error;
+use {from_c_xdr, CXDR};
 
 // Functions imported from Golang
 extern "C" {
     // Free Strings returned from Go functions
-    fn FreeGoCString(str: *const libc::c_char);
+    fn FreeGoXDR(xdr: CXDR);
     // LedgerKey XDR in base64 string to LedgerEntry XDR in base64 string
     fn SnapshotSourceGet(
         handle: libc::uintptr_t,
-        ledger_key: *const libc::c_char,
+        ledger_key: CXDR,
         include_expired: libc::c_int,
-    ) -> *const libc::c_char;
+    ) -> CXDR;
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -34,8 +34,6 @@ pub(crate) enum Error {
     Xdr(#[from] XdrError),
     #[error("nul error: {0}")]
     NulError(#[from] NulError),
-    #[error("decode error: {0}")]
-    DecodeError(#[from] DecodeError),
     #[error("utf8 error: {0}")]
     Utf8Error(#[from] Utf8Error),
     #[error("unexpected config ledger entry for setting_id {setting_id}")]
@@ -131,38 +129,26 @@ impl LedgerStorage {
         Ok(ledger_storage)
     }
 
-    fn get_xdr_base64(&self, key: &LedgerKey, include_expired: bool) -> Result<String, Error> {
-        let key_xdr = key.to_xdr_base64()?;
-        let key_cstr = CString::new(key_xdr)?;
-        let res = unsafe {
-            SnapshotSourceGet(
-                self.golang_handle,
-                key_cstr.as_ptr(),
-                include_expired.into(),
-            )
-        };
-        if res.is_null() {
-            return Err(Error::NotFound);
-        }
-        let unsafe_cstr = unsafe { CStr::from_ptr(res) };
-        // Make a safe copy of the string before freeing it
-        // Note: If we wanted more performance we should create an unsafe version of get_xdr_base64() which
-        //       returned a view of the C buffer as follows:
-        // return Ok((res, unsafe_cstr.to_bytes())); // we would later need to call FreeGoCString(res)
-        let str = String::from_utf8_lossy(unsafe_cstr.to_bytes()).to_string();
-        unsafe { FreeGoCString(res) };
-        Ok(str)
-    }
-
     pub(crate) fn get(&self, key: &LedgerKey, include_expired: bool) -> Result<LedgerEntry, Error> {
-        let base64_str = self.get_xdr_base64(key, include_expired)?;
-        let entry = LedgerEntry::from_xdr_base64(base64_str)?;
+        let xdr = self.get_xdr(key, include_expired)?;
+        let entry = LedgerEntry::from_xdr(xdr)?;
         Ok(entry)
     }
 
     pub(crate) fn get_xdr(&self, key: &LedgerKey, include_expired: bool) -> Result<Vec<u8>, Error> {
-        let base64_str = self.get_xdr_base64(key, include_expired)?;
-        Ok(base64.decode(base64_str)?)
+        let mut key_xdr = key.to_xdr()?;
+        let key_c_xdr = CXDR {
+            xdr: key_xdr.as_mut_ptr(),
+            len: key_xdr.len(),
+        };
+        let res =
+            unsafe { SnapshotSourceGet(self.golang_handle, key_c_xdr, include_expired.into()) };
+        if res.xdr.is_null() {
+            return Err(Error::NotFound);
+        }
+        let v = from_c_xdr(res.clone());
+        unsafe { FreeGoXDR(res) };
+        Ok(v)
     }
 
     pub(crate) fn get_configuration_setting(


### PR DESCRIPTION
Addresses most of #367 

It doesn't yet address  this though, which is hard since, in order to check expirations, we sometimes need to unmarshallthe entry anyways. I will revisit this when once the new expiration changes land.

> The ledger entry is obtained from the DB in binary-serialized XDR


Before:

```
goos: darwin
goarch: arm64
pkg: github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/preflight
BenchmarkGetPreflight
BenchmarkGetPreflight/In-memory_storage
BenchmarkGetPreflight/In-memory_storage-12         	    4802	    239106 ns/op
BenchmarkGetPreflight/DB_storage
BenchmarkGetPreflight/DB_storage-12                	    3680	    304496 ns/op
BenchmarkGetPreflight/DB_storage,_restarting
BenchmarkGetPreflight/DB_storage,_restarting-12    	    3664	    304327 ns/op
BenchmarkGetPreflight/DB_storage,_no_cache
BenchmarkGetPreflight/DB_storage,_no_cache-12      	    2146	    527755 ns/op
PASS
```


After:

```
goos: darwin
goarch: arm64
pkg: github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/preflight
BenchmarkGetPreflight
BenchmarkGetPreflight/In-memory_storage
BenchmarkGetPreflight/In-memory_storage-12         	    6972	    168184 ns/op
BenchmarkGetPreflight/DB_storage
BenchmarkGetPreflight/DB_storage-12                	    4916	    229217 ns/op
BenchmarkGetPreflight/DB_storage,_restarting
BenchmarkGetPreflight/DB_storage,_restarting-12    	    4800	    229573 ns/op
BenchmarkGetPreflight/DB_storage,_no_cache
BenchmarkGetPreflight/DB_storage,_no_cache-12      	    2594	    431494 ns/op
PASS
```
