### PR TITLE
soroban-rpc: fix datarace in bufferedResponseWriter.WriteOut

### DIFF
--- a/cmd/soroban-rpc/internal/network/requestdurationlimiter.go
+++ b/cmd/soroban-rpc/internal/network/requestdurationlimiter.go
@@ -110,23 +110,10 @@ func (w *bufferedResponseWriter) WriteOut(ctx context.Context, rw http.ResponseW
 	if w.statusCode != 0 {
 		rw.WriteHeader(w.statusCode)
 	}
-	// chunkSize defines the subset of the output buffer that we're going to attempt to write to the stream.
-	// we choose the typical ethernet MTU size here, to align with the expected transport layer characteristics.
-	const chunkSize = 1500
-	// iterate on the output buffer
-	for startChunkIdx := 0; startChunkIdx < len(w.buffer) && ctx.Err() == nil; {
-		// slice the output buffer into chunks.
-		chunkBuf := w.buffer[startChunkIdx:]
-		if len(chunkBuf) > chunkSize {
-			chunkBuf = chunkBuf[:chunkSize]
-		}
-		// write the chunk to the stream
-		n, err := rw.Write(chunkBuf)
-		// if we weren't able to write the chunk due to an error, abort writing.
-		if err != nil {
-			break
-		}
-		startChunkIdx += n
+
+	if ctx.Err() == nil {
+		// the following return size/error won't help us much at this point. The request is already finalized.
+		rw.Write(w.buffer) //nolint:errcheck
 	}
 }
 


### PR DESCRIPTION
### What

Fix data race #959 .

### Why

When implementing `bufferedResponseWriter.WriteOut`, I attempted to implement the writing to the output stream asynchronously, so that in case of context expiration the writing to the channel would be suspended at once.

Unfortuntally, it led to conflict with go http server library : When the `bufferedResponseWriter.WriteOut` could not complete writing to the stream in time, the method would return. However, the writing operation was still going on it's own pace.
then, the http server was attempting to write to the stream, creating a data race.

The solution is to write to the stream in smaller chunks, and continuously check the ctx.Err in order to examine when it expires.

### Known limitations

n/a
