### PR TITLE
Fix/typescript bindings

### DIFF
--- a/cmd/crates/soroban-spec-typescript/src/project_template/package.json
+++ b/cmd/crates/soroban-spec-typescript/src/project_template/package.json
@@ -4,7 +4,7 @@
     "dependencies": {
         "@stellar/freighter-api": "1.5.1",
         "buffer": "6.0.3",
-        "soroban-client": "1.0.0-beta.2"
+        "soroban-client": "1.0.0-beta.3"
     },
     "scripts": {
         "build": "node ./scripts/build.mjs"

--- a/cmd/crates/soroban-spec-typescript/src/project_template/src/invoke.ts
+++ b/cmd/crates/soroban-spec-typescript/src/project_template/src/invoke.ts
@@ -82,7 +82,7 @@ export async function invoke<R extends ResponseTypes, T = string>({
   contractId,
   wallet,
 }: InvokeArgs<R, T>): Promise<T | string | SomeRpcResponse> {
-  wallet = wallet ?? (await import("@stellar/freighter-api"));
+  wallet = wallet ?? (await import("@stellar/freighter-api")).default;
   let parse = parseResultXdr;
   const server = new SorobanClient.Server(rpcUrl, {
     allowHttp: rpcUrl.startsWith("http://"),

--- a/cmd/crates/soroban-spec-typescript/src/project_template/src/invoke.ts
+++ b/cmd/crates/soroban-spec-typescript/src/project_template/src/invoke.ts
@@ -17,6 +17,7 @@ import type {
 
 export type Tx = Transaction<Memo<MemoType>, Operation[]>;
 
+export class SendFailedError extends Error { }
 /**
  * Get account details from the Soroban network for the publicKey currently
  * selected in Freighter. If not connected to Freighter, return null.
@@ -162,7 +163,11 @@ export async function invoke<R extends ResponseTypes, T = string>({
   if ("returnValue" in raw) return parse(raw.returnValue!);
 
   // otherwise, it returned the result of `sendTransaction`
-  if ("errorResultXdr" in raw) return parse(raw.errorResultXdr!);
+  if ("errorResult" in raw) {
+    throw new SendFailedError(
+      `errorResult.result(): ${JSON.stringify(raw.errorResult?.result())}`
+    )
+  }
 
   // if neither of these are present, something went wrong
   console.error("Don't know how to parse result! Returning full RPC response.");


### PR DESCRIPTION
### What
* update the `@stellar/freighter-api` import to use the `default` object if there is no wallet connected yet
* update the soroban-client version to `1.0.0-beta.3` for the cli typescript bindings generation

### Why

* update the `@stellar/freighter-api` import to use the `default`: 
    * Before this change, I was seeing an error when trying to use the generated bindings in the [Getting Started demo app](https://soroban.stellar.org/docs/getting-started/create-an-app#call-the-contract-from-the-frontend) when a wallet isn't connected yet:
`error   wallet.isConnected is not a function`

    * `@stellar/freighter-api` returns a null prototype with a default that has the expected methods, `isConnected`, etc. This should be sufficient for view calls, so this change just uses the `default` until later in the invoke method, when an account is needed (for change calls).

* update the soroban-client version to `1.0.0-beta.3` for the cli typescript bindings generation: the one update that seemed necessary to make this upgrade work was to change the `errorResultXdr` from `sendTransaction` result to `errorResult`.

### Known limitations

N/A
