### PR TITLE
Fix typo in JSON-encoded field for a `getLedgerEntries` result

### DIFF
--- a/cmd/soroban-cli/src/rpc/mod.rs
+++ b/cmd/soroban-cli/src/rpc/mod.rs
@@ -152,7 +152,7 @@ pub struct LedgerEntryResult {
     )]
     pub last_modified_ledger: u32,
     #[serde(
-        rename = "liveUntilLedgerSeqLedgerSeq",
+        rename = "liveUntilLedgerSeq",
         skip_serializing_if = "Option::is_none",
         deserialize_with = "deserialize_option_number_from_string",
         default

--- a/cmd/soroban-rpc/internal/methods/get_ledger_entries.go
+++ b/cmd/soroban-rpc/internal/methods/get_ledger_entries.go
@@ -27,7 +27,7 @@ type LedgerEntryResult struct {
 	// Last modified ledger for this entry.
 	LastModifiedLedger int64 `json:"lastModifiedLedgerSeq,string"`
 	// The ledger sequence until the entry is live, available for entries that have associated ttl ledger entries.
-	LiveUntilLedgerSeq *uint32 `json:"liveUntilLedgerSeqLedgerSeq,string,omitempty"`
+	LiveUntilLedgerSeq *uint32 `json:"liveUntilLedgerSeq,string,omitempty"`
 }
 
 type GetLedgerEntriesResponse struct {


### PR DESCRIPTION
The diff is self-explanatory: this appears to be a typo.