### PR TITLE
Bump Core and dependency versions to the official tags/images.

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,7 @@ jobs:
 
       # core git ref should be latest commit for stable soroban functionality
       # the core bin can either be compiled in-line here as part of ci,
-      SYSTEM_TEST_CORE_GIT_REF: https://github.com/stellar/stellar-core.git#114b833e755400178a57142f45b7fb892ddb034f
+      SYSTEM_TEST_CORE_GIT_REF: https://github.com/stellar/stellar-core.git#v20.1.0
       SYSTEM_TEST_CORE_COMPILE_CONFIGURE_FLAGS: "--disable-tests"
       # or set SYSTEM_TEST_CORE_GIT_REF to empty, and set SYSTEM_TEST_CORE_IMAGE
       # to pull a pre-compiled image from dockerhub instead
@@ -44,7 +44,7 @@ jobs:
       SYSTEM_TEST_JS_STELLAR_SDK_GH_REF: 
 
       # the version of rs-stellar-xdr to use for quickstart
-      SYSTEM_TEST_RS_XDR_GIT_REF: v20.0.1
+      SYSTEM_TEST_RS_XDR_GIT_REF: v20.0.2
 
       # system test will build quickstart image internally to use for running the service stack
       # configured in standalone network mode(core, rpc)

--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -112,7 +112,7 @@ jobs:
     env:
       SOROBAN_RPC_INTEGRATION_TESTS_ENABLED: true
       SOROBAN_RPC_INTEGRATION_TESTS_CAPTIVE_CORE_BIN: /usr/bin/stellar-core
-      PROTOCOL_20_CORE_DEBIAN_PKG_VERSION: 20.0.3-1655.114b833e7.focal
+      PROTOCOL_20_CORE_DEBIAN_PKG_VERSION: 20.1.0-1656.114b833e7.focal
     steps:
       - uses: actions/checkout@v3
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2533,9 +2533,9 @@ dependencies = [
  "soroban-env-host",
  "soroban-ledger-snapshot",
  "soroban-sdk",
- "soroban-spec 20.0.3",
+ "soroban-spec",
  "soroban-spec-json",
- "soroban-spec-rust 20.0.3",
+ "soroban-spec-rust",
  "soroban-spec-tools",
  "soroban-spec-typescript",
  "stellar-strkey 0.0.7",
@@ -2669,21 +2669,10 @@ dependencies = [
  "rustc_version",
  "sha2 0.10.8",
  "soroban-env-common",
- "soroban-spec 20.1.0",
- "soroban-spec-rust 20.1.0",
+ "soroban-spec",
+ "soroban-spec-rust",
  "stellar-xdr",
  "syn 2.0.39",
-]
-
-[[package]]
-name = "soroban-spec"
-version = "20.0.3"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=93b09e42e4efa841cbd034c0bff0dc362765086c#93b09e42e4efa841cbd034c0bff0dc362765086c"
-dependencies = [
- "base64 0.13.1",
- "stellar-xdr",
- "thiserror",
- "wasmparser 0.88.0",
 ]
 
 [[package]]
@@ -2706,23 +2695,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.9.9",
- "soroban-spec 20.0.3",
+ "soroban-spec",
  "stellar-xdr",
- "thiserror",
-]
-
-[[package]]
-name = "soroban-spec-rust"
-version = "20.0.3"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=93b09e42e4efa841cbd034c0bff0dc362765086c#93b09e42e4efa841cbd034c0bff0dc362765086c"
-dependencies = [
- "prettyplease",
- "proc-macro2",
- "quote",
- "sha2 0.10.8",
- "soroban-spec 20.0.3",
- "stellar-xdr",
- "syn 2.0.39",
  "thiserror",
 ]
 
@@ -2735,7 +2709,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha2 0.10.8",
- "soroban-spec 20.1.0",
+ "soroban-spec",
  "stellar-xdr",
  "syn 2.0.39",
  "thiserror",
@@ -2750,7 +2724,7 @@ dependencies = [
  "hex",
  "itertools 0.10.5",
  "serde_json",
- "soroban-spec 20.0.3",
+ "soroban-spec",
  "stellar-strkey 0.0.7",
  "stellar-xdr",
  "thiserror",
@@ -2773,7 +2747,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.9.9",
- "soroban-spec 20.0.3",
+ "soroban-spec",
  "stellar-xdr",
  "temp-dir",
  "thiserror",
@@ -2795,7 +2769,7 @@ dependencies = [
  "soroban-env-host",
  "soroban-ledger-snapshot",
  "soroban-sdk",
- "soroban-spec 20.0.3",
+ "soroban-spec",
  "soroban-spec-tools",
  "stellar-strkey 0.0.7",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,15 +20,15 @@ git = "https://github.com/stellar/rs-soroban-env"
 rev = "c1b238b65bfd13666be4ac14e0e390c31b549caf"
 
 [workspace.dependencies.soroban-spec]
-version = "=20.0.3"
+version = "=20.1.0"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "93b09e42e4efa841cbd034c0bff0dc362765086c"
+rev = "811ce3da801c03a21d5fa80fda187c0f1012240f"
 # path = "../rs-soroban-sdk/soroban-spec"
 
 [workspace.dependencies.soroban-spec-rust]
-version = "=20.0.3"
+version = "=20.1.0"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "93b09e42e4efa841cbd034c0bff0dc362765086c"
+rev = "811ce3da801c03a21d5fa80fda187c0f1012240f"
 # path = "../rs-soroban-sdk/soroban-spec-rust"
 
 [workspace.dependencies.soroban-spec-json]

--- a/cmd/soroban-rpc/internal/test/docker-compose.yml
+++ b/cmd/soroban-rpc/internal/test/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     # Note: Please keep the image pinned to an immutable tag matching the Captive Core version.
     #       This avoids implicit updates which break compatibility between
     #       the Core container and captive core.
-    image: ${CORE_IMAGE:-stellar/unsafe-stellar-core:20.0.3-1655.114b833e7.focal}
+    image: ${CORE_IMAGE:-stellar/unsafe-stellar-core:20.1.0-1656.114b833e7.focal}
     depends_on:
       - core-postgres
     restart: on-failure


### PR DESCRIPTION
### What
This is a follow-up to #1160 that uses the official tags rather than the interim ones.

### Why
This is needed for #1163.

### Known limitations
n/a