### PR TITLE
[Draft] Make the `restorePreamble` a pointer so that `omitempty` takes effect

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 # Both cases should fallback to default of getting the version from git tag.
 ifeq ($(strip $(REPOSITORY_VERSION)),)
 	override REPOSITORY_VERSION = "$(shell git describe --tags --always --abbrev=0 --match='v[0-9]*.[0-9]*.[0-9]*' 2> /dev/null | sed 's/^.//')"
-endif  
+endif
 REPOSITORY_BRANCH := "$(shell git rev-parse --abbrev-ref HEAD)"
 BUILD_TIMESTAMP ?= $(shell date '+%Y-%m-%dT%H:%M:%S')
 GOLDFLAGS :=	-X 'github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/config.Version=${REPOSITORY_VERSION}' \
@@ -62,12 +62,12 @@ build-libpreflight: Cargo.lock
 	cd cmd/soroban-rpc/lib/preflight && cargo build --target $(CARGO_BUILD_TARGET) --profile release-with-panic-unwind
 
 build-test-wasms: Cargo.lock
-	cargo build --package 'test_*' --profile test-wasms --target wasm32-unknown-unknown
+	cargo build --package 'test_*' --profile test-wasms --target wasm32-unknown-unknown --jobs 4
 
 build-test: build-test-wasms install_rust
 
 test: build-test
-	cargo test 
+	cargo test
 
 e2e-test:
 	cargo test --test it -- --ignored
@@ -88,7 +88,7 @@ clean:
 publish:
 	cargo workspaces publish --all --force '*' --from-git --yes
 
-# the build-soroban-rpc build target is an optimized build target used by 
+# the build-soroban-rpc build target is an optimized build target used by
 # https://github.com/stellar/pipelines/stellar-horizon/Jenkinsfile-soroban-rpc-package-builder
 # as part of the package building.
 build-soroban-rpc: build-libpreflight
@@ -101,7 +101,7 @@ lint:
 	golangci-lint run ./...
 
 typescript-bindings-fixtures: build-test-wasms
-	cargo run -- contract bindings typescript \
+	cargo run --jobs 4 -- contract bindings typescript \
 					--wasm ./target/wasm32-unknown-unknown/test-wasms/test_custom_types.wasm \
 					--contract-id CBYMYMSDF6FBDNCFJCRC7KMO4REYFPOH2U4N7FXI3GJO6YXNCQ43CDSK \
 					--network futurenet \

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 # Both cases should fallback to default of getting the version from git tag.
 ifeq ($(strip $(REPOSITORY_VERSION)),)
 	override REPOSITORY_VERSION = "$(shell git describe --tags --always --abbrev=0 --match='v[0-9]*.[0-9]*.[0-9]*' 2> /dev/null | sed 's/^.//')"
-endif
+endif  
 REPOSITORY_BRANCH := "$(shell git rev-parse --abbrev-ref HEAD)"
 BUILD_TIMESTAMP ?= $(shell date '+%Y-%m-%dT%H:%M:%S')
 GOLDFLAGS :=	-X 'github.com/stellar/soroban-tools/cmd/soroban-rpc/internal/config.Version=${REPOSITORY_VERSION}' \
@@ -62,12 +62,12 @@ build-libpreflight: Cargo.lock
 	cd cmd/soroban-rpc/lib/preflight && cargo build --target $(CARGO_BUILD_TARGET) --profile release-with-panic-unwind
 
 build-test-wasms: Cargo.lock
-	cargo build --package 'test_*' --profile test-wasms --target wasm32-unknown-unknown --jobs 4
+	cargo build --package 'test_*' --profile test-wasms --target wasm32-unknown-unknown
 
 build-test: build-test-wasms install_rust
 
 test: build-test
-	cargo test
+	cargo test 
 
 e2e-test:
 	cargo test --test it -- --ignored
@@ -88,7 +88,7 @@ clean:
 publish:
 	cargo workspaces publish --all --force '*' --from-git --yes
 
