### PR TITLE
soroban-rpc: evict ledger entries

### DIFF
--- a/cmd/crates/soroban-test/tests/fixtures/test-wasms/hello_world/src/lib.rs
+++ b/cmd/crates/soroban-test/tests/fixtures/test-wasms/hello_world/src/lib.rs
@@ -30,7 +30,7 @@ impl Contract {
         addr
     }
 
-    pub fn inc(env: Env) {
+    pub fn inc_persistent(env: Env) {
         let mut count: u32 = env.storage().persistent().get(&COUNTER).unwrap_or(0); // Panic if the value of COUNTER is not u32.
         log!(&env, "count: {}", count);
 
@@ -39,6 +39,17 @@ impl Contract {
 
         // Save the count.
         env.storage().persistent().set(&COUNTER, &count);
+    }
+
+    pub fn inc_tmp(env: Env) {
+        let mut count: u32 = env.storage().temporary().get(&COUNTER).unwrap_or(0); // Panic if the value of COUNTER is not u32.
+        log!(&env, "count: {}", count);
+
+        // Increment the count.
+        count += 1;
+
+        // Save the count.
+        env.storage().temporary().set(&COUNTER, &count);
     }
 
     #[allow(unused_variables)]

--- a/cmd/soroban-rpc/internal/ingest/service.go
+++ b/cmd/soroban-rpc/internal/ingest/service.go
@@ -292,6 +292,10 @@ func (s *Service) evictLedgerEntries(tx db.WriteTx, ledgerCloseMeta xdr.LedgerCl
 	keysToEvict := make([]xdr.LedgerKey, len(ledgerCloseMeta.V2.EvictedTemporaryLedgerKeys)+len(ledgerCloseMeta.V2.EvictedPersistentLedgerEntries))
 	l := copy(keysToEvict, ledgerCloseMeta.V2.EvictedTemporaryLedgerKeys)
 	for i, entry := range ledgerCloseMeta.V2.EvictedPersistentLedgerEntries {
+		// TODO: we probably shouldn't be deleting evicted persistent ledger entries cold turkey.
+		//       Otherwise preflighting will fail for restoreFootprint.
+		//       For restoreFootPrint we need to confirm that the entry existed and its size (for the resource estimation).
+		//       so maybe we should store that.
 		key, err := entry.LedgerKey()
 		if err != nil {
 			return err

--- a/cmd/soroban-rpc/internal/ingest/service.go
+++ b/cmd/soroban-rpc/internal/ingest/service.go
@@ -294,7 +294,7 @@ func (s *Service) evictLedgerEntries(tx db.WriteTx, ledgerCloseMeta xdr.LedgerCl
 	for i, entry := range ledgerCloseMeta.V2.EvictedPersistentLedgerEntries {
 		// TODO: we probably shouldn't be deleting evicted persistent ledger entries cold turkey.
 		//       Otherwise preflighting will fail for restoreFootprint.
-		//       For restoreFootPrint we need to confirm that the entry existed and its size (for the resource estimation).
+		//       For the restoreFootPrint preflighting we need to confirm that the entry existed and its size (for the resource estimation).
 		//       so maybe we should store that.
 		key, err := entry.LedgerKey()
 		if err != nil {

--- a/cmd/soroban-rpc/internal/test/ingestion_test.go
+++ b/cmd/soroban-rpc/internal/test/ingestion_test.go
@@ -1,0 +1,150 @@
+package test
+
+import (
+	"context"
+	"crypto/sha256"
+	"testing"
+	"time"
+
+	"github.com/creachadair/jrpc2"
+	"github.com/creachadair/jrpc2/jhttp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/txnbuild"
+	"github.com/stellar/go/xdr"
+
+	"github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/methods"
+)
+
+func TestEvictTemporaryLedgerEntries(t *testing.T) {
+	test := NewTest(t)
+
+	ch := jhttp.NewChannel(test.sorobanRPCURL(), nil)
+	client := jrpc2.NewClient(ch, nil)
+
+	sourceAccount := keypair.Root(StandaloneNetworkPassphrase)
+	address := sourceAccount.Address()
+	account := txnbuild.NewSimpleAccount(address, 0)
+
+	helloWorldContract := getHelloWorldContract(t)
+
+	params := preflightTransactionParams(t, client, txnbuild.TransactionParams{
+		SourceAccount:        &account,
+		IncrementSequenceNum: true,
+		Operations: []txnbuild.Operation{
+			createInstallContractCodeOperation(account.AccountID, helloWorldContract),
+		},
+		BaseFee: txnbuild.MinBaseFee,
+		Preconditions: txnbuild.Preconditions{
+			TimeBounds: txnbuild.NewInfiniteTimeout(),
+		},
+	})
+	tx, err := txnbuild.NewTransaction(params)
+	assert.NoError(t, err)
+	sendSuccessfulTransaction(t, client, sourceAccount, tx)
+
+	params = preflightTransactionParams(t, client, txnbuild.TransactionParams{
+		SourceAccount:        &account,
+		IncrementSequenceNum: true,
+		Operations: []txnbuild.Operation{
+			createCreateContractOperation(t, address, helloWorldContract, StandaloneNetworkPassphrase),
+		},
+		BaseFee: txnbuild.MinBaseFee,
+		Preconditions: txnbuild.Preconditions{
+			TimeBounds: txnbuild.NewInfiniteTimeout(),
+		},
+	})
+	tx, err = txnbuild.NewTransaction(params)
+	assert.NoError(t, err)
+	sendSuccessfulTransaction(t, client, sourceAccount, tx)
+
+	contractID := getContractID(t, address, testSalt, StandaloneNetworkPassphrase)
+	invokeIncTemporaryEntryParams := txnbuild.TransactionParams{
+		SourceAccount:        &account,
+		IncrementSequenceNum: true,
+		Operations: []txnbuild.Operation{
+			createInvokeHostOperation(
+				address,
+				contractID,
+				"inc_tmp",
+			),
+		},
+		BaseFee: txnbuild.MinBaseFee,
+		Preconditions: txnbuild.Preconditions{
+			TimeBounds: txnbuild.NewInfiniteTimeout(),
+		},
+	}
+	params = preflightTransactionParams(t, client, invokeIncTemporaryEntryParams)
+	tx, err = txnbuild.NewTransaction(params)
+	assert.NoError(t, err)
+	sendSuccessfulTransaction(t, client, sourceAccount, tx)
+
+	contractIDHash := xdr.Hash(contractID)
+	counterSym := xdr.ScSymbol("COUNTER")
+	key := xdr.LedgerKey{
+		Type: xdr.LedgerEntryTypeContractData,
+		ContractData: &xdr.LedgerKeyContractData{
+			Contract: xdr.ScAddress{
+				Type:       xdr.ScAddressTypeScAddressTypeContract,
+				ContractId: &contractIDHash,
+			},
+			Key: xdr.ScVal{
+				Type: xdr.ScValTypeScvSymbol,
+				Sym:  &counterSym,
+			},
+			Durability: xdr.ContractDataDurabilityTemporary,
+		},
+	}
+
+	// make sure the ledger entry exists and so does the expiration entry counterpart
+
+	keyB64, err := xdr.MarshalBase64(key)
+	require.NoError(t, err)
+
+	getLedgerEntryRequest := methods.GetLedgerEntryRequest{
+		Key: keyB64,
+	}
+	var getLedgerEntryResult methods.GetLedgerEntryResponse
+	err = client.CallResult(context.Background(), "getLedgerEntry", getLedgerEntryRequest, &getLedgerEntryResult)
+	require.NoError(t, err)
+
+	binKey, err := key.MarshalBinary()
+	assert.NoError(t, err)
+
+	expirationKey := xdr.LedgerKey{
+		Type: xdr.LedgerEntryTypeExpiration,
+		Expiration: &xdr.LedgerKeyExpiration{
+			KeyHash: sha256.Sum256(binKey),
+		},
+	}
+
+	keyB64, err = xdr.MarshalBase64(expirationKey)
+	require.NoError(t, err)
+	getExpirationLedgerEntryRequest := methods.GetLedgerEntryRequest{
+		Key: keyB64,
+	}
+
+	err = client.CallResult(context.Background(), "getLedgerEntry", getExpirationLedgerEntryRequest, &getLedgerEntryResult)
+	assert.NoError(t, err)
+
+	// Wait until the entry gets evicted
+	evicted := false
+	for i := 0; i < 5000; i++ {
+		err = client.CallResult(context.Background(), "getLedgerEntry", getLedgerEntryRequest, &getLedgerEntryResult)
+		if err != nil {
+			evicted = true
+			t.Logf("ledger entry evicted")
+			break
+		}
+		t.Log("waiting for ledger entry to get evicted")
+		time.Sleep(time.Second)
+	}
+
+	require.True(t, evicted)
+
+	// Make sure that the expiration ledger entry was also evicted
+	err = client.CallResult(context.Background(), "getLedgerEntry", getExpirationLedgerEntryRequest, &getLedgerEntryResult)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
### What

Evict ledger entries when Core signals so through txmeta

### Why

Fixes #914 

### Known limitations

The eviction test I added doesn't succeed after more than 10 minutes. Either there is something wrong in Core or the eviction takes too long to be testeable. I won't merge until that has been figured out.
