### PR TITLE
rpc: unify all ledger sequence types to uint32 and stop stringyfying integers < 53-bits wide

### DIFF
--- a/cmd/soroban-cli/src/rpc/mod.rs
+++ b/cmd/soroban-cli/src/rpc/mod.rs
@@ -111,10 +111,7 @@ pub struct SendTransactionResponse {
         default
     )]
     pub error_result_xdr: Option<String>,
-    #[serde(
-        rename = "latestLedger",
-        deserialize_with = "deserialize_number_from_string"
-    )]
+    #[serde(rename = "latestLedger")]
     pub latest_ledger: u32,
     #[serde(
         rename = "latestLedgerCloseTime",
@@ -174,10 +171,7 @@ impl TryInto<GetTransactionResponse> for GetTransactionResponseRaw {
 pub struct LedgerEntryResult {
     pub key: String,
     pub xdr: String,
-    #[serde(
-        rename = "lastModifiedLedgerSeq",
-        deserialize_with = "deserialize_number_from_string"
-    )]
+    #[serde(rename = "lastModifiedLedgerSeq")]
     pub last_modified_ledger: u32,
     #[serde(
         rename = "liveUntilLedgerSeq",
@@ -191,10 +185,7 @@ pub struct LedgerEntryResult {
 #[derive(serde::Deserialize, serde::Serialize, Debug)]
 pub struct GetLedgerEntriesResponse {
     pub entries: Option<Vec<LedgerEntryResult>>,
-    #[serde(
-        rename = "latestLedger",
-        deserialize_with = "deserialize_number_from_string"
-    )]
+    #[serde(rename = "latestLedger")]
     pub latest_ledger: i64,
 }
 
@@ -207,20 +198,14 @@ pub struct GetNetworkResponse {
     )]
     pub friendbot_url: Option<String>,
     pub passphrase: String,
-    #[serde(
-        rename = "protocolVersion",
-        deserialize_with = "deserialize_number_from_string"
-    )]
+    #[serde(rename = "protocolVersion")]
     pub protocol_version: u32,
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug)]
 pub struct GetLatestLedgerResponse {
     pub id: String,
-    #[serde(
-        rename = "protocolVersion",
-        deserialize_with = "deserialize_number_from_string"
-    )]
+    #[serde(rename = "protocolVersion")]
     pub protocol_version: u32,
     pub sequence: u32,
 }
@@ -278,10 +263,7 @@ pub struct SimulateTransactionResponse {
         default
     )]
     pub restore_preamble: Option<RestorePreamble>,
-    #[serde(
-        rename = "latestLedger",
-        deserialize_with = "deserialize_number_from_string"
-    )]
+    #[serde(rename = "latestLedger")]
     pub latest_ledger: u32,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub error: Option<String>,
@@ -333,10 +315,7 @@ pub struct RestorePreamble {
 pub struct GetEventsResponse {
     #[serde(deserialize_with = "deserialize_default_from_null")]
     pub events: Vec<Event>,
-    #[serde(
-        rename = "latestLedger",
-        deserialize_with = "deserialize_number_from_string"
-    )]
+    #[serde(rename = "latestLedger")]
     pub latest_ledger: u32,
 }
 
@@ -963,7 +942,7 @@ mod tests {
  "minResourceFee": "100000000",
  "cost": { "cpuInsns": "1000", "memBytes": "1000" },
  "transactionData": "",
- "latestLedger": "1234"
+ "latestLedger": 1234
         }"#;
 
         let resp: SimulateTransactionResponse = serde_json::from_str(s).unwrap();
