### PR TITLE
Don't Convert Start Ledger to String for Events Command

### DIFF
--- a/cmd/soroban-cli/src/rpc/mod.rs
+++ b/cmd/soroban-cli/src/rpc/mod.rs
@@ -356,7 +356,7 @@ pub struct Event {
     #[serde(rename = "type")]
     pub event_type: String,
 
-    pub ledger: String,
+    pub ledger: u32,
     #[serde(rename = "ledgerClosedAt")]
     pub ledger_closed_at: String,
 

--- a/cmd/soroban-cli/src/rpc/mod.rs
+++ b/cmd/soroban-cli/src/rpc/mod.rs
@@ -822,7 +822,7 @@ soroban config identity fund {address} --helper-url <url>"#
 
         let mut oparams = ObjectParams::new();
         match start {
-            EventStart::Ledger(l) => oparams.insert("startLedger", l.to_string())?,
+            EventStart::Ledger(l) => oparams.insert("startLedger", l)?,
             EventStart::Cursor(c) => {
                 pagination.insert("cursor".to_string(), c.into());
             }


### PR DESCRIPTION
### What

`soroban events` takes a `uint32` for the `start-ledger` param. We should not convert it to a string before calling the RPC endpoint.
