### PR TITLE
soroban-cli: Warn or Error When Deploying Contracts Compiled with RC Version of Soroban SDK

### DIFF
--- a/cmd/crates/soroban-test/tests/it/integration/util.rs
+++ b/cmd/crates/soroban-test/tests/it/integration/util.rs
@@ -69,6 +69,7 @@ pub fn deploy_contract(sandbox: &TestEnv, wasm: &Wasm) -> String {
         .arg("install")
         .arg("--wasm")
         .arg(wasm.path())
+        .arg("--ignore-checks")
         .assert()
         .success()
         .stdout(format!("{hash}\n"));
@@ -80,6 +81,7 @@ pub fn deploy_contract(sandbox: &TestEnv, wasm: &Wasm) -> String {
         .arg(&format!("{hash}"))
         .arg("--salt")
         .arg(TEST_SALT)
+        .arg("--ignore-checks")
         .assert()
         .success()
         .stdout(format!("{TEST_CONTRACT_ID}\n"));

--- a/cmd/soroban-cli/src/commands/contract/deploy.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy.rs
@@ -10,8 +10,8 @@ use soroban_env_host::{
         AccountId, ContractExecutable, ContractIdPreimage, ContractIdPreimageFromAddress,
         CreateContractArgs, Error as XdrError, Hash, HashIdPreimage, HashIdPreimageContractId,
         HostFunction, InvokeHostFunctionOp, Memo, MuxedAccount, Operation, OperationBody,
-        Preconditions, PublicKey, ScAddress, SequenceNumber, Transaction, TransactionExt, Uint256,
-        VecM, WriteXdr, ScMetaV0, ScMetaEntry,
+        Preconditions, PublicKey, ScAddress, ScMetaEntry, ScMetaV0, SequenceNumber, Transaction,
+        TransactionExt, Uint256, VecM, WriteXdr,
     },
     HostError,
 };
@@ -81,14 +81,14 @@ pub enum Error {
     #[error("cannot parse WASM file {wasm}: {error}")]
     CannotParseWasm {
         wasm: std::path::PathBuf,
-        error: wasm::Error
+        error: wasm::Error,
     },
     #[error("Must provide either --wasm or --wash-hash")]
     WasmNotProvided,
     #[error("the deployed smart contract {wasm} was built with Soroban Rust SDK v{version}, a release candidate version not intended for use with the Stellar Public Network. To deploy anyway, use --ignore-checks")]
     ContractCompiledWithReleaseCandidateSdk {
         wasm: std::path::PathBuf,
-        version: String
+        version: String,
     },
     #[error(transparent)]
     Rpc(#[from] rpc::Error),
@@ -107,18 +107,18 @@ impl Cmd {
 
     pub async fn run_and_get_contract_id(&self) -> Result<String, Error> {
         if let Some(wasm_path) = &self.wasm {
-            let wasm_args = wasm::Args { wasm: wasm_path.clone() };
-            let wasm_spec = wasm_args.parse().map_err(|e| {
-                Error::CannotParseWasm {
-                    wasm: wasm_path.clone(),
-                    error: e
-                }
+            let wasm_args = wasm::Args {
+                wasm: wasm_path.clone(),
+            };
+            let wasm_spec = wasm_args.parse().map_err(|e| Error::CannotParseWasm {
+                wasm: wasm_path.clone(),
+                error: e,
             })?;
             if let Some(rs_sdk_ver) = get_contract_meta_sdk_version(&wasm_spec) {
                 if rs_sdk_ver.contains("rc") && !self.ignore_checks {
-                    return Err(Error::ContractCompiledWithReleaseCandidateSdk { 
+                    return Err(Error::ContractCompiledWithReleaseCandidateSdk {
                         wasm: wasm_path.clone(),
-                        version: rs_sdk_ver
+                        version: rs_sdk_ver,
                     });
                 } else if rs_sdk_ver.contains("rc") {
                     tracing::warn!("the deployed smart contract {path} was built with Soroban Rust SDK v{rs_sdk_ver}, a release candidate version not intended for use with the Stellar Public Network", path = wasm_path.display());
@@ -190,11 +190,9 @@ impl Cmd {
 
 fn get_contract_meta_sdk_version(wasm_spec: &utils::contract_spec::ContractSpec) -> Option<String> {
     let rs_sdk_version_option = if let Some(_meta) = &wasm_spec.meta_base64 {
-        wasm_spec.meta.iter().find(|entry| {
-            match entry {
-                ScMetaEntry::ScMetaV0(ScMetaV0 { key, .. }) => {
-                    key.to_string_lossy().contains(CONTRACT_META_SDK_KEY)
-                }
+        wasm_spec.meta.iter().find(|entry| match entry {
+            ScMetaEntry::ScMetaV0(ScMetaV0 { key, .. }) => {
+                key.to_string_lossy().contains(CONTRACT_META_SDK_KEY)
             }
         })
     } else {

--- a/cmd/soroban-cli/src/commands/contract/deploy.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy.rs
@@ -77,7 +77,6 @@ pub enum Error {
         wasm_hash: String,
         error: stellar_strkey::DecodeError,
     },
-    
     #[error("Must provide either --wasm or --wash-hash")]
     WasmNotProvided,
     #[error(transparent)]
@@ -159,7 +158,6 @@ impl Cmd {
         Ok(stellar_strkey::Contract(contract_id.0).to_string())
     }
 }
-
 
 fn build_create_contract_tx(
     hash: Hash,

--- a/cmd/soroban-cli/src/commands/contract/deploy.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy.rs
@@ -49,6 +49,7 @@ pub struct Cmd {
     #[command(flatten)]
     pub fee: crate::fee::Args,
     #[arg(long, short = 'i')]
+    /// Whether to ignore safety checks when deploying contracts
     pub ignore_checks: bool,
 }
 
@@ -205,7 +206,7 @@ fn get_contract_meta_sdk_version(wasm_spec: &utils::contract_spec::ContractSpec)
             }
         }
     }
-    return None;
+    None
 }
 
 fn build_create_contract_tx(

--- a/cmd/soroban-cli/src/commands/contract/deploy.rs
+++ b/cmd/soroban-cli/src/commands/contract/deploy.rs
@@ -10,8 +10,8 @@ use soroban_env_host::{
         AccountId, ContractExecutable, ContractIdPreimage, ContractIdPreimageFromAddress,
         CreateContractArgs, Error as XdrError, Hash, HashIdPreimage, HashIdPreimageContractId,
         HostFunction, InvokeHostFunctionOp, Memo, MuxedAccount, Operation, OperationBody,
-        Preconditions, PublicKey, ScAddress, SequenceNumber, Transaction,
-        TransactionExt, Uint256, VecM, WriteXdr,
+        Preconditions, PublicKey, ScAddress, SequenceNumber, Transaction, TransactionExt, Uint256,
+        VecM, WriteXdr,
     },
     HostError,
 };
@@ -100,7 +100,7 @@ impl Cmd {
                 wasm: wasm::Args { wasm: wasm.clone() },
                 config: self.config.clone(),
                 fee: self.fee.clone(),
-                ignore_checks: self.ignore_checks
+                ignore_checks: self.ignore_checks,
             }
             .run_and_get_hash()
             .await?;

--- a/cmd/soroban-cli/src/commands/contract/install.rs
+++ b/cmd/soroban-cli/src/commands/contract/install.rs
@@ -5,8 +5,8 @@ use std::num::ParseIntError;
 use clap::{command, Parser};
 use soroban_env_host::xdr::{
     Error as XdrError, Hash, HostFunction, InvokeHostFunctionOp, Memo, MuxedAccount, Operation,
-    OperationBody, Preconditions, ScMetaEntry, ScMetaV0, SequenceNumber, Transaction, TransactionExt, TransactionResult,
-    TransactionResultResult, Uint256, VecM,
+    OperationBody, Preconditions, ScMetaEntry, ScMetaV0, SequenceNumber, Transaction,
+    TransactionExt, TransactionResult, TransactionResultResult, Uint256, VecM,
 };
 
 use super::restore;

--- a/cmd/soroban-cli/src/commands/contract/install.rs
+++ b/cmd/soroban-cli/src/commands/contract/install.rs
@@ -74,7 +74,7 @@ impl Cmd {
             wasm: self.wasm.wasm.clone(),
             error: e,
         })?;
-        if let Some(rs_sdk_ver) = get_contract_meta_sdk_version(&wasm_spec) {
+        if let Some(rs_sdk_ver) = get_contract_meta_sdk_version(wasm_spec) {
             if rs_sdk_ver.contains("rc") && !self.ignore_checks {
                 return Err(Error::ContractCompiledWithReleaseCandidateSdk {
                     wasm: self.wasm.wasm.clone(),

--- a/cmd/soroban-cli/src/commands/contract/install.rs
+++ b/cmd/soroban-cli/src/commands/contract/install.rs
@@ -5,7 +5,7 @@ use std::num::ParseIntError;
 use clap::{command, Parser};
 use soroban_env_host::xdr::{
     Error as XdrError, Hash, HostFunction, InvokeHostFunctionOp, Memo, MuxedAccount, Operation,
-    OperationBody, Preconditions, SequenceNumber, Transaction, TransactionExt, TransactionResult,
+    OperationBody, Preconditions, ScMetaEntry, ScMetaV0, SequenceNumber, Transaction, TransactionExt, TransactionResult,
     TransactionResultResult, Uint256, VecM,
 };
 
@@ -13,6 +13,8 @@ use super::restore;
 use crate::key;
 use crate::rpc::{self, Client};
 use crate::{commands::config, utils, wasm};
+
+const CONTRACT_META_SDK_KEY: &str = "rssdkver";
 
 #[derive(Parser, Debug, Clone)]
 #[group(skip)]
@@ -23,6 +25,9 @@ pub struct Cmd {
     pub fee: crate::fee::Args,
     #[command(flatten)]
     pub wasm: wasm::Args,
+    #[arg(long, short = 'i', default_value = "false")]
+    /// Whether to ignore safety checks when deploying contracts
+    pub ignore_checks: bool,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -45,6 +50,16 @@ pub enum Error {
     UnexpectedSimulateTransactionResultSize { length: usize },
     #[error(transparent)]
     Restore(#[from] restore::Error),
+    #[error("cannot parse WASM file {wasm}: {error}")]
+    CannotParseWasm {
+        wasm: std::path::PathBuf,
+        error: wasm::Error,
+    },
+    #[error("the deployed smart contract {wasm} was built with Soroban Rust SDK v{version}, a release candidate version not intended for use with the Stellar Public Network. To deploy anyway, use --ignore-checks")]
+    ContractCompiledWithReleaseCandidateSdk {
+        wasm: std::path::PathBuf,
+        version: String,
+    },
 }
 
 impl Cmd {
@@ -55,6 +70,20 @@ impl Cmd {
     }
 
     pub async fn run_and_get_hash(&self) -> Result<Hash, Error> {
+        let wasm_spec = &self.wasm.parse().map_err(|e| Error::CannotParseWasm {
+            wasm: self.wasm.wasm.clone(),
+            error: e,
+        })?;
+        if let Some(rs_sdk_ver) = get_contract_meta_sdk_version(&wasm_spec) {
+            if rs_sdk_ver.contains("rc") && !self.ignore_checks {
+                return Err(Error::ContractCompiledWithReleaseCandidateSdk {
+                    wasm: self.wasm.wasm.clone(),
+                    version: rs_sdk_ver,
+                });
+            } else if rs_sdk_ver.contains("rc") {
+                tracing::warn!("the deployed smart contract {path} was built with Soroban Rust SDK v{rs_sdk_ver}, a release candidate version not intended for use with the Stellar Public Network", path = self.wasm.wasm.display());
+            }
+        }
         self.run_against_rpc_server(&self.wasm.read()?).await
     }
 
@@ -115,6 +144,26 @@ impl Cmd {
 
         Ok(hash)
     }
+}
+
+fn get_contract_meta_sdk_version(wasm_spec: &utils::contract_spec::ContractSpec) -> Option<String> {
+    let rs_sdk_version_option = if let Some(_meta) = &wasm_spec.meta_base64 {
+        wasm_spec.meta.iter().find(|entry| match entry {
+            ScMetaEntry::ScMetaV0(ScMetaV0 { key, .. }) => {
+                key.to_string_lossy().contains(CONTRACT_META_SDK_KEY)
+            }
+        })
+    } else {
+        None
+    };
+    if let Some(rs_sdk_version_entry) = &rs_sdk_version_option {
+        match rs_sdk_version_entry {
+            ScMetaEntry::ScMetaV0(ScMetaV0 { val, .. }) => {
+                return Some(val.to_string_lossy());
+            }
+        }
+    }
+    None
 }
 
 pub(crate) fn build_install_contract_code_tx(

--- a/cmd/soroban-rpc/internal/test/cli_test.go
+++ b/cmd/soroban-rpc/internal/test/cli_test.go
@@ -77,13 +77,13 @@ func TestCLIContractInstallAndDeploy(t *testing.T) {
 	runSuccessfulCLICmd(t, "contract install --wasm "+helloWorldContractPath)
 	wasm := getHelloWorldContract(t)
 	contractHash := xdr.Hash(sha256.Sum256(wasm))
-	output := runSuccessfulCLICmd(t, fmt.Sprintf("contract deploy --salt %s --wasm-hash %s", hex.EncodeToString(testSalt[:]), contractHash.HexString()))
+	output := runSuccessfulCLICmd(t, fmt.Sprintf("contract deploy --salt %s --wasm-hash %s --ignore-checks", hex.EncodeToString(testSalt[:]), contractHash.HexString()))
 	outputsContractIDInLastLine(t, output)
 }
 
 func TestCLIContractDeploy(t *testing.T) {
 	NewCLITest(t)
-	output := runSuccessfulCLICmd(t, fmt.Sprintf("contract deploy --salt %s --wasm %s", hex.EncodeToString(testSalt[:]), helloWorldContractPath))
+	output := runSuccessfulCLICmd(t, fmt.Sprintf("contract deploy --salt %s --wasm %s --ignore-checks", hex.EncodeToString(testSalt[:]), helloWorldContractPath))
 	outputsContractIDInLastLine(t, output)
 }
 
@@ -103,14 +103,14 @@ func outputsContractIDInLastLine(t *testing.T, output string) {
 
 func TestCLIContractDeployAndInvoke(t *testing.T) {
 	NewCLITest(t)
-	contractID := runSuccessfulCLICmd(t, fmt.Sprintf("contract deploy --salt=%s --wasm %s", hex.EncodeToString(testSalt[:]), helloWorldContractPath))
+	contractID := runSuccessfulCLICmd(t, fmt.Sprintf("contract deploy --salt=%s --wasm %s --ignore-checks", hex.EncodeToString(testSalt[:]), helloWorldContractPath))
 	output := runSuccessfulCLICmd(t, fmt.Sprintf("contract invoke --id %s -- hello --world=world", contractID))
 	require.Contains(t, output, `["Hello","world"]`)
 }
 
 func TestCLIRestorePreamble(t *testing.T) {
 	test := NewCLITest(t)
-	strkeyContractID := runSuccessfulCLICmd(t, fmt.Sprintf("contract deploy --salt=%s --wasm %s", hex.EncodeToString(testSalt[:]), helloWorldContractPath))
+	strkeyContractID := runSuccessfulCLICmd(t, fmt.Sprintf("contract deploy --salt=%s --wasm %s --ignore-checks", hex.EncodeToString(testSalt[:]), helloWorldContractPath))
 	count := runSuccessfulCLICmd(t, fmt.Sprintf("contract invoke --id %s -- inc", strkeyContractID))
 	require.Equal(t, "1", count)
 	count = runSuccessfulCLICmd(t, fmt.Sprintf("contract invoke --id %s -- inc", strkeyContractID))
@@ -128,7 +128,7 @@ func TestCLIRestorePreamble(t *testing.T) {
 
 func TestCLIExtend(t *testing.T) {
 	test := NewCLITest(t)
-	strkeyContractID := runSuccessfulCLICmd(t, fmt.Sprintf("contract deploy --salt=%s --wasm %s", hex.EncodeToString(testSalt[:]), helloWorldContractPath))
+	strkeyContractID := runSuccessfulCLICmd(t, fmt.Sprintf("contract deploy --salt=%s --wasm %s --ignore-checks", hex.EncodeToString(testSalt[:]), helloWorldContractPath))
 	count := runSuccessfulCLICmd(t, fmt.Sprintf("contract invoke --id %s -- inc", strkeyContractID))
 	require.Equal(t, "1", count)
 
@@ -152,7 +152,7 @@ func TestCLIExtend(t *testing.T) {
 }
 func TestCLIExtendTooLow(t *testing.T) {
 	test := NewCLITest(t)
-	strkeyContractID := runSuccessfulCLICmd(t, fmt.Sprintf("contract deploy --salt=%s --wasm %s", hex.EncodeToString(testSalt[:]), helloWorldContractPath))
+	strkeyContractID := runSuccessfulCLICmd(t, fmt.Sprintf("contract deploy --salt=%s --wasm %s --ignore-checks", hex.EncodeToString(testSalt[:]), helloWorldContractPath))
 	count := runSuccessfulCLICmd(t, fmt.Sprintf("contract invoke --id %s -- inc", strkeyContractID))
 	require.Equal(t, "1", count)
 
@@ -174,7 +174,7 @@ func TestCLIExtendTooLow(t *testing.T) {
 
 func TestCLIExtendTooHigh(t *testing.T) {
 	test := NewCLITest(t)
-	strkeyContractID := runSuccessfulCLICmd(t, fmt.Sprintf("contract deploy --salt=%s --wasm %s", hex.EncodeToString(testSalt[:]), helloWorldContractPath))
+	strkeyContractID := runSuccessfulCLICmd(t, fmt.Sprintf("contract deploy --salt=%s --wasm %s --ignore-checks", hex.EncodeToString(testSalt[:]), helloWorldContractPath))
 	count := runSuccessfulCLICmd(t, fmt.Sprintf("contract invoke --id %s -- inc", strkeyContractID))
 	require.Equal(t, "1", count)
 
@@ -193,7 +193,7 @@ func TestCLIExtendTooHigh(t *testing.T) {
 
 func TestCLIRestore(t *testing.T) {
 	test := NewCLITest(t)
-	strkeyContractID := runSuccessfulCLICmd(t, fmt.Sprintf("contract deploy --salt=%s --wasm %s", hex.EncodeToString(testSalt[:]), helloWorldContractPath))
+	strkeyContractID := runSuccessfulCLICmd(t, fmt.Sprintf("contract deploy --salt=%s --wasm %s --ignore-checks", hex.EncodeToString(testSalt[:]), helloWorldContractPath))
 	count := runSuccessfulCLICmd(t, fmt.Sprintf("contract invoke --id %s -- inc", strkeyContractID))
 	require.Equal(t, "1", count)
 

--- a/cmd/soroban-rpc/internal/test/cli_test.go
+++ b/cmd/soroban-rpc/internal/test/cli_test.go
@@ -66,7 +66,7 @@ func TestCLIWrapNative(t *testing.T) {
 
 func TestCLIContractInstall(t *testing.T) {
 	NewCLITest(t)
-	output := runSuccessfulCLICmd(t, "contract install --wasm "+helloWorldContractPath)
+	output := runSuccessfulCLICmd(t, fmt.Sprintf("contract install --wasm %s --ignore-checks", helloWorldContractPath))
 	wasm := getHelloWorldContract(t)
 	contractHash := xdr.Hash(sha256.Sum256(wasm))
 	require.Contains(t, output, contractHash.HexString())
@@ -74,7 +74,7 @@ func TestCLIContractInstall(t *testing.T) {
 
 func TestCLIContractInstallAndDeploy(t *testing.T) {
 	NewCLITest(t)
-	runSuccessfulCLICmd(t, "contract install --wasm "+helloWorldContractPath)
+	runSuccessfulCLICmd(t, fmt.Sprintf("contract install --wasm %s --ignore-checks", helloWorldContractPath))
 	wasm := getHelloWorldContract(t)
 	contractHash := xdr.Hash(sha256.Sum256(wasm))
 	output := runSuccessfulCLICmd(t, fmt.Sprintf("contract deploy --salt %s --wasm-hash %s --ignore-checks", hex.EncodeToString(testSalt[:]), contractHash.HexString()))

--- a/docs/soroban-cli-full-docs.md
+++ b/docs/soroban-cli-full-docs.md
@@ -285,6 +285,8 @@ Deploy a contract
   Default value: `100`
 * `-i`, `--ignore-checks` — Whether to ignore safety checks when deploying contracts
 
+  Default value: `false`
+
 
 
 ## `soroban contract fetch`
@@ -350,6 +352,9 @@ Install a WASM file to the ledger without creating a contract instance
 
   Default value: `100`
 * `--wasm <WASM>` — Path to wasm binary
+* `-i`, `--ignore-checks` — Whether to ignore safety checks when deploying contracts
+
+  Default value: `false`
 
 
 

--- a/docs/soroban-cli-full-docs.md
+++ b/docs/soroban-cli-full-docs.md
@@ -283,6 +283,7 @@ Deploy a contract
 * `--fee <FEE>` — fee amount for transaction, in stroops. 1 stroop = 0.0000001 xlm
 
   Default value: `100`
+* `-i`, `--ignore-checks` — Whether to ignore safety checks when deploying contracts
 
 
 


### PR DESCRIPTION
### What

This PR adds a check to the `soroban contract deploy` command if the Rust SDK version used to compile it is a release candidate SDK version.

If the new flag `--ignore-checks` is present, a warning is displayed. Otherwise, the command will return an error.

### Why

Release candidate versions of the Soroban Rust SDK are not suitable for use with the Stellar Public Network. We should at the very least warn users if they are deploying contracts compiled with release candidate SDK versions.

Closes #941 
