### PR TITLE
soroban-rpc: GetPreflight benchmark tweaks

### DIFF
--- a/cmd/soroban-rpc/internal/preflight/preflight_test.go
+++ b/cmd/soroban-rpc/internal/preflight/preflight_test.go
@@ -362,6 +362,8 @@ func benchmark(b *testing.B, config benchmarkConfig) {
 			disableCache: config.useDB.disableCache,
 		}
 	}
+
+	b.ResetTimer()
 	b.StopTimer()
 	for i := 0; i < b.N; i++ {
 		params := getPreflightParameters(b, dbConfig)


### PR DESCRIPTION
* ~Add walllock benchmark metric~
* Exclude db startup from the benchmark
