### PR TITLE
Run go mod tidy

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -17,7 +17,7 @@ jobs:
       - run: rustup update
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.20.1
+          go-version: 1.21
       - run: scripts/check-dependencies.bash
   validate-rust-git-rev-deps:
     runs-on: ubuntu-latest

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,6 +20,8 @@ jobs:
           fetch-depth: 0 # required for new-from-rev option in .golangci.yml
       - name: Setup GO
         uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # version v3.3.0
+        with:
+          go-version: '>=1.21.0'
 
       - name: Build libpreflight
         run: |

--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        go: [1.20.1]
+        go: [1.21]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -63,7 +63,7 @@ jobs:
       # because it uses apt-get and some OSs (e.g. windows) don't have it
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.20.1
+          go-version: 1.21
 
       - run: |
           rustup target add ${{ matrix.rust_target }}
@@ -106,7 +106,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        go: [1.20.1]
+        go: [1.21]
         test: ['.*CLI.*', '^Test(([^C])|(C[^L])|(CL[^I])).*$']
     runs-on: ${{ matrix.os }}
     env:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/stellar/soroban-tools
 
-go 1.20
+go 1.21
+
+toolchain go1.21.1
 
 require (
 	github.com/Masterminds/squirrel v1.5.4

--- a/go.sum
+++ b/go.sum
@@ -242,6 +242,7 @@ github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3x
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 h1:SOEGU9fKiNWd/HOJuq6+3iTQz8KNCLtVX6idSoTLdUw=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 h1:P6pPBnrTSX3DEVR4fDembhRWSsG5rVo6hYhAB/ADZrk=


### PR DESCRIPTION
Note that this PR enforces Go 1.21 transitively due to dependencies (at least github.com/creachadair/jrpc2) enforcing Go 1.21


