### PR TITLE
soroban-rpc: Fix caching of GetLatestLedgerSequence

### DIFF
--- a/cmd/soroban-rpc/internal/db/ledgerentry.go
+++ b/cmd/soroban-rpc/internal/db/ledgerentry.go
@@ -190,7 +190,7 @@ func (l *ledgerEntryReadTx) GetLatestLedgerSequence() (uint32, error) {
 		return l.cachedLatestLedgerSeq, nil
 	}
 	latestLedgerSeq, err := getLatestLedgerSequence(context.Background(), l.tx)
-	if err != nil {
+	if err == nil {
 		l.cachedLatestLedgerSeq = latestLedgerSeq
 	}
 	return latestLedgerSeq, err


### PR DESCRIPTION
🤦 

This, by itself, doesn't really improve the preflight times though:

before:
```
goos: darwin
goarch: arm64
pkg: github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/preflight
BenchmarkGetPreflight
BenchmarkGetPreflight/In-memory_storage
BenchmarkGetPreflight/In-memory_storage-12         	    7117	    166782 ns/op
BenchmarkGetPreflight/DB_storage
BenchmarkGetPreflight/DB_storage-12                	    4789	    227984 ns/op
BenchmarkGetPreflight/DB_storage,_restarting
BenchmarkGetPreflight/DB_storage,_restarting-12    	    5048	    227909 ns/op
BenchmarkGetPreflight/DB_storage,_no_cache
BenchmarkGetPreflight/DB_storage,_no_cache-12      	    2773	    425975 ns/op
PASS
```

after:
```
goos: darwin
goarch: arm64
pkg: github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/preflight
BenchmarkGetPreflight
BenchmarkGetPreflight/In-memory_storage
BenchmarkGetPreflight/In-memory_storage-12         	    7110	    168305 ns/op
BenchmarkGetPreflight/DB_storage
BenchmarkGetPreflight/DB_storage-12                	    5136	    226321 ns/op
BenchmarkGetPreflight/DB_storage,_restarting
BenchmarkGetPreflight/DB_storage,_restarting-12    	    4845	    228496 ns/op
BenchmarkGetPreflight/DB_storage,_no_cache
BenchmarkGetPreflight/DB_storage,_no_cache-12      	    2647	    432240 ns/op
PASS
```