### PR TITLE
fix: datetime api deprecation error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,9 +335,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+checksum = "f56b4c72906975ca04becb8a30e102dfecddd0c06181e3e95ddc444be28881f8"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -346,7 +346,7 @@ dependencies = [
  "serde",
  "time 0.1.45",
  "wasm-bindgen",
- "winapi",
+ "windows-targets",
 ]
 
 [[package]]

--- a/cmd/soroban-cli/Cargo.toml
+++ b/cmd/soroban-cli/Cargo.toml
@@ -74,7 +74,7 @@ hyper-tls = "0.5"
 http = "0.2.9"
 regex = "1.6.0"
 wasm-opt = { version = "0.114.0", optional = true }
-chrono = "0.4.23"
+chrono = "0.4.27"
 rpassword = "7.2.0"
 dirs = "4.0.0"
 toml = "0.5.9"

--- a/cmd/soroban-cli/src/commands/config/events_file.rs
+++ b/cmd/soroban-cli/src/commands/config/events_file.rs
@@ -123,7 +123,7 @@ impl Args {
                 }
             })?;
 
-            let dt: DateTime<Utc> = DateTime::from_utc(ndt, Utc);
+            let dt: DateTime<Utc> = DateTime::from_naive_utc_and_offset(ndt, Utc);
 
             let cereal_event = rpc::Event {
                 event_type: match contract_event.type_ {


### PR DESCRIPTION
### What

This updates to the newest version of `chrono` and updates the deprecated API.


### Why

CI seems to ignore the lockfile or update it? Perhaps `--frozen` should be added somewhere.

This causes the chrono crate to update and then cause a deprecation error. 

see #906 & #867 

### Known limitations

Still need to update CI to not update Cargo.lock