### PR TITLE
rpc: preflight: include system events in fee calculation

### DIFF
--- a/cmd/crates/soroban-test/tests/fixtures/test-wasms/hello_world/src/lib.rs
+++ b/cmd/crates/soroban-test/tests/fixtures/test-wasms/hello_world/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 use soroban_sdk::{
-    contract, contractimpl, log, symbol_short, vec, Address, Env, String, Symbol, Vec,
+    contract, contractimpl, log, symbol_short, vec, Address, BytesN, Env, String, Symbol, Vec,
 };
 
 const COUNTER: Symbol = symbol_short!("COUNTER");
@@ -44,6 +44,10 @@ impl Contract {
 
     pub fn prng_u64_in_range(env: Env, low: u64, high: u64) -> u64 {
         env.prng().u64_in_range(low..=high)
+    }
+
+    pub fn upgrade_contract(env: Env, hash: BytesN<32>) {
+        env.deployer().update_current_contract_wasm(hash);
     }
 
     #[allow(unused_variables)]

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -232,9 +232,9 @@ func TestSimulateTransactionSucceeds(t *testing.T) {
 					},
 				},
 			},
-			Instructions: 5733936,
+			Instructions: 6070660,
 			ReadBytes:    48,
-			WriteBytes:   6576,
+			WriteBytes:   7060,
 		},
 		RefundableFee: 20056,
 	}
@@ -1126,7 +1126,7 @@ func TestSimulateSystemEvent(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, xdr.Int64(45), transactionData.RefundableFee)
-	assert.Equal(t, xdr.Uint32(2860), transactionData.Resources.ReadBytes)
+	assert.Equal(t, xdr.Uint32(7260), transactionData.Resources.ReadBytes)
 	assert.Equal(t, xdr.Uint32(104), transactionData.Resources.WriteBytes)
 	require.GreaterOrEqual(t, len(response.Events), 3)
 }

--- a/cmd/soroban-rpc/lib/preflight/src/fees.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/fees.rs
@@ -261,7 +261,9 @@ fn calculate_unmodified_ledger_entry_bytes(
 fn calculate_contract_events_size_bytes(events: &Vec<DiagnosticEvent>) -> Result<u32> {
     let mut res: u32 = 0;
     for e in events {
-        if e.event.type_ != ContractEventType::Contract {
+        if e.event.type_ != ContractEventType::Contract
+            || e.event.type_ != ContractEventType::System
+        {
             continue;
         }
         let event_xdr = e

--- a/cmd/soroban-rpc/lib/preflight/src/fees.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/fees.rs
@@ -262,7 +262,7 @@ fn calculate_contract_events_size_bytes(events: &Vec<DiagnosticEvent>) -> Result
     let mut res: u32 = 0;
     for e in events {
         if e.event.type_ != ContractEventType::Contract
-            || e.event.type_ != ContractEventType::System
+            && e.event.type_ != ContractEventType::System
         {
             continue;
         }


### PR DESCRIPTION
### What

Include size of system events in fee estimation. They were removed at #844 

I interpreted  from @dmkozh at https://github.com/stellar/soroban-tools/pull/884#discussion_r1305729009 they had to be removed

- [x] Tsachi : added unit test.

### Why

Fixes #985

### Known limitations

N/A