@@ -973,7 +952,7 @@ mod tests {
     #[test]
     fn simulation_transaction_response_parsing_mostly_empty() {
         let s = r#"{
- "latestLedger": "1234"
+ "latestLedger": 1234
         }"#;
 
         let resp: SimulateTransactionResponse = serde_json::from_str(s).unwrap();

--- a/cmd/soroban-rpc/internal/methods/get_events.go
+++ b/cmd/soroban-rpc/internal/methods/get_events.go
@@ -68,7 +68,7 @@ func (e eventTypeSet) matches(event xdr.ContractEvent) bool {
 
 type EventInfo struct {
 	EventType                string   `json:"type"`
-	Ledger                   int32    `json:"ledger,string"`
+	Ledger                   int32    `json:"ledger"`
 	LedgerClosedAt           string   `json:"ledgerClosedAt"`
 	ContractID               string   `json:"contractId"`
 	ID                       string   `json:"id"`
@@ -79,7 +79,7 @@ type EventInfo struct {
 }
 
 type GetEventsRequest struct {
-	StartLedger int32              `json:"startLedger,string,omitempty"`
+	StartLedger uint32             `json:"startLedger,omitempty"`
 	Filters     []EventFilter      `json:"filters"`
 	Pagination  *PaginationOptions `json:"pagination,omitempty"`
 }
@@ -295,7 +295,7 @@ type PaginationOptions struct {
 
 type GetEventsResponse struct {
 	Events       []EventInfo `json:"events"`
-	LatestLedger int64       `json:"latestLedger,string"`
+	LatestLedger int64       `json:"latestLedger"`
 }
 
 type eventScanner interface {

--- a/cmd/soroban-rpc/internal/methods/get_events_test.go
+++ b/cmd/soroban-rpc/internal/methods/get_events_test.go
@@ -404,7 +404,7 @@ func TestGetEventsRequestValid(t *testing.T) {
 		[]byte("{ \"filters\": [], \"pagination\": { \"cursor\": \"0000000021474840576-0000000000\"} }"),
 		&request,
 	))
-	assert.Equal(t, int32(0), request.StartLedger)
+	assert.Equal(t, uint32(0), request.StartLedger)
 	assert.NoError(t, request.Valid(1000))
 
 	assert.EqualError(t, (&GetEventsRequest{
@@ -427,12 +427,6 @@ func TestGetEventsRequestValid(t *testing.T) {
 
 	assert.EqualError(t, (&GetEventsRequest{
 		StartLedger: 0,
-		Filters:     []EventFilter{},
-		Pagination:  nil,
-	}).Valid(1000), "startLedger must be positive")
-
-	assert.EqualError(t, (&GetEventsRequest{
-		StartLedger: -100,
 		Filters:     []EventFilter{},
 		Pagination:  nil,
 	}).Valid(1000), "startLedger must be positive")

--- a/cmd/soroban-rpc/internal/methods/get_latest_ledger.go
+++ b/cmd/soroban-rpc/internal/methods/get_latest_ledger.go
@@ -13,7 +13,7 @@ type GetLatestLedgerResponse struct {
 	// Hash of the latest ledger as a hex-encoded string
 	Hash string `json:"id"`
 	// Stellar Core protocol version associated with the ledger.
-	ProtocolVersion uint32 `json:"protocolVersion,string"`
+	ProtocolVersion uint32 `json:"protocolVersion"`
 	// Sequence number of the latest ledger.
 	Sequence uint32 `json:"sequence"`
 }

--- a/cmd/soroban-rpc/internal/methods/get_ledger_entries.go
+++ b/cmd/soroban-rpc/internal/methods/get_ledger_entries.go
@@ -25,16 +25,16 @@ type LedgerEntryResult struct {
 	// Ledger entry data encoded in base 64.
 	XDR string `json:"xdr"`
 	// Last modified ledger for this entry.
-	LastModifiedLedger int64 `json:"lastModifiedLedgerSeq,string"`
+	LastModifiedLedger uint32 `json:"lastModifiedLedgerSeq"`
 	// The ledger sequence until the entry is live, available for entries that have associated ttl ledger entries.
-	LiveUntilLedgerSeq *uint32 `json:"liveUntilLedgerSeq,string,omitempty"`
+	LiveUntilLedgerSeq *uint32 `json:"liveUntilLedgerSeq,omitempty"`
 }
 
 type GetLedgerEntriesResponse struct {
 	// All found ledger entries.
 	Entries []LedgerEntryResult `json:"entries"`
 	// Sequence number of the latest ledger at time of request.
-	LatestLedger int64 `json:"latestLedger,string"`
+	LatestLedger uint32 `json:"latestLedger"`
 }
 
 const getLedgerEntriesMaxKeys = 200
@@ -132,14 +132,14 @@ func NewGetLedgerEntriesHandler(logger *log.Entry, ledgerEntryReader db.LedgerEn
 			ledgerEntryResults = append(ledgerEntryResults, LedgerEntryResult{
 				Key:                keyXDR,
 				XDR:                entryXDR,
-				LastModifiedLedger: int64(ledgerKeyAndEntry.Entry.LastModifiedLedgerSeq),
+				LastModifiedLedger: uint32(ledgerKeyAndEntry.Entry.LastModifiedLedgerSeq),
 				LiveUntilLedgerSeq: ledgerKeyAndEntry.LiveUntilLedgerSeq,
 			})
 		}
 
 		response := GetLedgerEntriesResponse{
 			Entries:      ledgerEntryResults,
-			LatestLedger: int64(latestLedger),
+			LatestLedger: uint32(latestLedger),
 		}
 		return response, nil
 	})

--- a/cmd/soroban-rpc/internal/methods/get_ledger_entry.go
+++ b/cmd/soroban-rpc/internal/methods/get_ledger_entry.go
@@ -24,10 +24,10 @@ type GetLedgerEntryRequest struct {
 // TODO(https://github.com/stellar/soroban-tools/issues/374) remove after getLedgerEntries is deployed.
 type GetLedgerEntryResponse struct {
 	XDR                string `json:"xdr"`
-	LastModifiedLedger int64  `json:"lastModifiedLedgerSeq,string"`
-	LatestLedger       int64  `json:"latestLedger,string"`
+	LastModifiedLedger uint32 `json:"lastModifiedLedgerSeq"`
+	LatestLedger       uint32 `json:"latestLedger"`
 	// The ledger sequence until the entry is live, available for entries that have associated ttl ledger entries.
-	LiveUntilLedgerSeq *uint32 `json:"LiveUntilLedgerSeq,string,omitempty"`
+	LiveUntilLedgerSeq *uint32 `json:"LiveUntilLedgerSeq,omitempty"`
 }
 
 var invalidLedgerKeyXdrError = &jrpc2.Error{
@@ -96,8 +96,8 @@ func NewGetLedgerEntryHandler(logger *log.Entry, ledgerEntryReader db.LedgerEntr
 		}
 
 		response := GetLedgerEntryResponse{
-			LastModifiedLedger: int64(ledgerEntry.LastModifiedLedgerSeq),
-			LatestLedger:       int64(latestLedger),
+			LastModifiedLedger: uint32(ledgerEntry.LastModifiedLedgerSeq),
+			LatestLedger:       latestLedger,
 			LiveUntilLedgerSeq: liveUntilLedgerSeq,
 		}
 		if response.XDR, err = xdr.MarshalBase64(ledgerEntry.Data); err != nil {

--- a/cmd/soroban-rpc/internal/methods/get_network.go
+++ b/cmd/soroban-rpc/internal/methods/get_network.go
@@ -14,7 +14,7 @@ type GetNetworkRequest struct{}
 type GetNetworkResponse struct {
 	FriendbotURL    string `json:"friendbotUrl,omitempty"`
 	Passphrase      string `json:"passphrase"`
-	ProtocolVersion int    `json:"protocolVersion,string"`
+	ProtocolVersion int    `json:"protocolVersion"`
 }
 
 // NewGetNetworkHandler returns a json rpc handler to for the getNetwork method

--- a/cmd/soroban-rpc/internal/methods/get_transaction.go
+++ b/cmd/soroban-rpc/internal/methods/get_transaction.go
@@ -30,11 +30,11 @@ type GetTransactionResponse struct {
 	// Status is one of: TransactionSuccess, TransactionNotFound, or TransactionFailed.
 	Status string `json:"status"`
 	// LatestLedger is the latest ledger stored in Soroban-RPC.
-	LatestLedger int64 `json:"latestLedger,string"`
+	LatestLedger uint32 `json:"latestLedger"`
 	// LatestLedgerCloseTime is the unix timestamp of when the latest ledger was closed.
 	LatestLedgerCloseTime int64 `json:"latestLedgerCloseTime,string"`
 	// LatestLedger is the oldest ledger stored in Soroban-RPC.
-	OldestLedger int64 `json:"oldestLedger,string"`
+	OldestLedger uint32 `json:"oldestLedger"`
 	// LatestLedgerCloseTime is the unix timestamp of when the oldest ledger was closed.
 	OldestLedgerCloseTime int64 `json:"oldestLedgerCloseTime,string"`
 
@@ -53,7 +53,7 @@ type GetTransactionResponse struct {
 	ResultMetaXdr string `json:"resultMetaXdr,omitempty"`
 
 	// Ledger is the sequence of the ledger which included the transaction.
-	Ledger int64 `json:"ledger,string,omitempty"`
+	Ledger uint32 `json:"ledger,omitempty"`
 	// LedgerCloseTime is the unix timestamp of when the transaction was included in the ledger.
 	LedgerCloseTime int64 `json:"createdAt,string,omitempty"`
 }
@@ -86,9 +86,9 @@ func GetTransaction(getter transactionGetter, request GetTransactionRequest) (Ge
 
 	tx, found, storeRange := getter.GetTransaction(txHash)
 	response := GetTransactionResponse{
-		LatestLedger:          int64(storeRange.LastLedger.Sequence),
+		LatestLedger:          storeRange.LastLedger.Sequence,
 		LatestLedgerCloseTime: storeRange.LastLedger.CloseTime,
-		OldestLedger:          int64(storeRange.FirstLedger.Sequence),
+		OldestLedger:          storeRange.FirstLedger.Sequence,
 		OldestLedgerCloseTime: storeRange.FirstLedger.CloseTime,
 	}
 	if !found {
@@ -98,7 +98,7 @@ func GetTransaction(getter transactionGetter, request GetTransactionRequest) (Ge
 
 	response.ApplicationOrder = tx.ApplicationOrder
 	response.FeeBump = tx.FeeBump
-	response.Ledger = int64(tx.Ledger.Sequence)
+	response.Ledger = tx.Ledger.Sequence
 	response.LedgerCloseTime = tx.Ledger.CloseTime
 
 	response.ResultXdr = base64.StdEncoding.EncodeToString(tx.Result)

--- a/cmd/soroban-rpc/internal/methods/send_transaction.go
+++ b/cmd/soroban-rpc/internal/methods/send_transaction.go
@@ -31,7 +31,7 @@ type SendTransactionResponse struct {
 	Hash string `json:"hash"`
 	// LatestLedger is the latest ledger known to Soroban-RPC at the time it handled
 	// the transaction submission request.
-	LatestLedger int64 `json:"latestLedger,string"`
+	LatestLedger uint32 `json:"latestLedger"`
 	// LatestLedgerCloseTime is the unix timestamp of the close time of the latest ledger known to
 	// Soroban-RPC at the time it handled the transaction submission request.
 	LatestLedgerCloseTime int64 `json:"latestLedgerCloseTime,string"`
@@ -106,14 +106,14 @@ func NewSendTransactionHandler(daemon interfaces.Daemon, logger *log.Entry, stor
 				ErrorResultXDR:        resp.Error,
 				Status:                resp.Status,
 				Hash:                  txHash,
-				LatestLedger:          int64(ledgerInfo.Sequence),
+				LatestLedger:          ledgerInfo.Sequence,
 				LatestLedgerCloseTime: ledgerInfo.CloseTime,
 			}, nil
 		case proto.TXStatusPending, proto.TXStatusDuplicate, proto.TXStatusTryAgainLater:
 			return SendTransactionResponse{
 				Status:                resp.Status,
 				Hash:                  txHash,
-				LatestLedger:          int64(ledgerInfo.Sequence),
+				LatestLedger:          ledgerInfo.Sequence,
 				LatestLedgerCloseTime: ledgerInfo.CloseTime,
 			}, nil
 		default:

--- a/cmd/soroban-rpc/internal/methods/simulate_transaction.go
+++ b/cmd/soroban-rpc/internal/methods/simulate_transaction.go
@@ -43,7 +43,7 @@ type SimulateTransactionResponse struct {
 	Results         []SimulateHostFunctionResult `json:"results,omitempty"`         // an array of the individual host function call results
 	Cost            SimulateTransactionCost      `json:"cost,omitempty"`            // the effective cpu and memory cost of the invoked transaction execution.
 	RestorePreamble *RestorePreamble             `json:"restorePreamble,omitempty"` // If present, it indicates that a prior RestoreFootprint is required
-	LatestLedger    int64                        `json:"latestLedger,string"`
+	LatestLedger    uint32                       `json:"latestLedger"`
 }
 
 type PreflightGetter interface {
@@ -125,7 +125,7 @@ func NewSimulateTransactionHandler(logger *log.Entry, ledgerEntryReader db.Ledge
 		if err != nil {
 			return SimulateTransactionResponse{
 				Error:        err.Error(),
-				LatestLedger: int64(latestLedger),
+				LatestLedger: latestLedger,
 			}
 		}
 
@@ -154,7 +154,7 @@ func NewSimulateTransactionHandler(logger *log.Entry, ledgerEntryReader db.Ledge
 				CPUInstructions: result.CPUInstructions,
 				MemoryBytes:     result.MemoryBytes,
 			},
-			LatestLedger:    int64(latestLedger),
+			LatestLedger:    latestLedger,
 			RestorePreamble: restorePreamble,
 		}
 	})

--- a/cmd/soroban-rpc/internal/test/get_ledger_entries_test.go
+++ b/cmd/soroban-rpc/internal/test/get_ledger_entries_test.go
@@ -52,7 +52,7 @@ func TestGetLedgerEntriesNotFound(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, 0, len(result.Entries))
-	assert.Greater(t, result.LatestLedger, int64(0))
+	assert.Greater(t, result.LatestLedger, uint32(0))
 }
 
 func TestGetLedgerEntriesInvalidParams(t *testing.T) {
@@ -153,22 +153,22 @@ func TestGetLedgerEntriesSucceeds(t *testing.T) {
 	err = client.CallResult(context.Background(), "getLedgerEntries", request, &result)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(result.Entries))
-	require.Greater(t, result.LatestLedger, int64(0))
+	require.Greater(t, result.LatestLedger, uint32(0))
 
-	require.Greater(t, result.Entries[0].LastModifiedLedger, int64(0))
+	require.Greater(t, result.Entries[0].LastModifiedLedger, uint32(0))
 	require.LessOrEqual(t, result.Entries[0].LastModifiedLedger, result.LatestLedger)
 	require.NotNil(t, result.Entries[0].LiveUntilLedgerSeq)
-	require.Greater(t, *result.Entries[0].LiveUntilLedgerSeq, uint32(result.LatestLedger))
+	require.Greater(t, *result.Entries[0].LiveUntilLedgerSeq, result.LatestLedger)
 	require.Equal(t, contractCodeKeyB64, result.Entries[0].Key)
 	var firstEntry xdr.LedgerEntryData
 	require.NoError(t, xdr.SafeUnmarshalBase64(result.Entries[0].XDR, &firstEntry))
 	require.Equal(t, xdr.LedgerEntryTypeContractCode, firstEntry.Type)
 	require.Equal(t, contractBinary, firstEntry.MustContractCode().Code)
 
-	require.Greater(t, result.Entries[1].LastModifiedLedger, int64(0))
+	require.Greater(t, result.Entries[1].LastModifiedLedger, uint32(0))
 	require.LessOrEqual(t, result.Entries[1].LastModifiedLedger, result.LatestLedger)
 	require.NotNil(t, result.Entries[1].LiveUntilLedgerSeq)
-	require.Greater(t, *result.Entries[1].LiveUntilLedgerSeq, uint32(result.LatestLedger))
+	require.Greater(t, *result.Entries[1].LiveUntilLedgerSeq, result.LatestLedger)
 	require.Equal(t, contractInstanceKeyB64, result.Entries[1].Key)
 	var secondEntry xdr.LedgerEntryData
 	require.NoError(t, xdr.SafeUnmarshalBase64(result.Entries[1].XDR, &secondEntry))

--- a/cmd/soroban-rpc/internal/test/get_ledger_entry_test.go
+++ b/cmd/soroban-rpc/internal/test/get_ledger_entry_test.go
@@ -107,7 +107,7 @@ func TestGetLedgerEntrySucceeds(t *testing.T) {
 	var result methods.GetLedgerEntryResponse
 	err = client.CallResult(context.Background(), "getLedgerEntry", request, &result)
 	assert.NoError(t, err)
-	assert.Greater(t, result.LatestLedger, int64(0))
+	assert.Greater(t, result.LatestLedger, uint32(0))
 	assert.GreaterOrEqual(t, result.LatestLedger, result.LastModifiedLedger)
 	var entry xdr.LedgerEntryData
 	assert.NoError(t, xdr.SafeUnmarshalBase64(result.XDR, &entry))

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -216,7 +216,7 @@ func TestSimulateTransactionSucceeds(t *testing.T) {
 	contractHash := sha256.Sum256(contractBinary)
 	contractHashBytes := xdr.ScBytes(contractHash[:])
 	expectedXdr := xdr.ScVal{Type: xdr.ScValTypeScvBytes, Bytes: &contractHashBytes}
-	assert.Greater(t, result.LatestLedger, int64(0))
+	assert.Greater(t, result.LatestLedger, uint32(0))
 	assert.Greater(t, result.Cost.CPUInstructions, uint64(0))
 	assert.Greater(t, result.Cost.MemoryBytes, uint64(0))
 
@@ -578,7 +578,7 @@ func TestSimulateTransactionError(t *testing.T) {
 		},
 	}
 	result := simulateTransactionFromTxParams(t, client, params)
-	assert.Greater(t, result.LatestLedger, int64(0))
+	assert.Greater(t, result.LatestLedger, uint32(0))
 	assert.Contains(t, result.Error, "MissingValue")
 	require.Len(t, result.Events, 1)
 	var event xdr.DiagnosticEvent


### PR DESCRIPTION
### What

Closes https://github.com/stellar/soroban-tools/issues/1081

### Why

Consistent is good plus it's cleaner to not stringify fields we don't need to (since they can be treated by javascript).

### Known limitations

Downstream tickets are needed.
