### PR TITLE
bumped the preflight fees padding on instrs to 3M

### DIFF
--- a/cmd/soroban-rpc/lib/preflight/src/fees.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/fees.rs
@@ -143,7 +143,7 @@ fn calculate_host_function_soroban_resources(
         .get_cpu_insns_consumed()
         .context("cannot get instructions consumed")?;
     let instructions = max(
-        budget_instructions + 1000000,
+        budget_instructions + 3000000,
         budget_instructions * 120 / 100,
     );
     Ok(SorobanResources {


### PR DESCRIPTION
### What

increased the padding on preflight instr fees to 3M

### Why

to enable more advanced contracts that demand more compute to still get through, rather than get a fees exception based on newer v20 cost model.

### Known limitations


