### PR TITLE
feat(CLI): add dotenv so directories can now set CLI args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,6 +742,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2443,6 +2449,7 @@ dependencies = [
  "crate-git-revision 0.0.4",
  "csv",
  "dirs",
+ "dotenvy",
  "ed25519-dalek",
  "ethnum",
  "heck",

--- a/cmd/crates/soroban-test/tests/it/dotenv.rs
+++ b/cmd/crates/soroban-test/tests/it/dotenv.rs
@@ -1,0 +1,73 @@
+use soroban_test::TestEnv;
+
+use crate::util::HELLO_WORLD;
+
+const SOROBAN_CONTRACT_ID: &str = "SOROBAN_CONTRACT_ID=1";
+
+fn deploy(e: &TestEnv, id: &str) {
+    e.new_assert_cmd("contract")
+        .arg("deploy")
+        .arg("--wasm")
+        .arg(HELLO_WORLD.path())
+        .arg("--id")
+        .arg(id)
+        .assert()
+        .success();
+}
+
+fn write_env_file(e: &TestEnv, contents: &str) {
+    let env_file = e.dir().join(".env");
+    std::fs::write(&env_file, contents).unwrap();
+    assert_eq!(contents, std::fs::read_to_string(env_file).unwrap());
+}
+
+#[test]
+fn can_read_file() {
+    TestEnv::with_default(|e| {
+        deploy(e, "1");
+        write_env_file(e, SOROBAN_CONTRACT_ID);
+        e.new_assert_cmd("contract")
+            .arg("invoke")
+            .arg("--")
+            .arg("hello")
+            .arg("--world=world")
+            .assert()
+            .stdout("[\"Hello\",\"world\"]\n")
+            .success();
+    });
+}
+
+#[test]
+fn current_env_not_overwritten() {
+    TestEnv::with_default(|e| {
+        deploy(e, "1");
+        write_env_file(e, SOROBAN_CONTRACT_ID);
+
+        e.new_assert_cmd("contract")
+            .env("SOROBAN_CONTRACT_ID", "2")
+            .arg("invoke")
+            .arg("--")
+            .arg("hello")
+            .arg("--world=world")
+            .assert()
+            .stderr("error: parsing contract spec: contract spec not found\n");
+    });
+}
+
+#[test]
+fn cli_args_have_priority() {
+    TestEnv::with_default(|e| {
+        deploy(e, "2");
+        write_env_file(e, SOROBAN_CONTRACT_ID);
+        e.new_assert_cmd("contract")
+            .env("SOROBAN_CONTRACT_ID", "3")
+            .arg("invoke")
+            .arg("--id")
+            .arg("2")
+            .arg("--")
+            .arg("hello")
+            .arg("--world=world")
+            .assert()
+            .stdout("[\"Hello\",\"world\"]\n");
+    });
+}

--- a/cmd/crates/soroban-test/tests/it/main.rs
+++ b/cmd/crates/soroban-test/tests/it/main.rs
@@ -2,6 +2,7 @@ mod arg_parsing;
 mod config;
 
 mod custom_types;
+mod dotenv;
 mod invoke_sandbox;
 mod plugin;
 mod util;

--- a/cmd/soroban-cli/Cargo.toml
+++ b/cmd/soroban-cli/Cargo.toml
@@ -91,6 +91,7 @@ tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 cargo_metadata = "0.15.4"
 pathdiff = "0.2.1"
+dotenvy = "0.15.7"
 # For hyper-tls
 [target.'cfg(unix)'.dependencies]
 openssl = { version = "0.10.55", features = ["vendored"] }

--- a/cmd/soroban-cli/src/bin/main.rs
+++ b/cmd/soroban-cli/src/bin/main.rs
@@ -1,10 +1,11 @@
 use clap::{CommandFactory, Parser};
-use tracing_subscriber::{fmt, EnvFilter};
-
+use dotenvy::dotenv;
 use soroban_cli::{commands::plugin, Root};
+use tracing_subscriber::{fmt, EnvFilter};
 
 #[tokio::main]
 async fn main() {
+    let _ = dotenv().unwrap_or_default();
     let mut root = Root::try_parse().unwrap_or_else(|e| {
         use clap::error::ErrorKind;
         match e.kind() {


### PR DESCRIPTION
### What

Before parsing with clap load in variables found in a .env file. This will allow directories to set, 
- `SOROBAN_NETWORK`
- `SOROBAN_RPC_URL`
- `SOROBAN_NETWORK_PASSPHRASE`
- `SOROBAN_LEDGER_FILE`
- `SOROBAN_EVENTS_FILE`
- `SOROBAN_ACCOUNT`
- `SOROBAN_CONTRACT_ID`
- `SOROBAN_FEE`

### Why

To allow tests to use `.env` to setup the CLI calls. Went with `dotenvy` since `dotenv` is unmaintained.

### Known limitations

[TODO or N/A]
