### PR TITLE
Explicitly supply objectives in Prometheus SummaryOpts

### DIFF
--- a/cmd/soroban-rpc/internal/daemon/metrics.go
+++ b/cmd/soroban-rpc/internal/daemon/metrics.go
@@ -57,11 +57,13 @@ type CoreClientWithMetrics struct {
 func newCoreClientWithMetrics(client stellarcore.Client, registry *prometheus.Registry) *CoreClientWithMetrics {
 	submitMetric := prometheus.NewSummaryVec(prometheus.SummaryOpts{
 		Namespace: prometheusNamespace, Subsystem: "txsub", Name: "submission_duration_seconds",
-		Help: "submission durations to Stellar-Core, sliding window = 10m",
+		Help:       "submission durations to Stellar-Core, sliding window = 10m",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 	}, []string{"status"})
 	opCountMetric := prometheus.NewSummaryVec(prometheus.SummaryOpts{
 		Namespace: prometheusNamespace, Subsystem: "txsub", Name: "operation_count",
-		Help: "number of operations included in a transaction, sliding window = 10m",
+		Help:       "number of operations included in a transaction, sliding window = 10m",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 	}, []string{"status"})
 	registry.MustRegister(submitMetric, opCountMetric)
 

--- a/cmd/soroban-rpc/internal/events/events.go
+++ b/cmd/soroban-rpc/internal/events/events.go
@@ -64,14 +64,16 @@ func NewMemoryStore(daemon interfaces.Daemon, networkPassphrase string, retentio
 	// eventsDurationMetric is a metric for measuring latency of event store operations
 	eventsDurationMetric := prometheus.NewSummaryVec(prometheus.SummaryOpts{
 		Namespace: daemon.MetricsNamespace(), Subsystem: "events", Name: "operation_duration_seconds",
-		Help: "event store operation durations, sliding window = 10m",
+		Help:       "event store operation durations, sliding window = 10m",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 	},
 		[]string{"operation"},
 	)
 
 	eventCountMetric := prometheus.NewSummary(prometheus.SummaryOpts{
 		Namespace: daemon.MetricsNamespace(), Subsystem: "events", Name: "count",
-		Help: "count of events ingested, sliding window = 10m",
+		Help:       "count of events ingested, sliding window = 10m",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 	})
 	daemon.MetricsRegistry().MustRegister(eventCountMetric, eventsDurationMetric)
 	return &MemoryStore{

--- a/cmd/soroban-rpc/internal/ingest/service.go
+++ b/cmd/soroban-rpc/internal/ingest/service.go
@@ -53,7 +53,8 @@ func newService(cfg Config) *Service {
 	// ingestionDurationMetric is a metric for measuring the latency of ingestion
 	ingestionDurationMetric := prometheus.NewSummaryVec(prometheus.SummaryOpts{
 		Namespace: cfg.Daemon.MetricsNamespace(), Subsystem: "ingest", Name: "ledger_ingestion_duration_seconds",
-		Help: "ledger ingestion durations, sliding window = 10m",
+		Help:       "ledger ingestion durations, sliding window = 10m",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 	},
 		[]string{"type"},
 	)

--- a/cmd/soroban-rpc/internal/jsonrpc.go
+++ b/cmd/soroban-rpc/internal/jsonrpc.go
@@ -57,10 +57,11 @@ type HandlerParams struct {
 
 func decorateHandlers(daemon interfaces.Daemon, logger *log.Entry, m handler.Map) handler.Map {
 	requestMetric := prometheus.NewSummaryVec(prometheus.SummaryOpts{
-		Namespace: daemon.MetricsNamespace(),
-		Subsystem: "json_rpc",
-		Name:      "request_duration_seconds",
-		Help:      "JSON RPC request duration",
+		Namespace:  daemon.MetricsNamespace(),
+		Subsystem:  "json_rpc",
+		Name:       "request_duration_seconds",
+		Help:       "JSON RPC request duration",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 	}, []string{"endpoint", "status"})
 	decorated := handler.Map{}
 	for endpoint, h := range m {

--- a/cmd/soroban-rpc/internal/preflight/pool.go
+++ b/cmd/soroban-rpc/internal/preflight/pool.go
@@ -69,16 +69,18 @@ func NewPreflightWorkerPool(daemon interfaces.Daemon, workerCount uint, jobQueue
 		Help:      "number of preflight full queue errors",
 	})
 	preflightWP.durationMetric = prometheus.NewSummaryVec(prometheus.SummaryOpts{
-		Namespace: daemon.MetricsNamespace(),
-		Subsystem: "preflight_pool",
-		Name:      "request_ledger_get_duration_seconds",
-		Help:      "preflight request duration broken down by status",
+		Namespace:  daemon.MetricsNamespace(),
+		Subsystem:  "preflight_pool",
+		Name:       "request_ledger_get_duration_seconds",
+		Help:       "preflight request duration broken down by status",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 	}, []string{"status", "type"})
 	preflightWP.ledgerEntriesFetchedMetric = prometheus.NewSummary(prometheus.SummaryOpts{
-		Namespace: daemon.MetricsNamespace(),
-		Subsystem: "preflight_pool",
-		Name:      "request_ledger_entries_fetched",
-		Help:      "ledger entries fetched by simulate transaction calls",
+		Namespace:  daemon.MetricsNamespace(),
+		Subsystem:  "preflight_pool",
+		Name:       "request_ledger_entries_fetched",
+		Help:       "ledger entries fetched by simulate transaction calls",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 	})
 	daemon.MetricsRegistry().MustRegister(
 		requestQueueMetric,

--- a/cmd/soroban-rpc/internal/transactions/transactions.go
+++ b/cmd/soroban-rpc/internal/transactions/transactions.go
@@ -48,13 +48,15 @@ func NewMemoryStore(daemon interfaces.Daemon, networkPassphrase string, retentio
 	// transactionDurationMetric is a metric for measuring latency of transaction store operations
 	transactionDurationMetric := prometheus.NewSummaryVec(prometheus.SummaryOpts{
 		Namespace: daemon.MetricsNamespace(), Subsystem: "transactions", Name: "operation_duration_seconds",
-		Help: "transaction store operation durations, sliding window = 10m",
+		Help:       "transaction store operation durations, sliding window = 10m",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 	},
 		[]string{"operation"},
 	)
 	transactionCountMetric := prometheus.NewSummary(prometheus.SummaryOpts{
 		Namespace: daemon.MetricsNamespace(), Subsystem: "transactions", Name: "count",
-		Help: "count of transactions ingested, sliding window = 10m",
+		Help:       "count of transactions ingested, sliding window = 10m",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 	})
 	daemon.MetricsRegistry().MustRegister(transactionDurationMetric, transactionCountMetric)
 


### PR DESCRIPTION

### What

This PR explicitly supplies objectives in Prometheus.SummaryOpts because the new version of the Prometheus go client no longer provides the default value.

### Why
In previous versions of the Prometheus go client, default objectives were automatically provided in prometheus.SummaryOpts. However, this was [deprecated](https://github.com/prometheus/client_golang/pull/262/files) in [version 1.0.0.](https://github.com/prometheus/client_golang/blob/main/CHANGELOG.md#100--2019-06-15)

### Known limitations

N/A
