### PR TITLE
rpc: Sanity-check allocations when decoding

### DIFF
--- a/cmd/soroban-rpc/internal/methods/get_ledger_entries.go
+++ b/cmd/soroban-rpc/internal/methods/get_ledger_entries.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/creachadair/jrpc2"
 	"github.com/creachadair/jrpc2/handler"
-	"github.com/stellar/go/gxdr"
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/xdr"
 
@@ -51,14 +50,6 @@ func NewGetLedgerEntriesHandler(logger *log.Entry, ledgerEntryReader db.LedgerEn
 		var ledgerKeys []xdr.LedgerKey
 		for i, requestKey := range request.Keys {
 			var ledgerKey xdr.LedgerKey
-			if err := gxdr.ValidateLedgerKey(requestKey, gxdr.DefaultMaxDepth); err != nil {
-				logger.WithError(err).WithField("request", request).
-					Infof("could not validate ledgerKey at index %d from getLedgerEntries request", i)
-				return GetLedgerEntriesResponse{}, &jrpc2.Error{
-					Code:    jrpc2.InvalidParams,
-					Message: fmt.Sprintf("cannot unmarshal key value %s at index %d", requestKey, i),
-				}
-			}
 			if err := xdr.SafeUnmarshalBase64(requestKey, &ledgerKey); err != nil {
 				logger.WithError(err).WithField("request", request).
 					Infof("could not unmarshal requestKey %s at index %d from getLedgerEntries request", requestKey, i)

--- a/cmd/soroban-rpc/internal/methods/send_transaction.go
+++ b/cmd/soroban-rpc/internal/methods/send_transaction.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/creachadair/jrpc2"
 	"github.com/creachadair/jrpc2/handler"
-	"github.com/stellar/go/gxdr"
 	"github.com/stellar/go/network"
 	proto "github.com/stellar/go/protocols/stellarcore"
 	"github.com/stellar/go/support/log"
@@ -49,24 +48,17 @@ type LatestLedgerStore interface {
 	GetLatestLedger() transactions.LedgerInfo
 }
 
-var invalidTransactionXdrError = &jrpc2.Error{
-	Code:    jrpc2.InvalidParams,
-	Message: "invalid_xdr",
-}
-
 // NewSendTransactionHandler returns a submit transaction json rpc handler
 func NewSendTransactionHandler(daemon interfaces.Daemon, logger *log.Entry, store LatestLedgerStore, passphrase string) jrpc2.Handler {
 	submitter := daemon.CoreClient()
 	return handler.New(func(ctx context.Context, request SendTransactionRequest) (SendTransactionResponse, error) {
-		if err := gxdr.ValidateTransactionEnvelope(request.Transaction, gxdr.DefaultMaxDepth); err != nil {
-			logger.WithError(err).WithField("request", request).
-				Info("could not validate send transaction envelope")
-			return SendTransactionResponse{}, invalidTransactionXdrError
-		}
 		var envelope xdr.TransactionEnvelope
 		err := xdr.SafeUnmarshalBase64(request.Transaction, &envelope)
 		if err != nil {
-			return SendTransactionResponse{}, invalidTransactionXdrError
+			return SendTransactionResponse{}, &jrpc2.Error{
+				Code:    jrpc2.InvalidParams,
+				Message: "invalid_xdr",
+			}
 		}
 
 		var hash [32]byte

--- a/cmd/soroban-rpc/internal/methods/simulate_transaction.go
+++ b/cmd/soroban-rpc/internal/methods/simulate_transaction.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/creachadair/jrpc2"
 	"github.com/creachadair/jrpc2/handler"
-	"github.com/stellar/go/gxdr"
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/xdr"
 
@@ -54,13 +53,6 @@ type PreflightGetter interface {
 func NewSimulateTransactionHandler(logger *log.Entry, ledgerEntryReader db.LedgerEntryReader, ledgerReader db.LedgerReader, getter PreflightGetter) jrpc2.Handler {
 
 	return handler.New(func(ctx context.Context, request SimulateTransactionRequest) SimulateTransactionResponse {
-		if err := gxdr.ValidateTransactionEnvelope(request.Transaction, gxdr.DefaultMaxDepth); err != nil {
-			logger.WithError(err).WithField("request", request).
-				Info("could not validate simulate transaction envelope")
-			return SimulateTransactionResponse{
-				Error: "Could not unmarshal transaction",
-			}
-		}
 		var txEnvelope xdr.TransactionEnvelope
 		if err := xdr.SafeUnmarshalBase64(request.Transaction, &txEnvelope); err != nil {
 			logger.WithError(err).WithField("request", request).


### PR DESCRIPTION
This reverts commit 1ee4113b88fb49e9b3ad2aec8700b4d53473efe7 and updates stellar/go to https://github.com/stellar/go/pull/5116