-# the build-soroban-rpc build target is an optimized build target used by
+# the build-soroban-rpc build target is an optimized build target used by 
 # https://github.com/stellar/pipelines/stellar-horizon/Jenkinsfile-soroban-rpc-package-builder
 # as part of the package building.
 build-soroban-rpc: build-libpreflight
@@ -101,7 +101,7 @@ lint:
 	golangci-lint run ./...
 
 typescript-bindings-fixtures: build-test-wasms
-	cargo run --jobs 4 -- contract bindings typescript \
+	cargo run -- contract bindings typescript \
 					--wasm ./target/wasm32-unknown-unknown/test-wasms/test_custom_types.wasm \
 					--contract-id CBYMYMSDF6FBDNCFJCRC7KMO4REYFPOH2U4N7FXI3GJO6YXNCQ43CDSK \
 					--network futurenet \

--- a/cmd/soroban-rpc/internal/methods/simulate_transaction.go
+++ b/cmd/soroban-rpc/internal/methods/simulate_transaction.go
@@ -42,7 +42,7 @@ type SimulateTransactionResponse struct {
 	Events          []string                     `json:"events,omitempty"`          // DiagnosticEvent XDR in base64
 	Results         []SimulateHostFunctionResult `json:"results,omitempty"`         // an array of the individual host function call results
 	Cost            SimulateTransactionCost      `json:"cost,omitempty"`            // the effective cpu and memory cost of the invoked transaction execution.
-	RestorePreamble RestorePreamble              `json:"restorePreamble,omitempty"` // If present, it indicates that a prior RestoreFootprint is required
+	RestorePreamble *RestorePreamble             `json:"restorePreamble,omitempty"` // If present, it indicates that a prior RestoreFootprint is required
 	LatestLedger    int64                        `json:"latestLedger,string"`
 }
 
@@ -136,9 +136,9 @@ func NewSimulateTransactionHandler(logger *log.Entry, ledgerEntryReader db.Ledge
 				Auth: base64EncodeSlice(result.Auth),
 			})
 		}
