### PR TITLE
Make output consistent for all ways to get version

### DIFF
--- a/cmd/soroban-cli/src/commands/mod.rs
+++ b/cmd/soroban-cli/src/commands/mod.rs
@@ -45,11 +45,10 @@ Full CLI reference: https://github.com/stellar/soroban-tools/tree/main/docs/soro
 #[derive(Parser, Debug)]
 #[command(
     name = "soroban",
-    version = version::short(),
-    long_version = version::long(),
     about = ABOUT,
     long_about = ABOUT.to_string() + LONG_ABOUT,
     disable_help_subcommand = true,
+    disable_version_flag = true,
 )]
 pub struct Root {
     #[clap(flatten)]

--- a/cmd/soroban-cli/src/commands/mod.rs
+++ b/cmd/soroban-cli/src/commands/mod.rs
@@ -49,15 +49,8 @@ Full CLI reference: https://github.com/stellar/soroban-tools/tree/main/docs/soro
     version = version::long(),
     long_about = ABOUT.to_string() + LONG_ABOUT,
     disable_help_subcommand = true,
-    disable_version_flag = true,
 )]
 pub struct Root {
-    // Supply alternative and common ways to get at the version via a -V and
-    // --version, but hide it in the help so as not to clutter the help with so
-    // many ways to get at the version.
-    #[arg(short = 'V', long, action = ArgAction::Version, hide = true)]
-    pub version: bool,
-
     #[clap(flatten)]
     pub global_args: global::Args,
 

--- a/cmd/soroban-cli/src/commands/mod.rs
+++ b/cmd/soroban-cli/src/commands/mod.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use clap::{command, error::ErrorKind, CommandFactory, FromArgMatches, Parser};
+use clap::{command, error::ErrorKind, ArgAction, CommandFactory, FromArgMatches, Parser};
 
 pub mod completion;
 pub mod config;
@@ -46,11 +46,18 @@ Full CLI reference: https://github.com/stellar/soroban-tools/tree/main/docs/soro
 #[command(
     name = "soroban",
     about = ABOUT,
+    version = version::long(),
     long_about = ABOUT.to_string() + LONG_ABOUT,
     disable_help_subcommand = true,
     disable_version_flag = true,
 )]
 pub struct Root {
+    // Supply alternative and common ways to get at the version via a -V and
+    // --version, but hide it in the help so as not to clutter the help with so
+    // many ways to get at the version.
+    #[arg(short = 'V', long, action = ArgAction::Version, hide = true)]
+    pub version: bool,
+
     #[clap(flatten)]
     pub global_args: global::Args,
 

--- a/cmd/soroban-cli/src/commands/mod.rs
+++ b/cmd/soroban-cli/src/commands/mod.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use clap::{command, error::ErrorKind, ArgAction, CommandFactory, FromArgMatches, Parser};
+use clap::{command, error::ErrorKind, CommandFactory, FromArgMatches, Parser};
 
 pub mod completion;
 pub mod config;

--- a/cmd/soroban-cli/src/commands/version.rs
+++ b/cmd/soroban-cli/src/commands/version.rs
@@ -15,15 +15,11 @@ impl Cmd {
     }
 }
 
-pub fn short() -> String {
-    format!("{} ({GIT_REVISION})", env!("CARGO_PKG_VERSION"))
-}
-
 pub fn long() -> String {
     let env = soroban_env_host::VERSION;
     let xdr = soroban_env_host::VERSION.xdr;
     [
-        short(),
+        format!("{} ({GIT_REVISION})", env!("CARGO_PKG_VERSION")),
         format!("soroban-env {} ({})", env.pkg, env.rev),
         format!("soroban-env interface version {}", meta::INTERFACE_VERSION),
         format!(


### PR DESCRIPTION
### What
Make output of any way to get at the version consistent.

### Why
We should have one version output for folks to provide consistent version info when reporting bugs.

Close #795