### PR TITLE
soroban-rpc: remove noisy rollback message

### DIFF
--- a/cmd/soroban-rpc/internal/ingest/service.go
+++ b/cmd/soroban-rpc/internal/ingest/service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stellar/go/historyarchive"
 	"github.com/stellar/go/ingest"
 	backends "github.com/stellar/go/ingest/ledgerbackend"
+	supportdb "github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/xdr"
 
@@ -208,9 +209,14 @@ func (s *Service) fillEntriesFromCheckpoint(ctx context.Context, archive history
 	if err != nil {
 		return err
 	}
+	transactionCommitted := false
 	defer func() {
-		if err := tx.Rollback(); err != nil {
-			s.logger.WithError(err).Warn("could not rollback fillEntriesFromCheckpoint write transactions")
+		if transactionCommitted == false {
+			// Internally, we might already have rolled back the transaction. We should
+			// not generate benign error/warning here in case the transaction was already rolled back.
+			if err := tx.Rollback(); err != nil && err != supportdb.ErrAlreadyRolledback {
+				s.logger.WithError(err).Warn("could not rollback fillEntriesFromCheckpoint write transactions")
+			}
 		}
 	}()
 
@@ -222,9 +228,12 @@ func (s *Service) fillEntriesFromCheckpoint(ctx context.Context, archive history
 	}
 
 	s.logger.Info("committing checkpoint ledger entries")
-	if err := tx.Commit(checkpointLedger); err != nil {
+	err = tx.Commit(checkpointLedger)
+	transactionCommitted = true
+	if err != nil {
 		return err
 	}
+
 	s.logger.Info("finished checkpoint processing")
 	return nil
 }

--- a/cmd/soroban-rpc/internal/ingest/service.go
+++ b/cmd/soroban-rpc/internal/ingest/service.go
@@ -211,11 +211,11 @@ func (s *Service) fillEntriesFromCheckpoint(ctx context.Context, archive history
 	}
 	transactionCommitted := false
 	defer func() {
-		if transactionCommitted == false {
+		if !transactionCommitted {
 			// Internally, we might already have rolled back the transaction. We should
 			// not generate benign error/warning here in case the transaction was already rolled back.
-			if err := tx.Rollback(); err != nil && err != supportdb.ErrAlreadyRolledback {
-				s.logger.WithError(err).Warn("could not rollback fillEntriesFromCheckpoint write transactions")
+			if rollbackErr := tx.Rollback(); rollbackErr != nil && rollbackErr != supportdb.ErrAlreadyRolledback {
+				s.logger.WithError(rollbackErr).Warn("could not rollback fillEntriesFromCheckpoint write transactions")
 			}
 		}
 	}()


### PR DESCRIPTION
### What

When stopping soroban-rpc, it would generate a benign warning message:
```
WARN[2023-10-26T11:49:39.561-04:00] could not rollback fillEntriesFromCheckpoint write transactions  error="transaction has already been committed or rolled back" pid=20799
```

### Why

The underlying transaction was already rolled back by the database session. There is no need to roll it back again.
Given that this is the exception rather then the rule, I've silenced this particular case.

### Known limitations

n/a
