### PR TITLE
feat: try invoking CLI from go test

### DIFF
--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -126,9 +126,10 @@ jobs:
 
       - name: Build soroban contract fixtures
         run: |
-          rustup update
-          rustup target add wasm32-unknown-unknown
-          make build-test-wasms
+         rustup update
+         rustup target add wasm32-unknown-unknown
+         make build_rust
+         make build-test-wasms
 
       - name: Install Captive Core
         run: |

--- a/cmd/crates/soroban-test/tests/it/invoke_sandbox.rs
+++ b/cmd/crates/soroban-test/tests/it/invoke_sandbox.rs
@@ -444,17 +444,3 @@ async fn fetch() {
     cmd.run().await.unwrap();
     assert!(f.exists());
 }
-
-#[ignore]
-#[tokio::test]
-async fn from_go() {
-    TestEnv::with_default(|e| {
-        e.new_assert_cmd("contract")
-            .args(["install", "--wasm", HELLO_WORLD.path().to_str().unwrap()])
-            .assert()
-            .success()
-            .stdout(predicates::str::starts_with(
-                "c221ca07e2b9e4fc6a5f566dcd82551af5575c1de0057a8da7abab648c3ab849",
-            ));
-    });
-}

--- a/cmd/crates/soroban-test/tests/it/invoke_sandbox.rs
+++ b/cmd/crates/soroban-test/tests/it/invoke_sandbox.rs
@@ -444,3 +444,17 @@ async fn fetch() {
     cmd.run().await.unwrap();
     assert!(f.exists());
 }
