### PR TITLE
soroban-cli: set the exit code to 1 in case of an error

### DIFF
--- a/cmd/crates/soroban-test/tests/it/custom_types.rs
+++ b/cmd/crates/soroban-test/tests/it/custom_types.rs
@@ -40,11 +40,11 @@ fn generate_help() {
 }
 
 #[test]
-fn multi_arg() {
+fn multi_arg_failure() {
     invoke(&TestEnv::default(), "multi_args")
         .arg("--b")
         .assert()
-        .success()
+        .failure()
         .stderr("error: Missing argument a\n");
 }
 
@@ -258,22 +258,22 @@ fn i32() {
 }
 
 #[test]
-fn handle_arg_larger_than_i32() {
+fn handle_arg_larger_than_i32_failure() {
     invoke(&TestEnv::default(), "i32_")
         .arg("--i32_")
         .arg(u32::MAX.to_string())
         .assert()
-        .success()
+        .failure()
         .stderr(predicates::str::contains("value is not parseable"));
 }
 
 #[test]
-fn handle_arg_larger_than_i64() {
+fn handle_arg_larger_than_i64_failure() {
     invoke(&TestEnv::default(), "i64_")
         .arg("--i64_")
         .arg(u64::MAX.to_string())
         .assert()
-        .success()
+        .failure()
         .stderr(predicates::str::contains("value is not parseable"));
 }
 

--- a/cmd/soroban-cli/src/bin/main.rs
+++ b/cmd/soroban-cli/src/bin/main.rs
@@ -46,5 +46,6 @@ async fn main() {
 
     if let Err(e) = root.run().await {
         eprintln!("error: {e}");
+        std::process::exit(1);
     }
 }


### PR DESCRIPTION
### What

 set the exit code to 1 in case of an error

### Why

see https://github.com/stellar/soroban-tools/issues/920

### Known limitations

n/a