### PR TITLE
Set base prng to zero in preflight and invoke

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1862,6 +1862,7 @@ dependencies = [
  "anyhow",
  "base64 0.21.4",
  "libc",
+ "rand 0.8.5",
  "sha2 0.10.7",
  "soroban-env-host",
  "thiserror",

--- a/cmd/crates/soroban-test/tests/fixtures/test-wasms/hello_world/src/lib.rs
+++ b/cmd/crates/soroban-test/tests/fixtures/test-wasms/hello_world/src/lib.rs
@@ -42,6 +42,10 @@ impl Contract {
         count
     }
 
+    pub fn prng_u64_in_range(env: Env, low: u64, high: u64) -> u64 {
+        env.prng().u64_in_range(low..=high)
+    }
+
     #[allow(unused_variables)]
     pub fn multi_word_cmd(env: Env, contract_owner: String) {}
     /// Logs a string with `hello ` in front.

--- a/cmd/crates/soroban-test/tests/it/contract_sandbox.rs
+++ b/cmd/crates/soroban-test/tests/it/contract_sandbox.rs
@@ -465,3 +465,29 @@ fn build() {
         .assert()
         .success();
 }
+
+#[test]
+fn invoke_prng_u64_in_range_test() {
+    let sandbox = TestEnv::default();
+    let res = sandbox
+        .new_assert_cmd("contract")
+        .arg("deploy")
+        .arg("--wasm")
+        .arg(HELLO_WORLD.path())
+        .assert()
+        .success();
+    let stdout = String::from_utf8(res.get_output().stdout.clone()).unwrap();
+    let id = stdout.trim_end();
+    println!("{id}");
+    sandbox
+        .new_assert_cmd("contract")
+        .arg("invoke")
+        .arg("--id")
+        .arg(id)
+        .arg("--")
+        .arg("prng_u64_in_range")
+        .arg("--low=0")
+        .arg("--high=100")
+        .assert()
+        .success();
+}

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -382,6 +382,7 @@ impl Cmd {
         let h = Host::with_storage_and_budget(storage, budget);
         h.switch_to_recording_auth(true)?;
         h.set_source_account(source_account)?;
+        h.set_base_prng_seed([0; 32])?;
 
         let mut ledger_info = state.ledger_info();
         ledger_info.sequence_number += 1;

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -382,7 +382,7 @@ impl Cmd {
         let h = Host::with_storage_and_budget(storage, budget);
         h.switch_to_recording_auth(true)?;
         h.set_source_account(source_account)?;
-        h.set_base_prng_seed([0; 32])?;
+        h.set_base_prng_seed(rand::Rng::gen(&mut rand::thread_rng()))?;
 
         let mut ledger_info = state.ledger_info();
         ledger_info.sequence_number += 1;

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -232,9 +232,9 @@ func TestSimulateTransactionSucceeds(t *testing.T) {
 					},
 				},
 			},
-			Instructions: 5007615,
+			Instructions: 5733936,
 			ReadBytes:    48,
-			WriteBytes:   5532,
+			WriteBytes:   6576,
 		},
 		RefundableFee: 20056,
 	}

--- a/cmd/soroban-rpc/lib/preflight/Cargo.toml
+++ b/cmd/soroban-rpc/lib/preflight/Cargo.toml
@@ -13,4 +13,4 @@ thiserror = { workspace = true }
 libc = "0.2.147"
 sha2 = { workspace = true }
 soroban-env-host = { workspace = true }
-
+rand = "0.8.5"

--- a/cmd/soroban-rpc/lib/preflight/src/preflight.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/preflight.rs
@@ -52,6 +52,8 @@ pub(crate) fn preflight_invoke_hf_op(
         .context("cannot set debug diagnostic level")?;
     host.set_ledger_info(ledger_info.clone())
         .context("cannot set ledger info")?;
+    host.set_base_prng_seed([0; 32])
+        .context("cannot set base prng seed")?;
 
     // We make an assumption here:
     // - if a transaction doesn't include any soroban authorization entries the client either

--- a/cmd/soroban-rpc/lib/preflight/src/preflight.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/preflight.rs
@@ -52,7 +52,7 @@ pub(crate) fn preflight_invoke_hf_op(
         .context("cannot set debug diagnostic level")?;
     host.set_ledger_info(ledger_info.clone())
         .context("cannot set ledger info")?;
-    host.set_base_prng_seed([0; 32])
+    host.set_base_prng_seed(rand::Rng::gen(&mut rand::thread_rng()))
         .context("cannot set base prng seed")?;
 
     // We make an assumption here:


### PR DESCRIPTION
### What
Set base prng to zero in preflight and invoke.

### Why
The base prng seed need to be configured in the host for the prng host functions to work. Without it being set invocatinos of contract functions that use the prng will fail, and simulations will also.

```[tasklist]
### Todo
- [x] Decide what value should be set: ~zero, or~ **random**, ~or fixed.~
- [x] Find a way to test it. (Thanks to @tsachiherman)
- [x] Get tests passing.
``` 