### PR TITLE
Flatten the `getEvents` response structure

### DIFF
--- a/cmd/soroban-cli/src/commands/config/events_file.rs
+++ b/cmd/soroban-cli/src/commands/config/events_file.rs
@@ -14,6 +14,7 @@ use std::{
     fs,
     path::{Path, PathBuf},
 };
+use stellar_strkey::{Contract, Strkey};
 
 #[derive(Debug, clap::Args, Clone, Default)]
 #[group(skip)]
@@ -136,19 +137,19 @@ impl Args {
                 id,
                 ledger: ledger_info.sequence_number.to_string(),
                 ledger_closed_at: dt.format("%Y-%m-%dT%H:%M:%SZ").to_string(),
-                contract_id: hex::encode(
+                contract_id: Strkey::Contract(Contract(
                     contract_event
                         .contract_id
                         .as_ref()
-                        .unwrap_or(&xdr::Hash([0; 32])),
-                ),
+                        .unwrap_or(&xdr::Hash([0; 32]))
+                        .0,
+                ))
+                .to_string(),
                 topic,
-                value: rpc::EventValue {
-                    xdr: match &contract_event.body {
-                        xdr::ContractEventBody::V0(e) => &e.data,
-                    }
-                    .to_xdr_base64()?,
-                },
+                value: match &contract_event.body {
+                    xdr::ContractEventBody::V0(e) => &e.data,
+                }
+                .to_xdr_base64()?,
             };
 
             events.push(cereal_event);

--- a/cmd/soroban-cli/src/commands/events.rs
+++ b/cmd/soroban-cli/src/commands/events.rs
@@ -34,8 +34,8 @@ pub struct Cmd {
     count: usize,
 
     /// A set of (up to 5) contract IDs to filter events on. This parameter can
-    /// be passed multiple times, e.g. `--id abc --id def`, or passed with
-    /// multiple parameters, e.g. `--id abd def`.
+    /// be passed multiple times, e.g. `--id C123.. --id C456..`, or passed with
+    /// multiple parameters, e.g. `--id C123 C456`.
     ///
     /// Though the specification supports multiple filter objects (i.e.
     /// combinations of type, IDs, and topics), only one set can be specified on
@@ -352,8 +352,14 @@ mod tests {
         assert_eq!(file.events.len(), 2);
         assert_eq!(file.events[0].ledger, "2");
         assert_eq!(file.events[1].ledger, "2");
-        assert_eq!(file.events[0].contract_id, "0".repeat(64));
-        assert_eq!(file.events[1].contract_id, "01".repeat(32));
+        assert_eq!(
+            file.events[0].contract_id,
+            "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4"
+        );
+        assert_eq!(
+            file.events[1].contract_id,
+            "CAAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQC526"
+        );
         assert_eq!(file.latest_ledger, 2);
     }
 

--- a/cmd/soroban-cli/src/rpc/mod.rs
+++ b/cmd/soroban-cli/src/rpc/mod.rs
@@ -304,7 +304,7 @@ pub struct Event {
     #[serde(rename = "contractId")]
     pub contract_id: String,
     pub topic: Vec<String>,
-    pub value: EventValue,
+    pub value: String,
 }
 
 impl Display for Event {
@@ -326,7 +326,7 @@ impl Display for Event {
             let scval = xdr::ScVal::from_xdr_base64(topic).map_err(|_| std::fmt::Error)?;
             writeln!(f, "            {scval:?}")?;
         }
-        let scval = xdr::ScVal::from_xdr_base64(&self.value.xdr).map_err(|_| std::fmt::Error)?;
+        let scval = xdr::ScVal::from_xdr_base64(&self.value).map_err(|_| std::fmt::Error)?;
         writeln!(f, "  Value:    {scval:?}")
     }
 }
@@ -374,7 +374,7 @@ impl Event {
 
         colored!(
             stdout,
-            "  Contract: {}0x{}{}\n",
+            "  Contract: {}{}{}\n",
             fg!(Some(Color::Green)),
             self.contract_id,
             reset!(),
@@ -392,7 +392,7 @@ impl Event {
             )?;
         }
 
-        let scval = xdr::ScVal::from_xdr_base64(&self.value.xdr)?;
+        let scval = xdr::ScVal::from_xdr_base64(&self.value)?;
         colored!(
             stdout,
             "  Value: {}{:?}{}\n",
@@ -403,11 +403,6 @@ impl Event {
 
         Ok(())
     }
-}
-
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
-pub struct EventValue {
-    pub xdr: String,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, clap::ValueEnum)]

