### PR TITLE
soroban-rpc: preflight: Increase instruction leeway to 20%

### DIFF
--- a/cmd/soroban-rpc/lib/preflight/src/fees.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/fees.rs
@@ -142,11 +142,11 @@ fn calculate_host_function_soroban_resources(
         })
         .sum();
 
-    // Add a 15% leeway with a minimum of 50k instructions
+    // Add a 20% leeway with a minimum of 50k instructions
     let budget_instructions = budget
         .get_cpu_insns_consumed()
         .context("cannot get instructions consumed")?;
-    let instructions = max(budget_instructions + 50000, budget_instructions * 115 / 100);
+    let instructions = max(budget_instructions + 50000, budget_instructions * 120 / 100);
     Ok(SorobanResources {
         footprint: ledger_footprint,
         instructions: u32::try_from(instructions)?,


### PR DESCRIPTION
### What

Increase instruction leeway to 20% from 15%

### Why

A Horizon test was failing due to not enough instructions being provisioned https://github.com/stellar/go/pull/5023#issuecomment-1699419628

### Known limitations

The problem appeared after updating Core/rs-soroban-env at https://github.com/stellar/soroban-tools/pull/884 but I have no idea of why the preflight provisioning stopped being sufficient nor whether 20% will be good enough.
