### PR TITLE
soroban-rpc: Force On-Disk Mode by Removing --captive-core-use-db

### DIFF
--- a/cmd/soroban-rpc/internal/config/config.go
+++ b/cmd/soroban-rpc/internal/config/config.go
@@ -15,7 +15,6 @@ type Config struct {
 	Strict bool
 
 	StellarCoreURL         string
-	CaptiveCoreUseDB       bool
 	CaptiveCoreStoragePath string
 	StellarCoreBinaryPath  string
 	CaptiveCoreConfigPath  string

--- a/cmd/soroban-rpc/internal/config/options.go
+++ b/cmd/soroban-rpc/internal/config/options.go
@@ -175,12 +175,6 @@ func (cfg *Config) options() ConfigOptions {
 			},
 		},
 		{
-			Name:         "captive-core-use-db",
-			Usage:        "informs captive core to use on disk mode. the db will by default be created in current runtime directory of soroban-rpc, unless DATABASE=<path> setting is present in captive core config file.",
-			ConfigKey:    &cfg.CaptiveCoreUseDB,
-			DefaultValue: false,
-		},
-		{
 			Name:      "history-archive-urls",
 			Usage:     "comma-separated list of stellar history archives to connect with",
 			ConfigKey: &cfg.HistoryArchiveURLs,

--- a/cmd/soroban-rpc/internal/config/test.soroban.rpc.config
+++ b/cmd/soroban-rpc/internal/config/test.soroban.rpc.config
@@ -4,7 +4,6 @@ NETWORK_PASSPHRASE="Standalone Network ; February 2017"
 STELLAR_CORE_URL="http://localhost:11626"
 CAPTIVE_CORE_CONFIG_PATH="/opt/stellar/soroban-rpc/etc/stellar-captive-core.cfg"
 CAPTIVE_CORE_STORAGE_PATH="/opt/stellar/soroban-rpc/captive-core"
-CAPTIVE_CORE_USE_DB=true
 STELLAR_CORE_BINARY_PATH="/usr/bin/stellar-core"
 HISTORY_ARCHIVE_URLS=["http://localhost:1570"]
 DB_PATH="/opt/stellar/soroban-rpc/rpc_db.sqlite"

--- a/cmd/soroban-rpc/internal/config/toml_test.go
+++ b/cmd/soroban-rpc/internal/config/toml_test.go
@@ -31,7 +31,6 @@ func TestBasicTomlReading(t *testing.T) {
 	// Check the fields got read correctly
 	assert.Equal(t, []string{"http://history-futurenet.stellar.org"}, cfg.HistoryArchiveURLs)
 	assert.Equal(t, network.FutureNetworkPassphrase, cfg.NetworkPassphrase)
-	assert.Equal(t, true, cfg.CaptiveCoreUseDB)
 	assert.Equal(t, "/etc/stellar/soroban-rpc", cfg.CaptiveCoreStoragePath)
 	assert.Equal(t, "/etc/stellar/soroban-rpc/captive-core.cfg", cfg.CaptiveCoreConfigPath)
 }

--- a/cmd/soroban-rpc/internal/config/toml_test.go
+++ b/cmd/soroban-rpc/internal/config/toml_test.go
@@ -19,7 +19,6 @@ NETWORK_PASSPHRASE = "Test SDF Future Network ; October 2022"
 
 # testing comments work ok
 STELLAR_CORE_BINARY_PATH = "/usr/bin/stellar-core"
-CAPTIVE_CORE_USE_DB = true
 CAPTIVE_CORE_STORAGE_PATH = "/etc/stellar/soroban-rpc"
 CAPTIVE_CORE_CONFIG_PATH = "/etc/stellar/soroban-rpc/captive-core.cfg"
 `

--- a/cmd/soroban-rpc/internal/daemon/daemon.go
+++ b/cmd/soroban-rpc/internal/daemon/daemon.go
@@ -105,7 +105,7 @@ func newCaptiveCore(cfg *config.Config, logger *supportlog.Entry) (*ledgerbacken
 		HistoryArchiveURLs:             cfg.HistoryArchiveURLs,
 		NetworkPassphrase:              cfg.NetworkPassphrase,
 		Strict:                         true,
-		UseDB:                          cfg.CaptiveCoreUseDB,
+		UseDB:                          true,
 		EnforceSorobanDiagnosticEvents: true,
 	}
 	captiveCoreToml, err := ledgerbackend.NewCaptiveCoreTomlFromFile(cfg.CaptiveCoreConfigPath, captiveCoreTomlParams)
@@ -122,7 +122,7 @@ func newCaptiveCore(cfg *config.Config, logger *supportlog.Entry) (*ledgerbacken
 		Log:                 logger.WithField("subservice", "stellar-core"),
 		Toml:                captiveCoreToml,
 		UserAgent:           "captivecore",
-		UseDB:               cfg.CaptiveCoreUseDB,
+		UseDB:               true,
 	}
 	return ledgerbackend.NewCaptive(captiveConfig)
 

--- a/cmd/soroban-rpc/internal/test/integration.go
+++ b/cmd/soroban-rpc/internal/test/integration.go
@@ -121,7 +121,6 @@ func (i *Test) launchDaemon(coreBinaryPath string) {
 	config.CaptiveCoreConfigPath = path.Join(i.composePath, "captive-core-integration-tests.cfg")
 	config.CaptiveCoreStoragePath = i.t.TempDir()
 	config.CaptiveCoreHTTPPort = 0
-	config.CaptiveCoreUseDB = true
 	config.FriendbotURL = friendbotURL
 	config.NetworkPassphrase = StandaloneNetworkPassphrase
 	config.HistoryArchiveURLs = []string{"http://localhost:1570"}


### PR DESCRIPTION
### What

This PR removes the `--captive-core-use-db` flag and forces on-disk mode.

### Why

Eventually, the core working-state size will grow, and eventually get too big for RAM. This means in-memory captive-core will not work long-term. Therefore, we should force users to use on-disk mode.