--- a/cmd/soroban-rpc/internal/methods/get_events.go
+++ b/cmd/soroban-rpc/internal/methods/get_events.go
@@ -67,19 +67,15 @@ func (e eventTypeSet) matches(event xdr.ContractEvent) bool {
 }
 
 type EventInfo struct {
-	EventType                string         `json:"type"`
-	Ledger                   int32          `json:"ledger,string"`
-	LedgerClosedAt           string         `json:"ledgerClosedAt"`
-	ContractID               string         `json:"contractId"`
-	ID                       string         `json:"id"`
-	PagingToken              string         `json:"pagingToken"`
-	Topic                    []string       `json:"topic"`
-	Value                    EventInfoValue `json:"value"`
-	InSuccessfulContractCall bool           `json:"inSuccessfulContractCall"`
-}
-
-type EventInfoValue struct {
-	XDR string `json:"xdr"`
+	EventType                string   `json:"type"`
+	Ledger                   int32    `json:"ledger,string"`
+	LedgerClosedAt           string   `json:"ledgerClosedAt"`
+	ContractID               string   `json:"contractId"`
+	ID                       string   `json:"id"`
+	PagingToken              string   `json:"pagingToken"`
+	Topic                    []string `json:"topic"`
+	Value                    string   `json:"value"`
+	InSuccessfulContractCall bool     `json:"inSuccessfulContractCall"`
 }
 
 type GetEventsRequest struct {
@@ -413,7 +409,7 @@ func eventInfoForEvent(event xdr.DiagnosticEvent, cursor events.Cursor, ledgerCl
 		ID:                       cursor.String(),
 		PagingToken:              cursor.String(),
 		Topic:                    topic,
-		Value:                    EventInfoValue{XDR: data},
+		Value:                    data,
 		InSuccessfulContractCall: event.InSuccessfulContractCall,
 	}
 	if event.Event.ContractId != nil {

--- a/cmd/soroban-rpc/internal/methods/get_events_test.go
+++ b/cmd/soroban-rpc/internal/methods/get_events_test.go
@@ -623,16 +623,14 @@ func TestGetEvents(t *testing.T) {
 			})
 			assert.NoError(t, err)
 			expected = append(expected, EventInfo{
-				EventType:      EventTypeContract,
-				Ledger:         1,
-				LedgerClosedAt: now.Format(time.RFC3339),
-				ContractID:     "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
-				ID:             id,
-				PagingToken:    id,
-				Topic:          []string{value},
-				Value: EventInfoValue{
-					XDR: value,
-				},
+				EventType:                EventTypeContract,
+				Ledger:                   1,
+				LedgerClosedAt:           now.Format(time.RFC3339),
+				ContractID:               "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+				ID:                       id,
+				PagingToken:              id,
+				Topic:                    []string{value},
+				Value:                    value,
 				InSuccessfulContractCall: true,
 			})
 		}
@@ -744,7 +742,7 @@ func TestGetEvents(t *testing.T) {
 				ID:                       id,
 				PagingToken:              id,
 				Topic:                    []string{counterXdr, value},
-				Value:                    EventInfoValue{XDR: value},
+				Value:                    value,
 				InSuccessfulContractCall: true,
 			},
 		}
@@ -838,7 +836,7 @@ func TestGetEvents(t *testing.T) {
 				ID:                       id,
 				PagingToken:              id,
 				Topic:                    []string{counterXdr, value},
-				Value:                    EventInfoValue{XDR: value},
+				Value:                    value,
 				InSuccessfulContractCall: true,
 			},
 		}
@@ -898,7 +896,7 @@ func TestGetEvents(t *testing.T) {
 				ID:                       id,
 				PagingToken:              id,
 				Topic:                    []string{counterXdr},
-				Value:                    EventInfoValue{XDR: counterXdr},
+				Value:                    counterXdr,
 				InSuccessfulContractCall: true,
 			},
 		}
@@ -946,16 +944,14 @@ func TestGetEvents(t *testing.T) {
 			value, err := xdr.MarshalBase64(txMeta[i].MustV3().SorobanMeta.Events[0].Body.MustV0().Data)
 			assert.NoError(t, err)
 			expected = append(expected, EventInfo{
-				EventType:      EventTypeContract,
-				Ledger:         1,
-				LedgerClosedAt: now.Format(time.RFC3339),
-				ContractID:     "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
-				ID:             id,
-				PagingToken:    id,
-				Topic:          []string{value},
-				Value: EventInfoValue{
-					XDR: value,
-				},
+				EventType:                EventTypeContract,
+				Ledger:                   1,
+				LedgerClosedAt:           now.Format(time.RFC3339),
+				ContractID:               "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+				ID:                       id,
+				PagingToken:              id,
+				Topic:                    []string{value},
+				Value:                    value,
 				InSuccessfulContractCall: true,
 			})
 		}
@@ -1039,7 +1035,7 @@ func TestGetEvents(t *testing.T) {
 				ID:                       id,
 				PagingToken:              id,
 				Topic:                    []string{counterXdr},
-				Value:                    EventInfoValue{XDR: expectedXdr},
+				Value:                    expectedXdr,
 				InSuccessfulContractCall: true,
 			})
 		}


### PR DESCRIPTION
### What
This makes `value: { xdr: "a base64-encoded string of an ScVal" }` just `value: "the string"`, because the nested object just adds verbosity and structure complexity.

### Why
Closes #998
[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
