### PR TITLE
chore: don't force rebuild during build-test-wasms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: check build test
+all: build test
 
 export RUSTFLAGS=-Dwarnings -Dclippy::all -Dclippy::pedantic
 
@@ -61,7 +61,7 @@ build: build_rust build_go
 build-libpreflight: Cargo.lock
 	cd cmd/soroban-rpc/lib/preflight && cargo build --target $(CARGO_BUILD_TARGET) --profile release-with-panic-unwind
 
-build-test-wasms: Cargo.lock
+build-test-wasms:
 	cargo build --package 'test_*' --profile test-wasms --target wasm32-unknown-unknown
 
 build-test: build-test-wasms install_rust


### PR DESCRIPTION
### What

Remove the `Cargo.lock` prereq from the `build-test-wasms` task and the `check` from the `all:` directive

### Why

I don't see a good reason to include these, and they cause most tasks to take significantly longer to run. If there's no strong reason to include them, then it would be nice to save the build time.

### Known limitations

These were originally added here https://github.com/stellar/soroban-tools/pull/251 and here https://github.com/stellar/soroban-tools/commit/0c51782cb8ee9cf4e7b019e4edb807b3c52d963d. I don't see a description of why these particular changes were added.