-		restorePreable := RestorePreamble{}
+		var restorePreamble *RestorePreamble = nil
 		if len(result.PreRestoreTransactionData) != 0 {
-			restorePreable = RestorePreamble{
+			restorePreamble = &RestorePreamble{
 				TransactionData: base64.StdEncoding.EncodeToString(result.PreRestoreTransactionData),
 				MinResourceFee:  result.PreRestoreMinFee,
 			}
@@ -155,7 +155,7 @@ func NewSimulateTransactionHandler(logger *log.Entry, ledgerEntryReader db.Ledge
 				MemoryBytes:     result.MemoryBytes,
 			},
 			LatestLedger:    int64(latestLedger),
-			RestorePreamble: restorePreable,
+			RestorePreamble: restorePreamble,
 		}
 	})
 }

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -184,7 +184,7 @@ func preflightTransactionParamsLocally(t *testing.T, params txnbuild.Transaction
 func preflightTransactionParams(t *testing.T, client *jrpc2.Client, params txnbuild.TransactionParams) txnbuild.TransactionParams {
 	response := simulateTransactionFromTxParams(t, client, params)
 	// The preamble should be zero except for the special restore case
-	assert.Zero(t, response.RestorePreamble)
+	assert.Nil(t, response.RestorePreamble)
 	return preflightTransactionParamsLocally(t, params, response)
 }
 
@@ -858,6 +858,7 @@ func TestSimulateTransactionBumpAndRestoreFootprint(t *testing.T) {
 	waitForExpiration()
 
 	simulationResult := simulateTransactionFromTxParams(t, client, invokeIncPresistentEntryParams)
+	require.NotNil(t, simulationResult.RestorePreamble)
 	assert.NotZero(t, simulationResult.RestorePreamble)
 
 	params = preflightTransactionParamsLocally(t,


### PR DESCRIPTION
### What
This drops the `restorePreamble` field from the `simulateTransaction` response when there is nothing in it.

### Why
See [this failing action](https://github.com/stellar/soroban-tools/actions/runs/6179126968/job/16773545732) and [details on Slack](https://stellarfoundation.slack.com/archives/C02B04RMK/p1694653063065409), with the relevant part included here:

```
time="2023-09-14T00:54:48.445Z" level=debug msg="finished JSONRPC request result" duration=3.273792ms json_req=146 pid=6111 req=146 result="{\"transactionData\":\"AAAAAAAAAAIAAAAGAAAAAa/6eoLeofDK5ksPljSZ7t/rAj/XR18e40fCB9LBugstAAAAFAAAAAEAAAAHqA0LEZLq3WL+N3rBQLTWuPqdV3Vv6XIAGeBJaz1wMdsAAAAAABg1gAAAAxwAAAAAAAAAAAAAAAk=\",\"minResourceFee\":\"27889\",\"events\":[\"AAAAAQAAAAAAAAAAAAAAAgAAAAAAAAADAAAADwAAAAdmbl9jYWxsAAAAAA0AAAAgr/p6gt6h8MrmSw+WNJnu3+sCP9dHXx7jR8IH0sG6Cy0AAAAPAAAABWhlbGxvAAAAAAAADwAAAAVBbG9oYQAAAA==\",\"AAAAAQAAAAAAAAABr/p6gt6h8MrmSw+WNJnu3+sCP9dHXx7jR8IH0sG6Cy0AAAACAAAAAAAAAAIAAAAPAAAACWZuX3JldHVybgAAAAAAAA8AAAAFaGVsbG8AAAAAAAAQAAAAAQAAAAIAAAAPAAAABUhlbGxvAAAAAAAADwAAAAVBbG9oYQAAAA==\"],\"results\":[{\"auth\":[],\"xdr\":\"AAAAEAAAAAEAAAACAAAADwAAAAVIZWxsbwAAAAAAAA8AAAAFQWxvaGEAAAA=\"}],\"cost\":{\"cpuInsns\":\"1322134\",\"memBytes\":\"1207047\"},\"restorePreamble\":{\"transactionData\":\"\",\"minResourceFee\":\"0\"},\"latestLedger\":\"2634\"}"
```

Notice the inclusion of `restorePreamble` with no meaningful data:

```json
{
    "transactionData": "<omitted for brevity>",
    "minResourceFee": "27889",
    "events": [
      "<omitted for brevity>",
      "<omitted for brevity>"
    ],
    "results": [
      {
        "auth": [],
        "xdr": "AAAAEAAAAAEAAAACAAAADwAAAAVIZWxsbwAAAAAAAA8AAAAFQWxvaGEAAAA="
      }
    ],
    "cost": {
      "cpuInsns": "1322134",
      "memBytes": "1207047"
    },
    "restorePreamble": {
      "transactionData": "",
      "minResourceFee": "0"
    },
    "latestLedger": "2634"
  }
```

There are a few reasons why this PR adds better behavior:
 - it makes the restoration case easier to detect (i.e. just presence of `restorePreamble`, not its members)
 - it makes response payloads smaller (marginally, but still)

It looks like this was expected by some (see https://github.com/stellar/soroban-tools/pull/931#discussion_r1325197933), but the JS SDK expected this field to be omitted (after some discussion, [see Slack](https://stellarfoundation.slack.com/archives/C02B04RMK/p1694653063065409)): [js-soroban-client#src/soroban_rpc.ts](https://github.com/stellar/js-soroban-client/blob/828440fe3ba18d45fff282dce3c58fa92b5c44da/src/soroban_rpc.ts#L246-L249).

### Known limitations
Having pointers obviously introduces a risk of `nil` pointer dereferences, but it seems like this conversion happens at the highest level (e.g. right before serializing the response), so it's probably fairly low risk.