### PR TITLE
soroban-rpc: Add Timeout for Initializing Captive Core

### DIFF
--- a/cmd/soroban-rpc/internal/config/config.go
+++ b/cmd/soroban-rpc/internal/config/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	FriendbotURL                                string
 	HistoryArchiveURLs                          []string
 	IngestionTimeout                            time.Duration
+	CaptiveCoreTimeout                          time.Duration
 	LogFormat                                   LogFormat
 	LogLevel                                    logrus.Level
 	MaxEventsLimit                              uint

--- a/cmd/soroban-rpc/internal/config/options.go
+++ b/cmd/soroban-rpc/internal/config/options.go
@@ -175,6 +175,12 @@ func (cfg *Config) options() ConfigOptions {
 			},
 		},
 		{
+			Name:         "captive-core-timeout",
+			Usage:        "Timeout for configuring and connecting to the specified Stellar Core instance",
+			ConfigKey:    &cfg.CaptiveCoreTimeout,
+			DefaultValue: 1 * time.Minute,
+		},
+		{
 			Name:      "history-archive-urls",
 			Usage:     "comma-separated list of stellar history archives to connect with",
 			ConfigKey: &cfg.HistoryArchiveURLs,

--- a/cmd/soroban-rpc/internal/daemon/daemon.go
+++ b/cmd/soroban-rpc/internal/daemon/daemon.go
@@ -113,6 +113,8 @@ func newCaptiveCore(cfg *config.Config, logger *supportlog.Entry) (*ledgerbacken
 		logger.WithError(err).Fatal("Invalid captive core toml")
 	}
 
+	newCaptiveCoreCtx, cancelNewCaptiveCore := context.WithTimeout(context.Background(), cfg.CaptiveCoreTimeout)
+	defer cancelNewCaptiveCore()
 	captiveConfig := ledgerbackend.CaptiveCoreConfig{
 		BinaryPath:          cfg.StellarCoreBinaryPath,
 		StoragePath:         cfg.CaptiveCoreStoragePath,
@@ -123,6 +125,7 @@ func newCaptiveCore(cfg *config.Config, logger *supportlog.Entry) (*ledgerbacken
 		Toml:                captiveCoreToml,
 		UserAgent:           "captivecore",
 		UseDB:               true,
+		Context:             newCaptiveCoreCtx,
 	}
 	return ledgerbackend.NewCaptive(captiveConfig)
 


### PR DESCRIPTION
### What

Part of #509 

This adds a configurable timeout (default 1m) for initializing and connecting to captive core.

### Why

It's possible that we could get stuck when initializing captive core, so it's useful to set a timeout.
