### PR TITLE
hot fix v20.0.2, increased preflight instruction fee padding to 3 million

### DIFF
--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -236,6 +236,11 @@ func TestSimulateTransactionSucceeds(t *testing.T) {
 			ReadBytes:    0,
 			WriteBytes:   7048,
 		},
+		// the resulting fee is derived from the compute factors and a default padding is applied to instructions by preflight
+		// for test purposes, the most deterministic way to assert the resulting fee is expected value in test scope, is to capture
+		// the resulting fee from current preflight output and re-plug it in here, rather than try to re-implement the cost-model algo
+		// in the test.
+		ResourceFee: 135910,
 	}
 
 	// First, decode and compare the transaction data so we get a decent diff if it fails.
@@ -246,7 +251,7 @@ func TestSimulateTransactionSucceeds(t *testing.T) {
 	assert.InDelta(t, uint32(expectedTransactionData.Resources.Instructions), uint32(transactionData.Resources.Instructions), 3200000)
 	assert.InDelta(t, uint32(expectedTransactionData.Resources.ReadBytes), uint32(transactionData.Resources.ReadBytes), 10)
 	assert.InDelta(t, uint32(expectedTransactionData.Resources.WriteBytes), uint32(transactionData.Resources.WriteBytes), 300)
-	assert.Greater(t, int64(transactionData.ResourceFee), int64(0))
+	assert.InDelta(t, int64(expectedTransactionData.ResourceFee), int64(transactionData.ResourceFee), 3000)
 
 	// Then decode and check the result xdr, separately so we get a decent diff if it fails.
 	assert.Len(t, result.Results, 1)
@@ -1121,7 +1126,11 @@ func TestSimulateSystemEvent(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.InDelta(t, 7464, uint32(transactionData.Resources.ReadBytes), 200)
-	assert.Greater(t, int64(transactionData.ResourceFee), int64(0))
+	// the resulting fee is derived from compute factors and a default padding is applied to instructions by preflight
+	// for test purposes, the most deterministic way to assert the resulting fee is expected value in test scope, is to capture
+	// the resulting fee from current preflight output and re-plug it in here, rather than try to re-implement the cost-model algo
+	// in the test.
+	assert.InDelta(t, 100980, int64(transactionData.ResourceFee), 5000)
 	assert.InDelta(t, 104, uint32(transactionData.Resources.WriteBytes), 15)
 	require.GreaterOrEqual(t, len(response.Events), 3)
 }

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -236,7 +236,6 @@ func TestSimulateTransactionSucceeds(t *testing.T) {
 			ReadBytes:    0,
 			WriteBytes:   7048,
 		},
-		ResourceFee: 113910,
 	}
 
 	// First, decode and compare the transaction data so we get a decent diff if it fails.
@@ -247,7 +246,7 @@ func TestSimulateTransactionSucceeds(t *testing.T) {
 	assert.InDelta(t, uint32(expectedTransactionData.Resources.Instructions), uint32(transactionData.Resources.Instructions), 3200000)
 	assert.InDelta(t, uint32(expectedTransactionData.Resources.ReadBytes), uint32(transactionData.Resources.ReadBytes), 10)
 	assert.InDelta(t, uint32(expectedTransactionData.Resources.WriteBytes), uint32(transactionData.Resources.WriteBytes), 300)
-	assert.InDelta(t, int64(expectedTransactionData.ResourceFee), int64(transactionData.ResourceFee), 3000)
+	assert.Greater(t, int64(transactionData.ResourceFee), int64(0))
 
 	// Then decode and check the result xdr, separately so we get a decent diff if it fails.
 	assert.Len(t, result.Results, 1)
@@ -1122,7 +1121,7 @@ func TestSimulateSystemEvent(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.InDelta(t, 7464, uint32(transactionData.Resources.ReadBytes), 200)
-	assert.InDelta(t, 80980, int64(transactionData.ResourceFee), 5000)
+	assert.Greater(t, int64(transactionData.ResourceFee), int64(0))
 	assert.InDelta(t, 104, uint32(transactionData.Resources.WriteBytes), 15)
 	require.GreaterOrEqual(t, len(response.Events), 3)
 }

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -244,7 +244,7 @@ func TestSimulateTransactionSucceeds(t *testing.T) {
 	err := xdr.SafeUnmarshalBase64(result.TransactionData, &transactionData)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedTransactionData.Resources.Footprint, transactionData.Resources.Footprint)
-	assert.InDelta(t, uint32(expectedTransactionData.Resources.Instructions), uint32(transactionData.Resources.Instructions), 200000)
+	assert.InDelta(t, uint32(expectedTransactionData.Resources.Instructions), uint32(transactionData.Resources.Instructions), 3200000)
 	assert.InDelta(t, uint32(expectedTransactionData.Resources.ReadBytes), uint32(transactionData.Resources.ReadBytes), 10)
 	assert.InDelta(t, uint32(expectedTransactionData.Resources.WriteBytes), uint32(transactionData.Resources.WriteBytes), 300)
 	assert.InDelta(t, int64(expectedTransactionData.ResourceFee), int64(transactionData.ResourceFee), 3000)

--- a/cmd/soroban-rpc/lib/preflight/src/fees.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/fees.rs
@@ -138,12 +138,12 @@ fn calculate_host_function_soroban_resources(
         .map(|c| c.encoded_new_value.as_ref().map_or(0, Vec::len) as u32)
         .sum();
 
-    // Add a 20% leeway with a minimum of 1 million instructions
+    // Add a 20% leeway with a minimum of 3 million instructions
     let budget_instructions = budget
         .get_cpu_insns_consumed()
         .context("cannot get instructions consumed")?;
     let instructions = max(
-        budget_instructions + 1000000,
+        budget_instructions + 3000000,
         budget_instructions * 120 / 100,
     );
     Ok(SorobanResources {


### PR DESCRIPTION
### What

increased the instruction fee padding during preflight to 3 million to accommodate new v20 cost model and more complex contracts that use more compute.

### Why

avoid preflight fees failure on contracts that used to work pre-v20

### Known limitations

[TODO or N/A]
