### PR TITLE
soroban-rpc: further DB querying performance tweaks

### DIFF
--- a/cmd/soroban-rpc/internal/db/ledgerentry.go
+++ b/cmd/soroban-rpc/internal/db/ledgerentry.go
@@ -344,7 +344,7 @@ func (r ledgerEntryReader) GetLatestLedgerSequence(ctx context.Context) (uint32,
 	return getLatestLedgerSequence(ctx, r.db, &r.db.cache)
 }
 
-// NewCachedTx() catches all accessed ledger entries and selct statements. If many ledger entries are accessed, it will grow without bounds.
+// NewCachedTx() caches all accessed ledger entries and select statements. If many ledger entries are accessed, it will grow without bounds.
 func (r ledgerEntryReader) NewCachedTx(ctx context.Context) (LedgerEntryReadTx, error) {
 	txSession := r.db.Clone()
 	// We need to copy the cached ledger entries locally when we start the transaction

--- a/cmd/soroban-rpc/internal/db/ledgerentry_test.go
+++ b/cmd/soroban-rpc/internal/db/ledgerentry_test.go
@@ -846,6 +846,8 @@ func NewTestDB(tb testing.TB) *DB {
 	})
 	return &DB{
 		SessionInterface: db,
-		ledgerEntryCache: newTransactionalCache(),
+		cache: dbCache{
+			ledgerEntries: newTransactionalCache(),
+		},
 	}
 }


### PR DESCRIPTION
1. Cache statement preparation of `GetLedgerEntries()`
2. Make caching of the `GetLatestLedger()` write-through. This should allow us to only query the latestLedger a maximum of once per run of soroban-rpc.

before:

```
goos: darwin
goarch: arm64

pkg: github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/db
BenchmarkGetLedgerEntry
BenchmarkGetLedgerEntry/With_cache,_include_expired
BenchmarkGetLedgerEntry/With_cache,_include_expired-12         	   19622	     61162 ns/op
BenchmarkGetLedgerEntry/With_cache,_exclude_expired
BenchmarkGetLedgerEntry/With_cache,_exclude_expired-12         	   16340	     72964 ns/op
BenchmarkGetLedgerEntry/Without_cache,_exclude_expired
BenchmarkGetLedgerEntry/Without_cache,_exclude_expired-12      	    4460	    270240 ns/op

pkg: github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/preflight
BenchmarkGetPreflight
BenchmarkGetPreflight/In-memory_storage
BenchmarkGetPreflight/In-memory_storage-12         	    7078	    167447 ns/op
BenchmarkGetPreflight/DB_storage
BenchmarkGetPreflight/DB_storage-12                	    4978	    233438 ns/op
BenchmarkGetPreflight/DB_storage,_restarting
BenchmarkGetPreflight/DB_storage,_restarting-12    	    5108	    236347 ns/op
BenchmarkGetPreflight/DB_storage,_no_cache
BenchmarkGetPreflight/DB_storage,_no_cache-12      	    2596	    466076 ns/op
```

after:

```
goos: darwin
goarch: arm64

pkg: github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/db
BenchmarkGetLedgerEntry
BenchmarkGetLedgerEntry/With_cache,_include_expired
BenchmarkGetLedgerEntry/With_cache,_include_expired-12         	   19719	     60855 ns/op
BenchmarkGetLedgerEntry/With_cache,_exclude_expired
BenchmarkGetLedgerEntry/With_cache,_exclude_expired-12         	   19993	     60114 ns/op
BenchmarkGetLedgerEntry/Without_cache,_exclude_expired
BenchmarkGetLedgerEntry/Without_cache,_exclude_expired-12      	    4884	    241781 ns/op

pkg: github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/preflight
BenchmarkGetPreflight
BenchmarkGetPreflight/In-memory_storage
BenchmarkGetPreflight/In-memory_storage-12         	    6369	    168082 ns/op
BenchmarkGetPreflight/DB_storage
BenchmarkGetPreflight/DB_storage-12                	    5392	    219820 ns/op
BenchmarkGetPreflight/DB_storage,_restarting
BenchmarkGetPreflight/DB_storage,_restarting-12    	    5395	    220875 ns/op
BenchmarkGetPreflight/DB_storage,_no_cache
BenchmarkGetPreflight/DB_storage,_no_cache-12      	    2829	    425707 ns/op
```