### PR TITLE
clippy: fix clippy warning per rust 1.73

### DIFF
--- a/cmd/crates/soroban-spec-tools/src/lib.rs
+++ b/cmd/crates/soroban-spec-tools/src/lib.rs
@@ -696,7 +696,7 @@ impl Spec {
                 let v: u128 = int
                     .clone()
                     .try_into()
-                    .map_err(|_| Error::InvalidValue(Some(ScType::U128)))?;
+                    .map_err(|()| Error::InvalidValue(Some(ScType::U128)))?;
                 Value::String(v.to_string())
             }
 
@@ -705,7 +705,7 @@ impl Spec {
                 let v: i128 = int
                     .clone()
                     .try_into()
-                    .map_err(|_| Error::InvalidValue(Some(ScType::I128)))?;
+                    .map_err(|()| Error::InvalidValue(Some(ScType::I128)))?;
                 Value::String(v.to_string())
             }
 

--- a/cmd/soroban-cli/src/commands/config/locator.rs
+++ b/cmd/soroban-cli/src/commands/config/locator.rs
@@ -293,7 +293,7 @@ impl KeyType {
     pub fn list_paths(&self, paths: &[Location]) -> Result<Vec<(String, Location)>, Error> {
         Ok(paths
             .iter()
-            .flat_map(|p| self.list(p).unwrap_or(vec![]))
+            .flat_map(|p| self.list(p).unwrap_or_default())
             .collect())
     }
 

--- a/cmd/soroban-cli/src/commands/contract/invoke.rs
+++ b/cmd/soroban-cli/src/commands/contract/invoke.rs
@@ -243,7 +243,7 @@ impl Cmd {
         let contract_address_arg = ScAddress::Contract(Hash(contract_id));
         let function_symbol_arg = function
             .try_into()
-            .map_err(|_| Error::FunctionNameTooLong(function.clone()))?;
+            .map_err(|()| Error::FunctionNameTooLong(function.clone()))?;
 
         let final_args =
             parsed_args

--- a/cmd/soroban-cli/src/commands/mod.rs
+++ b/cmd/soroban-cli/src/commands/mod.rs
@@ -72,7 +72,7 @@ impl Root {
             }
             match e.kind() {
                 ErrorKind::InvalidSubcommand => match plugin::run() {
-                    Ok(_) => Error::Clap(e),
+                    Ok(()) => Error::Clap(e),
                     Err(e) => Error::Plugin(e),
                 },
                 _ => Error::Clap(e),

--- a/cmd/soroban-cli/src/rpc/mod.rs
+++ b/cmd/soroban-cli/src/rpc/mod.rs
@@ -495,11 +495,13 @@ impl Client {
 
     pub async fn verify_network_passphrase(&self, expected: Option<&str>) -> Result<String, Error> {
         let server = self.get_network().await?.passphrase;
-        if expected.is_some() && expected != Some(&server) {
-            return Err(Error::InvalidNetworkPassphrase {
-                expected: expected.unwrap().to_string(),
-                server,
-            });
+        if expected != Some(&server) {
+            if let Some(expected_val) = expected {
+                return Err(Error::InvalidNetworkPassphrase {
+                    expected: expected_val.to_string(),
+                    server,
+                });
+            }
         }
         Ok(server)
     }


### PR DESCRIPTION
### What

fix clippy warning

### Why

Clippy updates for v1.73 is more opinionated then ever!

### Known limitations

n/a