### PR TITLE
fix(CLI): ignore the expiration in contract_read test

### DIFF
--- a/cmd/crates/soroban-test/tests/it/integration_and_sandbox.rs
+++ b/cmd/crates/soroban-test/tests/it/integration_and_sandbox.rs
@@ -128,7 +128,7 @@ fn contract_data_read() {
         .arg("--durability=persistent")
         .assert()
         .success()
-        .stdout("COUNTER,1,4096\n");
+        .stdout(predicates::str::starts_with("COUNTER,1"));
 
     sandbox
         .new_assert_cmd("contract")
@@ -149,7 +149,7 @@ fn contract_data_read() {
         .arg("--durability=persistent")
         .assert()
         .success()
-        .stdout("COUNTER,2,4096\n");
+        .stdout(predicates::str::starts_with("COUNTER,2"));
 }
 
 #[test]


### PR DESCRIPTION
### What

fixes #987 

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
