### PR TITLE
feat(CLI): Assembled Transaction that handle preparing transaction post simulation

### DIFF
--- a/cmd/soroban-cli/src/rpc/txn.rs
+++ b/cmd/soroban-cli/src/rpc/txn.rs
@@ -139,11 +139,10 @@ impl Handler {
                         network_passphrase,
                     )?,
                     state: State::Raw,
-                }
-                .bump_seq_num();
+                };
                 let sim = txn.simulate(client).await?;
                 Ok(Self {
-                    txn: txn.txn,
+                    txn: assemble(&txn.txn, &sim)?,
                     state: State::Authorized(sim),
                 })
             }


### PR DESCRIPTION
This renames the `transaction` module to `txn`. Adds `txn::Assembled`. `Assembled` handles the different steps in preparing a transaction to be submitted. This is the first step in allowing intermediate transactions be returned and externally signed.
Also in improving error messages from failed transactions.