+
+#[ignore]
+#[tokio::test]
+async fn from_go() {
+    TestEnv::with_default(|e| {
+        e.new_assert_cmd("contract")
+            .args(["install", "--wasm", HELLO_WORLD.path().to_str().unwrap()])
+            .assert()
+            .success()
+            .stdout(predicates::str::starts_with(
+                "c221ca07e2b9e4fc6a5f566dcd82551af5575c1de0057a8da7abab648c3ab849",
+            ));
+    });
+}

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -867,7 +867,7 @@ func TestInstallContractWithCLI(t *testing.T) {
 	require.NoError(t, err)
 	res, err := cmd.Output()
 	require.NoError(t, err)
-	require.Equal(t, string(res), "c221ca07e2b9e4fc6a5f566dcd82551af5575c1de0057a8da7abab648c3ab849\n")
+	require.Equal(t, string(res), "a3bb4d5479e7167f8221775f5ff6a3924c77ddd446dae0e7267b4ed74695bd6d\n")
 
 }
 

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -849,7 +849,7 @@ func TestCLI(t *testing.T) {
 	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
 		SourceAccount: &txnbuild.SimpleAccount{
 			AccountID: keypair.Root(StandaloneNetworkPassphrase).Address(),
-			Sequence:  0,
+			Sequence:  1,
 		},
 		IncrementSequenceNum: false,
 		Operations: []txnbuild.Operation{&txnbuild.CreateAccount{
@@ -869,11 +869,10 @@ func TestCLI(t *testing.T) {
 		panic(lookErr)
 	}
 
-	args := []string{"cargo", "test", "--package", "soroban-test", "--test", "it", "--", "invoke_sandbox::from_go", "--exact", "--nocapture", "--ignored"}
-
+	// args := []string{"cargo", "test", "--package", "soroban-test", "--test", "it", "--", "invoke_sandbox::from_go", "--exact", "--nocapture", "--ignored"}
+	args := []string{"cargo", "run", "--", "--vv", "contract", "install", "--wasm ../../../../target/wasm32-unknown-unknown/test-wasms/test_hello_world.wasm"}
 	env := os.Environ()
-	// env = append(env, "SOROBAN_RPC_URL=http://localhost:8000", "NETWORK_PASSPHRASE=Standalone Network ; February 2017")
-	env = append(env, "SOROBAN_RPC_URL=http://localhost:8000", "SOROBAN_NETWORK_PASSPHRASE=Standalone Network ; February 2017")
+	env = append(env, "SOROBAN_RPC_URL=http://localhost:8000/", "SOROBAN_NETWORK_PASSPHRASE=Standalone Network ; February 2017")
 
 	execErr := syscall.Exec(binary, args, env)
 	if execErr != nil {

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -865,9 +865,7 @@ func TestCLI(t *testing.T) {
 	require.NoError(t, err)
 	sendSuccessfulTransaction(t, client, sourceAccount, tx)
 	binary, lookErr := exec.LookPath("cargo")
-	if lookErr != nil {
-		panic(lookErr)
-	}
+	require.NoError(t, lookErr)
 
 	// args := []string{"cargo", "test", "--package", "soroban-test", "--test", "it", "--", "invoke_sandbox::from_go", "--exact", "--nocapture", "--ignored"}
 	args := []string{"cargo", "run", "--", "--vv", "contract", "install", "--wasm", "../../../../target/wasm32-unknown-unknown/test-wasms/test_hello_world.wasm"}

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"path"
 	"runtime"
-	"syscall"
 	"testing"
 	"time"
 
@@ -839,7 +838,7 @@ func TestSimulateTransactionBumpAndRestoreFootprint(t *testing.T) {
 	sendSuccessfulTransaction(t, client, sourceAccount, tx)
 }
 
-func TestCLI(t *testing.T) {
+func InstallContractWithCLI(t *testing.T) {
 	test := NewTest(t)
 	ch := jhttp.NewChannel(test.sorobanRPCURL(), nil)
 	client := jrpc2.NewClient(ch, nil)
@@ -864,18 +863,11 @@ func TestCLI(t *testing.T) {
 	})
 	require.NoError(t, err)
 	sendSuccessfulTransaction(t, client, sourceAccount, tx)
-	binary, lookErr := exec.LookPath("cargo")
-	require.NoError(t, lookErr)
-
-	// args := []string{"cargo", "test", "--package", "soroban-test", "--test", "it", "--", "invoke_sandbox::from_go", "--exact", "--nocapture", "--ignored"}
-	args := []string{"cargo", "run", "--", "--vv", "contract", "install", "--wasm", "../../../../target/wasm32-unknown-unknown/test-wasms/test_hello_world.wasm"}
-	env := os.Environ()
-	env = append(env, "SOROBAN_RPC_URL=http://localhost:8000/", "SOROBAN_NETWORK_PASSPHRASE=Standalone Network ; February 2017")
-
-	execErr := syscall.Exec(binary, args, env)
-	if execErr != nil {
-		panic(execErr)
-	}
+	cmd := exec.Command("cargo", "run", "--", "--vv", "contract", "install", "--wasm", "../../../../target/wasm32-unknown-unknown/test-wasms/test_hello_world.wasm", "--rpc-url", "http://localhost:8000/", "--network-passphrase", "Standalone Network ; February 2017")
+	require.NoError(t, err)
+	res, err := cmd.Output()
+	require.NoError(t, err)
+	require.Equal(t, string(res), "c221ca07e2b9e4fc6a5f566dcd82551af5575c1de0057a8da7abab648c3ab849\n")
 
 }
 

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -867,7 +867,9 @@ func TestInstallContractWithCLI(t *testing.T) {
 	require.NoError(t, err)
 	res, err := cmd.Output()
 	require.NoError(t, err)
-	require.Equal(t, string(res), "a3bb4d5479e7167f8221775f5ff6a3924c77ddd446dae0e7267b4ed74695bd6d\n")
+	wasm := getHelloWorldContract(t)
+	contractHash := xdr.Hash(sha256.Sum256(wasm))
+	require.Contains(t, string(res), contractHash.HexString())
 
 }
 

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -862,10 +862,9 @@ func TestCLI(t *testing.T) {
 			TimeBounds: txnbuild.NewInfiniteTimeout(),
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	sendSuccessfulTransaction(t, client, sourceAccount, tx)
 	binary, lookErr := exec.LookPath("cargo")
-	time.Sleep(40 * time.Second)
 	if lookErr != nil {
 		panic(lookErr)
 	}

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -870,7 +870,7 @@ func TestCLI(t *testing.T) {
 	}
 
 	// args := []string{"cargo", "test", "--package", "soroban-test", "--test", "it", "--", "invoke_sandbox::from_go", "--exact", "--nocapture", "--ignored"}
-	args := []string{"cargo", "run", "--", "--vv", "contract", "install", "--wasm ../../../../target/wasm32-unknown-unknown/test-wasms/test_hello_world.wasm"}
+	args := []string{"cargo", "run", "--", "--vv", "contract", "install", "--wasm", "../../../../target/wasm32-unknown-unknown/test-wasms/test_hello_world.wasm"}
 	env := os.Environ()
 	env = append(env, "SOROBAN_RPC_URL=http://localhost:8000/", "SOROBAN_NETWORK_PASSPHRASE=Standalone Network ; February 2017")
 

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -836,3 +836,42 @@ func TestSimulateTransactionBumpAndRestoreFootprint(t *testing.T) {
 	assert.NoError(t, err)
 	sendSuccessfulTransaction(t, client, sourceAccount, tx)
 }
+
+func TestCLI(t *testing.T) {
+	test := NewTest(t)
+	ch := jhttp.NewChannel(test.sorobanRPCURL(), nil)
+	client := jrpc2.NewClient(ch, nil)
+
+	sourceAccount := keypair.Root(StandaloneNetworkPassphrase)
+
+	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
+		SourceAccount: &txnbuild.SimpleAccount{
+			AccountID: keypair.Root(StandaloneNetworkPassphrase).Address(),
+			Sequence:  0,
+		},
+		IncrementSequenceNum: false,
+		Operations: []txnbuild.Operation{&txnbuild.CreateAccount{
+			Destination: "GDIY6AQQ75WMD4W46EYB7O6UYMHOCGQHLAQGQTKHDX4J2DYQCHVCR4W4",
+			Amount:      "100000",
+		}},
+		BaseFee: txnbuild.MinBaseFee,
+		Memo:    nil,
+		Preconditions: txnbuild.Preconditions{
+			TimeBounds: txnbuild.NewInfiniteTimeout(),
+		},
+	})
+	assert.NoError(t, err)
+	sendSuccessfulTransaction(t, client, sourceAccount, tx)
+	p, err := os.StartProcess("cargo", []string{"run", "--", "config", "identity", "address", "--hd-path", "1"}, nil)
+	assert.NoError(t, err)
+	res, err := p.Wait()
+	assert.NoError(t, err)
+	println(res.String())
+	// time.Sleep(5 * time.Hour)
+}
+
+// FundAccount(t, client, sourceAccount, "GDIY6AQQ75WMD4W46EYB7O6UYMHOCGQHLAQGQTKHDX4J2DYQCHVCR4W4")
+// soroban config identity address --hd-path 1
+// FundAccount(t, client, sourceAccount, "GCKZUJVUNEFGD4HLFBUNVYM2QY2P5WQQZMGRA3DDL4HYVT5MW5KG3ODV")
+// soroban config identity address --hd-path 2
+// FundAccount(t, client, sourceAccount, "GCTS3CUJXL5M7B2JA6KTFV75PI4QFF4IV4RNO3SDZJRWXGZ36FUEBRC7")

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -838,7 +838,7 @@ func TestSimulateTransactionBumpAndRestoreFootprint(t *testing.T) {
 	sendSuccessfulTransaction(t, client, sourceAccount, tx)
 }
 
-func InstallContractWithCLI(t *testing.T) {
+func TestInstallContractWithCLI(t *testing.T) {
 	test := NewTest(t)
 	ch := jhttp.NewChannel(test.sorobanRPCURL(), nil)
 	client := jrpc2.NewClient(ch, nil)

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -870,11 +870,4 @@ func TestInstallContractWithCLI(t *testing.T) {
 	wasm := getHelloWorldContract(t)
 	contractHash := xdr.Hash(sha256.Sum256(wasm))
 	require.Contains(t, string(res), contractHash.HexString())
-
 }
-
-// FundAccount(t, client, sourceAccount, "GDIY6AQQ75WMD4W46EYB7O6UYMHOCGQHLAQGQTKHDX4J2DYQCHVCR4W4")
-// soroban config identity address --hd-path 1
-// FundAccount(t, client, sourceAccount, "GCKZUJVUNEFGD4HLFBUNVYM2QY2P5WQQZMGRA3DDL4HYVT5MW5KG3ODV")
-// soroban config identity address --hd-path 2
-// FundAccount(t, client, sourceAccount, "GCTS3CUJXL5M7B2JA6KTFV75PI4QFF4IV4RNO3SDZJRWXGZ36FUEBRC7")


### PR DESCRIPTION
### What

Invoke the rust CLI from a go integration test

### Why

This will allow testing the CLI against the same RPC server in the repo and not rely on quickstart.

### Known limitations

[TODO or N/A]
