### PR TITLE
update Dockerfile to go 1.21

### DIFF
--- a/cmd/soroban-rpc/docker/Dockerfile
+++ b/cmd/soroban-rpc/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-bullseye as build
+FROM golang:1.21-bullseye as build
 ARG RUST_TOOLCHAIN_VERSION=stable
 ARG REPOSITORY_VERSION
 


### PR DESCRIPTION
### What

updated Dockerfile to use go 1.21

### Why

Dockerfile won't build with go 1.20

### Known limitations


