### PR TITLE
rpc: preflight: enable debug by default now that there is a debug budget

### DIFF
--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -112,7 +112,7 @@ jobs:
     env:
       SOROBAN_RPC_INTEGRATION_TESTS_ENABLED: true
       SOROBAN_RPC_INTEGRATION_TESTS_CAPTIVE_CORE_BIN: /usr/bin/stellar-core
-      PROTOCOL_20_CORE_DEBIAN_PKG_VERSION: 19.14.1-1529.fcbbad4ce.focal
+      PROTOCOL_20_CORE_DEBIAN_PKG_VERSION: 19.14.1-1547.f2d06fbce.focal
     steps:
       - uses: actions/checkout@v3
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2453,6 +2453,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "soroban-builtin-sdk-macros"
+version = "20.0.0-rc2"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=2674d867d7c6aa4212abab05ff30e5804ff1db90#2674d867d7c6aa4212abab05ff30e5804ff1db90"
+dependencies = [
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
 name = "soroban-cli"
 version = "20.0.0-rc4"
 dependencies = [
@@ -2518,7 +2529,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "20.0.0-rc2"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=91f44778389490ad863d61a8a90ac9875ba6d8fd#91f44778389490ad863d61a8a90ac9875ba6d8fd"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=2674d867d7c6aa4212abab05ff30e5804ff1db90#2674d867d7c6aa4212abab05ff30e5804ff1db90"
 dependencies = [
  "arbitrary",
  "crate-git-revision 0.0.6",
@@ -2535,7 +2546,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "20.0.0-rc2"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=91f44778389490ad863d61a8a90ac9875ba6d8fd#91f44778389490ad863d61a8a90ac9875ba6d8fd"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=2674d867d7c6aa4212abab05ff30e5804ff1db90#2674d867d7c6aa4212abab05ff30e5804ff1db90"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -2544,9 +2555,10 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "20.0.0-rc2"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=91f44778389490ad863d61a8a90ac9875ba6d8fd#91f44778389490ad863d61a8a90ac9875ba6d8fd"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=2674d867d7c6aa4212abab05ff30e5804ff1db90#2674d867d7c6aa4212abab05ff30e5804ff1db90"
 dependencies = [
  "backtrace",
+ "curve25519-dalek 4.1.1",
  "ed25519-dalek 2.0.0",
  "getrandom",
  "k256",
@@ -2557,8 +2569,8 @@ dependencies = [
  "rand_chacha",
  "sha2 0.10.7",
  "sha3",
+ "soroban-builtin-sdk-macros",
  "soroban-env-common",
- "soroban-native-sdk-macros",
  "soroban-wasmi",
  "static_assertions",
  "stellar-strkey 0.0.7 (git+https://github.com/stellar/rs-stellar-strkey?rev=e6ba45c60c16de28c7522586b80ed0150157df73)",
@@ -2567,7 +2579,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "20.0.0-rc2"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=91f44778389490ad863d61a8a90ac9875ba6d8fd#91f44778389490ad863d61a8a90ac9875ba6d8fd"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=2674d867d7c6aa4212abab05ff30e5804ff1db90#2674d867d7c6aa4212abab05ff30e5804ff1db90"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
@@ -2585,7 +2597,7 @@ version = "20.0.0-rc4"
 [[package]]
 name = "soroban-ledger-snapshot"
 version = "20.0.0-rc2"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=729ed3ac5fe8600a3245d5816eadd3c95ab2eb54#729ed3ac5fe8600a3245d5816eadd3c95ab2eb54"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=fb422beae0d4944dc0e83559a8940b31f5ebd89d#fb422beae0d4944dc0e83559a8940b31f5ebd89d"
 dependencies = [
  "serde",
  "serde_json",
@@ -2595,20 +2607,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "soroban-native-sdk-macros"
-version = "20.0.0-rc2"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=91f44778389490ad863d61a8a90ac9875ba6d8fd#91f44778389490ad863d61a8a90ac9875ba6d8fd"
-dependencies = [
- "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 2.0.37",
-]
-
-[[package]]
 name = "soroban-sdk"
 version = "20.0.0-rc2"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=729ed3ac5fe8600a3245d5816eadd3c95ab2eb54#729ed3ac5fe8600a3245d5816eadd3c95ab2eb54"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=fb422beae0d4944dc0e83559a8940b31f5ebd89d#fb422beae0d4944dc0e83559a8940b31f5ebd89d"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -2625,7 +2626,7 @@ dependencies = [
 [[package]]
 name = "soroban-sdk-macros"
 version = "20.0.0-rc2"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=729ed3ac5fe8600a3245d5816eadd3c95ab2eb54#729ed3ac5fe8600a3245d5816eadd3c95ab2eb54"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=fb422beae0d4944dc0e83559a8940b31f5ebd89d#fb422beae0d4944dc0e83559a8940b31f5ebd89d"
 dependencies = [
  "crate-git-revision 0.0.6",
  "darling",
@@ -2644,7 +2645,7 @@ dependencies = [
 [[package]]
 name = "soroban-spec"
 version = "20.0.0-rc2"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=729ed3ac5fe8600a3245d5816eadd3c95ab2eb54#729ed3ac5fe8600a3245d5816eadd3c95ab2eb54"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=fb422beae0d4944dc0e83559a8940b31f5ebd89d#fb422beae0d4944dc0e83559a8940b31f5ebd89d"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -2669,7 +2670,7 @@ dependencies = [
 [[package]]
 name = "soroban-spec-rust"
 version = "20.0.0-rc2"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=729ed3ac5fe8600a3245d5816eadd3c95ab2eb54#729ed3ac5fe8600a3245d5816eadd3c95ab2eb54"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=fb422beae0d4944dc0e83559a8940b31f5ebd89d#fb422beae0d4944dc0e83559a8940b31f5ebd89d"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,18 +16,18 @@ version = "20.0.0-rc4"
 [workspace.dependencies.soroban-env-host]
 version = "20.0.0-rc2"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "91f44778389490ad863d61a8a90ac9875ba6d8fd"
+rev = "2674d867d7c6aa4212abab05ff30e5804ff1db90"
 
 [workspace.dependencies.soroban-spec]
 version = "20.0.0-rc2"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "729ed3ac5fe8600a3245d5816eadd3c95ab2eb54"
+rev = "fb422beae0d4944dc0e83559a8940b31f5ebd89d"
 # path = "../rs-soroban-sdk/soroban-spec"
 
 [workspace.dependencies.soroban-spec-rust]
 version = "20.0.0-rc2"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "729ed3ac5fe8600a3245d5816eadd3c95ab2eb54"
+rev = "fb422beae0d4944dc0e83559a8940b31f5ebd89d"
 # path = "../rs-soroban-sdk/soroban-spec-rust"
 
 [workspace.dependencies.soroban-spec-json]
@@ -45,12 +45,12 @@ path = "./cmd/crates/soroban-spec-tools"
 [workspace.dependencies.soroban-sdk]
 version = "20.0.0-rc2"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "729ed3ac5fe8600a3245d5816eadd3c95ab2eb54"
+rev = "fb422beae0d4944dc0e83559a8940b31f5ebd89d"
 
 [workspace.dependencies.soroban-ledger-snapshot]
 version = "20.0.0-rc2"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "729ed3ac5fe8600a3245d5816eadd3c95ab2eb54"
+rev = "fb422beae0d4944dc0e83559a8940b31f5ebd89d"
 
 [workspace.dependencies.soroban-cli]
 version = "20.0.0-rc4"

--- a/cmd/soroban-rpc/internal/config/options.go
+++ b/cmd/soroban-rpc/internal/config/options.go
@@ -278,7 +278,7 @@ func (cfg *Config) options() ConfigOptions {
 			Name:         "preflight-enable-debug",
 			Usage:        "Enable debug information in preflighting (provides more detailed errors). It should not be enabled in production deployments.",
 			ConfigKey:    &cfg.PreflightEnableDebug,
-			DefaultValue: false,
+			DefaultValue: true,
 		},
 		{
 			TomlKey:      strutils.KebabToConstantCase("request-backlog-global-queue-limit"),

--- a/cmd/soroban-rpc/internal/test/docker-compose.yml
+++ b/cmd/soroban-rpc/internal/test/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     # Note: Please keep the image pinned to an immutable tag matching the Captive Core version.
     #       This avoids implicit updates which break compatibility between
     #       the Core container and captive core.
-    image: ${CORE_IMAGE:-2opremio/stellar-core:19.14.1-1529.fcbbad4ce.focal}
+    image: ${CORE_IMAGE:-stellar/stellar-core:19.14.1-1547.f2d06fbce.focal}
     depends_on:
       - core-postgres
     restart: on-failure

--- a/cmd/soroban-rpc/lib/preflight/Cargo.toml
+++ b/cmd/soroban-rpc/lib/preflight/Cargo.toml
@@ -12,5 +12,5 @@ base64 = { workspace = true }
 thiserror = { workspace = true }
 libc = "0.2.147"
 sha2 = { workspace = true }
-soroban-env-host = { workspace = true }
+soroban-env-host = { workspace = true,  features = ["recording_auth"]}
 rand = "0.8.5"


### PR DESCRIPTION
### What

Update Rust/Core dependencies and enable preflight debug by default.

### Why

Debug was disabled by default before since there wasn't a budget for it. Now (in the latest rs-env Rust library updates there is)

### Known limitations

NA
