### PR TITLE
increased the instruction padding for preflight fees to 3 million

### DIFF
--- a/cmd/soroban-rpc/lib/preflight/src/fees.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/fees.rs
@@ -138,12 +138,12 @@ fn calculate_host_function_soroban_resources(
         .map(|c| c.encoded_new_value.as_ref().map_or(0, Vec::len) as u32)
         .sum();
 
-    // Add a 20% leeway with a minimum of 1 million instructions
+    // Add a 20% leeway with a minimum of 3 million instructions
     let budget_instructions = budget
         .get_cpu_insns_consumed()
         .context("cannot get instructions consumed")?;
     let instructions = max(
-        budget_instructions + 1000000,
+        budget_instructions + 3000000,
         budget_instructions * 120 / 100,
     );
     Ok(SorobanResources {


### PR DESCRIPTION
### What

increase the instruction budget padding on preflight fees calc

### Why

allows more complex contracts with higher compute to still get through preflight w/o fees error.
### Known limitations


