### PR TITLE
soroban-rpc: Fix integration tests

### DIFF
--- a/cmd/soroban-rpc/internal/test/get_ledger_entries_test.go
+++ b/cmd/soroban-rpc/internal/test/get_ledger_entries_test.go
@@ -83,11 +83,12 @@ func TestGetLedgerEntriesSucceeds(t *testing.T) {
 	kp := keypair.Root(StandaloneNetworkPassphrase)
 	account := txnbuild.NewSimpleAccount(kp.Address(), 0)
 
+	contractBinary := getHelloWorldContract(t)
 	params := preflightTransactionParams(t, client, txnbuild.TransactionParams{
 		SourceAccount:        &account,
 		IncrementSequenceNum: true,
 		Operations: []txnbuild.Operation{
-			createInstallContractCodeOperation(account.AccountID, testContract),
+			createInstallContractCodeOperation(account.AccountID, contractBinary),
 		},
 		BaseFee: txnbuild.MinBaseFee,
 		Preconditions: txnbuild.Preconditions{
@@ -110,7 +111,7 @@ func TestGetLedgerEntriesSucceeds(t *testing.T) {
 	txStatusResponse := getTransaction(t, client, sendTxResponse.Hash)
 	require.Equal(t, methods.TransactionStatusSuccess, txStatusResponse.Status)
 
-	contractHash := sha256.Sum256(testContract)
+	contractHash := sha256.Sum256(contractBinary)
 	contractKeyB64, err := xdr.MarshalBase64(xdr.LedgerKey{
 		Type: xdr.LedgerEntryTypeContractCode,
 		ContractCode: &xdr.LedgerKeyContractCode{
@@ -153,6 +154,6 @@ func TestGetLedgerEntriesSucceeds(t *testing.T) {
 
 	var firstEntry xdr.LedgerEntryData
 	require.NoError(t, xdr.SafeUnmarshalBase64(result.Entries[0].XDR, &firstEntry))
-	require.Equal(t, testContract, firstEntry.MustContractCode().Code)
+	require.Equal(t, contractBinary, firstEntry.MustContractCode().Code)
 	require.Equal(t, contractKeyB64, result.Entries[0].Key)
 }

--- a/cmd/soroban-rpc/internal/test/get_ledger_entry_test.go
+++ b/cmd/soroban-rpc/internal/test/get_ledger_entry_test.go
@@ -75,11 +75,12 @@ func TestGetLedgerEntrySucceeds(t *testing.T) {
 	kp := keypair.Root(StandaloneNetworkPassphrase)
 	account := txnbuild.NewSimpleAccount(kp.Address(), 0)
 
+	contractBinary := getHelloWorldContract(t)
 	params := preflightTransactionParams(t, client, txnbuild.TransactionParams{
 		SourceAccount:        &account,
 		IncrementSequenceNum: true,
 		Operations: []txnbuild.Operation{
-			createInstallContractCodeOperation(account.AccountID, testContract),
+			createInstallContractCodeOperation(account.AccountID, contractBinary),
 		},
 		BaseFee: txnbuild.MinBaseFee,
 		Preconditions: txnbuild.Preconditions{
@@ -91,7 +92,7 @@ func TestGetLedgerEntrySucceeds(t *testing.T) {
 
 	sendSuccessfulTransaction(t, client, kp, tx)
 
-	contractHash := sha256.Sum256(testContract)
+	contractHash := sha256.Sum256(contractBinary)
 	keyB64, err := xdr.MarshalBase64(xdr.LedgerKey{
 		Type: xdr.LedgerEntryTypeContractCode,
 		ContractCode: &xdr.LedgerKeyContractCode{
@@ -110,5 +111,5 @@ func TestGetLedgerEntrySucceeds(t *testing.T) {
 	assert.GreaterOrEqual(t, result.LatestLedger, result.LastModifiedLedger)
 	var entry xdr.LedgerEntryData
 	assert.NoError(t, xdr.SafeUnmarshalBase64(result.XDR, &entry))
-	assert.Equal(t, testContract, entry.MustContractCode().Code)
+	assert.Equal(t, contractBinary, entry.MustContractCode().Code)
 }

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -232,9 +232,9 @@ func TestSimulateTransactionSucceeds(t *testing.T) {
 					},
 				},
 			},
-			Instructions: 79653,
+			Instructions: 4961700,
 			ReadBytes:    48,
-			WriteBytes:   64,
+			WriteBytes:   5468,
 		},
 		RefundableFee: 20056,
 	}


### PR DESCRIPTION
### What

The first commit fixes failing integration tests caused by a change in the [host](https://github.com/stellar/rs-soroban-env/pull/1053/files). Now, the contract upload operation will validate that the wasm is actually valid. This change in behavior broke our integration tests because in some of our tests we upload contracts with a junk binary payload.

The second commit fixes TestSimulateTransactionSucceeds by updating the fee related fields in `expectedTransactionData`.  I'm not sure if this is the appropriate fix or if this is a sign that we need to update the preflight lib to be consistent with core.


### Known limitations

[N/A]
