### PR TITLE
soroban-cli: wrap token fails with valid inputs in sandbox mode

### DIFF
--- a/cmd/soroban-cli/src/commands/lab/token/wrap.rs
+++ b/cmd/soroban-cli/src/commands/lab/token/wrap.rs
@@ -94,7 +94,6 @@ impl Cmd {
         }))?;
 
         let contract_id = vec_to_hash(&res)?;
-
         state.update(&h);
         self.config.set_state(&state)?;
         Ok(stellar_strkey::Contract(contract_id.0).to_string())
@@ -136,9 +135,9 @@ impl Cmd {
 ///
 /// Might return an error
 pub fn vec_to_hash(res: &ScVal) -> Result<Hash, XdrError> {
-    if let ScVal::Bytes(res_hash) = &res {
+    if let ScVal::Address(ScAddress::Contract(res_contract)) = &res {
         let mut hash_bytes: [u8; 32] = [0; 32];
-        for (i, b) in res_hash.iter().enumerate() {
+        for (i, b) in res_contract.0.iter().enumerate() {
             hash_bytes[i] = *b;
         }
         Ok(Hash(hash_bytes))


### PR DESCRIPTION
<!-- Please answer these questions before submitting your issue. Thanks! -->

### What version are you using?

9615897821492671f951169f8f442d69cafb3d81

```console
❯ soroban version
soroban 0.9.4 (v0.9.5-70-g9615897821492671f951169f8f442d69cafb3d81)
soroban-env 0.0.17 (eb5a9ba053a7b64a8eff605db625525378f7bea0)
soroban-env interface version 85899345977
stellar-xdr 0.0.17 (39904e09941046dab61e6e35fc89e31bf2dea1cd)
xdr next (65afa63b7f52c898143ebbe9541ef91fcf290ade)
```

### What did you do?

```console
❯ soroban lab token wrap --asset ABC:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF
```

### What did you expect to see?

I expect the Stellar Asset contract to be deployed resulting in a contract address being outputted.

For example:

```
CBMLAIHYS74DMIS5PXB5SH3KL2N3TRHU5IEYNLDINFPNX5Y3ERMWLANJ
```

### What did you see instead?

```
error: xdr processing error: xdr value invalid
```

### Further details

The same command works with the RPC, so this issue appears to be isolated to the sandbox variation.

For example:

```console
❯ soroban config network add --rpc-url http://localhost:8000/soroban/rpc --network-passphrase 'Standalone Network ; February 2017' local
❯ soroban config identity add --secret-key me
❯ soroban lab token wrap --network local --source me --asset ABC:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF
CBMLAIHYS74DMIS5PXB5SH3KL2N3TRHU5IEYNLDINFPNX5Y3ERMWLANJ
```