### PR TITLE
soroban-cli: upgrade ed25519-dalek to version 2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,8 +810,6 @@ checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek 3.2.0",
  "ed25519 1.5.3",
- "rand 0.7.3",
- "serde",
  "sha2 0.9.9",
  "zeroize",
 ]
@@ -1012,17 +1010,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
@@ -1030,7 +1017,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -1539,7 +1526,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys",
 ]
 
@@ -1862,7 +1849,7 @@ dependencies = [
  "anyhow",
  "base64 0.21.4",
  "libc",
- "rand 0.8.5",
+ "rand",
  "sha2 0.10.7",
  "soroban-env-host",
  "thiserror",
@@ -1908,36 +1895,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1955,9 +1919,6 @@ name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
-]
 
 [[package]]
 name = "rand_core"
@@ -1965,16 +1926,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.10",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
+ "getrandom",
 ]
 
 [[package]]
@@ -2001,7 +1953,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.10",
+ "getrandom",
  "redox_syscall 0.2.16",
  "thiserror",
 ]
@@ -2490,7 +2442,7 @@ dependencies = [
  "csv",
  "dirs",
  "dotenvy",
- "ed25519-dalek 1.0.1",
+ "ed25519-dalek 2.0.0",
  "ethnum",
  "heck",
  "hex",
@@ -2504,7 +2456,7 @@ dependencies = [
  "openssl",
  "pathdiff",
  "predicates 2.1.5",
- "rand 0.8.5",
+ "rand",
  "regex",
  "rpassword",
  "sep5",
@@ -2570,13 +2522,13 @@ source = "git+https://github.com/stellar/rs-soroban-env?rev=8c63bff68a15d79aca3a
 dependencies = [
  "backtrace",
  "ed25519-dalek 2.0.0",
- "getrandom 0.2.10",
+ "getrandom",
  "k256",
  "num-derive",
  "num-integer",
  "num-traits",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand",
+ "rand_chacha",
  "sha2 0.10.7",
  "sha3",
  "soroban-env-common",
@@ -2636,7 +2588,7 @@ dependencies = [
  "bytes-lit",
  "ctor",
  "ed25519-dalek 2.0.0",
- "rand 0.8.5",
+ "rand",
  "soroban-env-guest",
  "soroban-env-host",
  "soroban-ledger-snapshot",
@@ -3029,7 +2981,7 @@ dependencies = [
  "hmac 0.12.1",
  "once_cell",
  "pbkdf2",
- "rand 0.8.5",
+ "rand",
  "rustc-hash",
  "sha2 0.10.7",
  "thiserror",
@@ -3317,12 +3269,6 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/cmd/soroban-cli/Cargo.toml
+++ b/cmd/soroban-cli/Cargo.toml
@@ -66,7 +66,7 @@ rand = "0.8.5"
 wasmparser = { workspace = true }
 sha2 = { workspace = true }
 csv = "1.1.6"
-ed25519-dalek = "1.0.1"
+ed25519-dalek = "2.0.0"
 jsonrpsee-http-client = "0.18.1"
 jsonrpsee-core = "0.18.1"
 hyper   = "0.14.27"

--- a/cmd/soroban-cli/src/commands/config/identity/address.rs
+++ b/cmd/soroban-cli/src/commands/config/identity/address.rs
@@ -35,7 +35,7 @@ impl Cmd {
         Ok(())
     }
 
-    pub fn private_key(&self) -> Result<ed25519_dalek::Keypair, Error> {
+    pub fn private_key(&self) -> Result<ed25519_dalek::SigningKey, Error> {
         Ok(if let Some(name) = &self.name {
             self.locator.read_identity(name)?
         } else {
@@ -46,7 +46,7 @@ impl Cmd {
 
     pub fn public_key(&self) -> Result<stellar_strkey::ed25519::PublicKey, Error> {
         Ok(stellar_strkey::ed25519::PublicKey::from_payload(
-            self.private_key()?.public.as_bytes(),
+            self.private_key()?.verifying_key().as_bytes(),
         )?)
     }
 }

--- a/cmd/soroban-cli/src/commands/config/mod.rs
+++ b/cmd/soroban-cli/src/commands/config/mod.rs
@@ -76,7 +76,7 @@ pub struct Args {
 }
 
 impl Args {
-    pub fn key_pair(&self) -> Result<ed25519_dalek::Keypair, Error> {
+    pub fn key_pair(&self) -> Result<ed25519_dalek::SigningKey, Error> {
         let key = if let Some(source_account) = &self.source_account {
             self.account(source_account)?
         } else {

--- a/cmd/soroban-cli/src/commands/config/secret.rs
+++ b/cmd/soroban-cli/src/commands/config/secret.rs
@@ -110,7 +110,7 @@ impl Secret {
     }
 
     pub fn key_pair(&self, index: Option<usize>) -> Result<ed25519_dalek::SigningKey, Error> {
-        Ok(utils::into_signing_key(&self.private_key(index)?)?)
+        Ok(utils::into_signing_key(&self.private_key(index)?))
     }
 
     pub fn from_seed(seed: Option<&str>) -> Result<Self, Error> {

--- a/cmd/soroban-cli/src/commands/config/secret.rs
+++ b/cmd/soroban-cli/src/commands/config/secret.rs
@@ -105,12 +105,12 @@ impl Secret {
     pub fn public_key(&self, index: Option<usize>) -> Result<PublicKey, Error> {
         let key = self.key_pair(index)?;
         Ok(stellar_strkey::ed25519::PublicKey::from_payload(
-            key.public.as_bytes(),
+            key.verifying_key().as_bytes(),
         )?)
     }
 
-    pub fn key_pair(&self, index: Option<usize>) -> Result<ed25519_dalek::Keypair, Error> {
-        Ok(utils::into_key_pair(&self.private_key(index)?)?)
+    pub fn key_pair(&self, index: Option<usize>) -> Result<ed25519_dalek::SigningKey, Error> {
+        Ok(utils::into_signing_key(&self.private_key(index)?)?)
     }
 
     pub fn from_seed(seed: Option<&str>) -> Result<Self, Error> {

--- a/cmd/soroban-cli/src/commands/contract/bump.rs
+++ b/cmd/soroban-cli/src/commands/contract/bump.rs
@@ -136,12 +136,13 @@ impl Cmd {
         let key = self.config.key_pair()?;
 
         // Get the account sequence number
-        let public_strkey = stellar_strkey::ed25519::PublicKey(key.public.to_bytes()).to_string();
+        let public_strkey =
+            stellar_strkey::ed25519::PublicKey(key.verifying_key().to_bytes()).to_string();
         let account_details = client.get_account(&public_strkey).await?;
         let sequence: i64 = account_details.seq_num.into();
 
         let tx = Transaction {
-            source_account: MuxedAccount::Ed25519(Uint256(key.public.to_bytes())),
+            source_account: MuxedAccount::Ed25519(Uint256(key.verifying_key().to_bytes())),
             fee: self.fee.fee,
             seq_num: SequenceNumber(sequence + 1),
             cond: Preconditions::None,

--- a/cmd/soroban-cli/src/commands/contract/deploy.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy.rs
@@ -172,7 +172,8 @@ impl Cmd {
         let key = self.config.key_pair()?;
 
         // Get the account sequence number
-        let public_strkey = stellar_strkey::ed25519::PublicKey(key.public.to_bytes()).to_string();
+        let public_strkey =
+            stellar_strkey::ed25519::PublicKey(key.verifying_key().to_bytes()).to_string();
 
         let account_details = client.get_account(&public_strkey).await?;
         let sequence: i64 = account_details.seq_num.into();
@@ -197,10 +198,10 @@ fn build_create_contract_tx(
     fee: u32,
     network_passphrase: &str,
     salt: [u8; 32],
-    key: &ed25519_dalek::Keypair,
+    key: &ed25519_dalek::SigningKey,
 ) -> Result<(Transaction, Hash), Error> {
     let source_account = AccountId(PublicKey::PublicKeyTypeEd25519(
-        key.public.to_bytes().into(),
+        key.verifying_key().to_bytes().into(),
     ));
 
     let contract_id_preimage = ContractIdPreimage::Address(ContractIdPreimageFromAddress {
@@ -220,7 +221,7 @@ fn build_create_contract_tx(
         }),
     };
     let tx = Transaction {
-        source_account: MuxedAccount::Ed25519(Uint256(key.public.to_bytes())),
+        source_account: MuxedAccount::Ed25519(Uint256(key.verifying_key().to_bytes())),
         fee,
         seq_num: SequenceNumber(sequence),
         cond: Preconditions::None,

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 use std::{fmt::Debug, fs, io, rc::Rc};
 
 use clap::{arg, command, value_parser, Parser};
-use ed25519_dalek::Keypair;
+use ed25519_dalek::SigningKey;
 use heck::ToKebabCase;
 use soroban_env_host::e2e_invoke::{get_ledger_changes, ExpirationEntryMap};
 use soroban_env_host::xdr::ReadXdr;
@@ -173,7 +173,7 @@ impl Cmd {
         &self,
         contract_id: [u8; 32],
         spec_entries: &[ScSpecEntry],
-    ) -> Result<(String, Spec, InvokeContractArgs, Vec<Keypair>), Error> {
+    ) -> Result<(String, Spec, InvokeContractArgs, Vec<SigningKey>), Error> {
         let spec = Spec(Some(spec_entries.to_vec()));
         let mut cmd = clap::Command::new(self.contract_id.clone())
             .no_binary_name(true)
@@ -189,7 +189,7 @@ impl Cmd {
 
         let func = spec.find_function(function)?;
         // create parsed_args in same order as the inputs to func
-        let mut signers: Vec<Keypair> = vec![];
+        let mut signers: Vec<SigningKey> = vec![];
         let parsed_args = func
             .inputs
             .iter()
@@ -291,7 +291,8 @@ impl Cmd {
         let key = self.config.key_pair()?;
 
         // Get the account sequence number
-        let public_strkey = stellar_strkey::ed25519::PublicKey(key.public.to_bytes()).to_string();
+        let public_strkey =
+            stellar_strkey::ed25519::PublicKey(key.verifying_key().to_bytes()).to_string();
         let account_details = client.get_account(&public_strkey).await?;
         let sequence: i64 = account_details.seq_num.into();
 
@@ -348,7 +349,7 @@ impl Cmd {
 
         // Create source account, adding it to the ledger if not already present.
         let source_account = AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(
-            self.config.key_pair()?.public.to_bytes(),
+            self.config.key_pair()?.verifying_key().to_bytes(),
         )));
         let source_account_ledger_key = LedgerKey::Account(LedgerKeyAccount {
             account_id: source_account.clone(),
@@ -536,7 +537,7 @@ fn build_invoke_contract_tx(
     parameters: InvokeContractArgs,
     sequence: i64,
     fee: u32,
-    key: &Keypair,
+    key: &SigningKey,
 ) -> Result<Transaction, Error> {
     let op = Operation {
         source_account: None,
@@ -546,7 +547,7 @@ fn build_invoke_contract_tx(
         }),
     };
     Ok(Transaction {
-        source_account: MuxedAccount::Ed25519(Uint256(key.public.to_bytes())),
+        source_account: MuxedAccount::Ed25519(Uint256(key.verifying_key().to_bytes())),
         fee,
         seq_num: SequenceNumber(sequence),
         cond: Preconditions::None,

--- a/cmd/soroban-cli/src/commands/contract/restore.rs
+++ b/cmd/soroban-cli/src/commands/contract/restore.rs
@@ -143,12 +143,13 @@ impl Cmd {
         let key = self.config.key_pair()?;
 
         // Get the account sequence number
-        let public_strkey = stellar_strkey::ed25519::PublicKey(key.public.to_bytes()).to_string();
+        let public_strkey =
+            stellar_strkey::ed25519::PublicKey(key.verifying_key().to_bytes()).to_string();
         let account_details = client.get_account(&public_strkey).await?;
         let sequence: i64 = account_details.seq_num.into();
 
         let tx = Transaction {
-            source_account: MuxedAccount::Ed25519(Uint256(key.public.to_bytes())),
+            source_account: MuxedAccount::Ed25519(Uint256(key.verifying_key().to_bytes())),
             fee: self.fee.fee,
             seq_num: SequenceNumber(sequence + 1),
             cond: Preconditions::None,

--- a/cmd/soroban-cli/src/commands/lab/token/wrap.rs
+++ b/cmd/soroban-cli/src/commands/lab/token/wrap.rs
@@ -108,7 +108,8 @@ impl Cmd {
         let key = self.config.key_pair()?;
 
         // Get the account sequence number
-        let public_strkey = stellar_strkey::ed25519::PublicKey(key.public.to_bytes()).to_string();
+        let public_strkey =
+            stellar_strkey::ed25519::PublicKey(key.verifying_key().to_bytes()).to_string();
         // TODO: use symbols for the method names (both here and in serve)
         let account_details = client.get_account(&public_strkey).await?;
         let sequence: i64 = account_details.seq_num.into();
@@ -152,7 +153,7 @@ fn build_wrap_token_tx(
     sequence: i64,
     fee: u32,
     _network_passphrase: &str,
-    key: &ed25519_dalek::Keypair,
+    key: &ed25519_dalek::SigningKey,
 ) -> Result<Transaction, Error> {
     let contract = ScAddress::Contract(contract_id.clone());
     let mut read_write = vec![
@@ -191,7 +192,7 @@ fn build_wrap_token_tx(
     };
 
     Ok(Transaction {
-        source_account: MuxedAccount::Ed25519(Uint256(key.public.to_bytes())),
+        source_account: MuxedAccount::Ed25519(Uint256(key.verifying_key().to_bytes())),
         fee,
         seq_num: SequenceNumber(sequence),
         cond: Preconditions::None,

--- a/cmd/soroban-cli/src/rpc/mod.rs
+++ b/cmd/soroban-cli/src/rpc/mod.rs
@@ -650,8 +650,8 @@ soroban config identity fund {address} --helper-url <url>"#
     pub async fn prepare_and_send_transaction(
         &self,
         tx_without_preflight: &Transaction,
-        source_key: &ed25519_dalek::Keypair,
-        signers: &[ed25519_dalek::Keypair],
+        source_key: &ed25519_dalek::SigningKey,
+        signers: &[ed25519_dalek::SigningKey],
         network_passphrase: &str,
         log_events: Option<LogEvents>,
         log_resources: Option<LogResources>,

--- a/cmd/soroban-cli/src/utils.rs
+++ b/cmd/soroban-cli/src/utils.rs
@@ -164,7 +164,7 @@ pub fn transaction_hash(tx: &Transaction, network_passphrase: &str) -> Result<[u
 ///
 /// Might return an error
 pub fn sign_transaction(
-    key: &ed25519_dalek::Keypair,
+    key: &ed25519_dalek::SigningKey,
     tx: &Transaction,
     network_passphrase: &str,
 ) -> Result<TransactionEnvelope, XdrError> {
@@ -172,7 +172,7 @@ pub fn sign_transaction(
     let tx_signature = key.sign(&tx_hash);
 
     let decorated_signature = DecoratedSignature {
-        hint: SignatureHint(key.public.to_bytes()[28..].try_into()?),
+        hint: SignatureHint(key.verifying_key().to_bytes()[28..].try_into()?),
         signature: Signature(tx_signature.to_bytes().try_into()?),
     };
 
@@ -336,20 +336,20 @@ pub fn find_config_dir(mut pwd: std::path::PathBuf) -> std::io::Result<std::path
     Ok(soroban_dir(&pwd))
 }
 
-pub(crate) fn into_key_pair(
+pub(crate) fn into_signing_key(
     key: &PrivateKey,
-) -> Result<ed25519_dalek::Keypair, ed25519_dalek::SignatureError> {
-    let secret = ed25519_dalek::SecretKey::from_bytes(&key.0)?;
-    let public = (&secret).into();
-    Ok(ed25519_dalek::Keypair { secret, public })
+) -> Result<ed25519_dalek::SigningKey, ed25519_dalek::SignatureError> {
+    let secret: ed25519_dalek::SecretKey;
+    secret = key.0;
+    Ok(ed25519_dalek::SigningKey::from_bytes(&secret))
 }
 
 /// Used in tests
 #[allow(unused)]
 pub(crate) fn parse_secret_key(
     s: &str,
-) -> Result<ed25519_dalek::Keypair, ed25519_dalek::SignatureError> {
-    into_key_pair(&PrivateKey::from_string(s).unwrap())
+) -> Result<ed25519_dalek::SigningKey, ed25519_dalek::SignatureError> {
+    into_signing_key(&PrivateKey::from_string(s).unwrap())
 }
 
 pub fn is_hex_string(s: &str) -> bool {

--- a/cmd/soroban-cli/src/utils.rs
+++ b/cmd/soroban-cli/src/utils.rs
@@ -336,20 +336,17 @@ pub fn find_config_dir(mut pwd: std::path::PathBuf) -> std::io::Result<std::path
     Ok(soroban_dir(&pwd))
 }
 
-pub(crate) fn into_signing_key(
-    key: &PrivateKey,
-) -> Result<ed25519_dalek::SigningKey, ed25519_dalek::SignatureError> {
-    let secret: ed25519_dalek::SecretKey;
-    secret = key.0;
-    Ok(ed25519_dalek::SigningKey::from_bytes(&secret))
+pub(crate) fn into_signing_key(key: &PrivateKey) -> ed25519_dalek::SigningKey {
+    let secret: ed25519_dalek::SecretKey = key.0;
+    ed25519_dalek::SigningKey::from_bytes(&secret)
 }
 
 /// Used in tests
 #[allow(unused)]
 pub(crate) fn parse_secret_key(
     s: &str,
-) -> Result<ed25519_dalek::SigningKey, ed25519_dalek::SignatureError> {
-    into_signing_key(&PrivateKey::from_string(s).unwrap())
+) -> Result<ed25519_dalek::SigningKey, stellar_strkey::DecodeError> {
+    Ok(into_signing_key(&PrivateKey::from_string(s)?))
 }
 
 pub fn is_hex_string(s: &str) -> bool {


### PR DESCRIPTION
### What

update ed25519-dalek from 1.0.1 to 2.0.0.

### Why

Use latest security primitives.

Versions prior to 2 have a vulnerability when generating signature with different public keys and the same private key: https://rustsec.org/advisories/RUSTSEC-2022-0093.

### Known limitations

n/a
