### PR TITLE
cli: Appease new clippy version

### DIFF
--- a/cmd/crates/soroban-spec-typescript/src/lib.rs
+++ b/cmd/crates/soroban-spec-typescript/src/lib.rs
@@ -192,12 +192,12 @@ pub fn entry_to_ts(entry: &Entry) -> String {
                 output = format!(r#"return {output};"#);
             };
             let parse_result_xdr = if return_type == "void" {
-                r#"parseResultXdr: () => {}"#.to_owned()
+                r"parseResultXdr: () => {}".to_owned()
             } else {
                 format!(
-                    r#"parseResultXdr: (xdr): {return_type} => {{
+                    r"parseResultXdr: (xdr): {return_type} => {{
                 {output}
-            }}"#
+            }}"
                 )
             };
             let js_name = jsify_name(name);

--- a/cmd/crates/soroban-test/tests/it/arg_parsing.rs
+++ b/cmd/crates/soroban-test/tests/it/arg_parsing.rs
@@ -90,7 +90,7 @@ fn parse_i256() {
 
 #[test]
 fn parse_bytes() {
-    let b = from_string_primitive(r#"beefface"#, &ScSpecTypeDef::Bytes).unwrap();
+    let b = from_string_primitive(r"beefface", &ScSpecTypeDef::Bytes).unwrap();
     assert_eq!(
         b,
         ScVal::Bytes(ScBytes(vec![0xbe, 0xef, 0xfa, 0xce].try_into().unwrap()))
@@ -100,7 +100,7 @@ fn parse_bytes() {
 
 #[test]
 fn parse_bytes_when_hex_is_all_numbers() {
-    let b = from_string_primitive(r#"4554"#, &ScSpecTypeDef::Bytes).unwrap();
+    let b = from_string_primitive(r"4554", &ScSpecTypeDef::Bytes).unwrap();
     assert_eq!(
         b,
         ScVal::Bytes(ScBytes(vec![0x45, 0x54].try_into().unwrap()))
@@ -111,7 +111,7 @@ fn parse_bytes_when_hex_is_all_numbers() {
 #[test]
 fn parse_bytesn() {
     let b = from_string_primitive(
-        r#"beefface"#,
+        r"beefface",
         &ScSpecTypeDef::BytesN(ScSpecTypeBytesN { n: 4 }),
     )
     .unwrap();
@@ -124,8 +124,8 @@ fn parse_bytesn() {
 
 #[test]
 fn parse_bytesn_when_hex_is_all_numbers() {
-    let b = from_string_primitive(r#"4554"#, &ScSpecTypeDef::BytesN(ScSpecTypeBytesN { n: 2 }))
-        .unwrap();
+    let b =
+        from_string_primitive(r"4554", &ScSpecTypeDef::BytesN(ScSpecTypeBytesN { n: 2 })).unwrap();
     assert_eq!(
         b,
         ScVal::Bytes(ScBytes(vec![0x45, 0x54].try_into().unwrap()))


### PR DESCRIPTION
It was complaining about some unnecessary hashes around raw strings.

See https://rust-lang.github.io/rust-clippy/master/index.html#needless_raw_string_hashes