### PR TITLE
rpc: Store and serve the event transaction ID

### DIFF
--- a/cmd/soroban-rpc/internal/events/events_test.go
+++ b/cmd/soroban-rpc/internal/events/events_test.go
@@ -83,7 +83,7 @@ func eventsAreEqual(t *testing.T, a, b []event) {
 
 func TestScanRangeValidation(t *testing.T) {
 	m := NewMemoryStore(interfaces.MakeNoOpDeamon(), "unit-tests", 4)
-	assertNoCalls := func(contractEvent xdr.DiagnosticEvent, cursor Cursor, timestamp int64) bool {
+	assertNoCalls := func(xdr.DiagnosticEvent, Cursor, int64, *xdr.Hash) bool {
 		t.Fatalf("unexpected call")
 		return true
 	}
@@ -362,7 +362,7 @@ func TestScan(t *testing.T) {
 		for _, input := range genEquivalentInputs(testCase.input) {
 			var events []event
 			iterateAll := true
-			f := func(contractEvent xdr.DiagnosticEvent, cursor Cursor, ledgerCloseTimestamp int64) bool {
+			f := func(contractEvent xdr.DiagnosticEvent, cursor Cursor, ledgerCloseTimestamp int64, hash *xdr.Hash) bool {
 				require.Equal(t, ledgerCloseTime(cursor.Ledger), ledgerCloseTimestamp)
 				diagnosticEventXDR, err := contractEvent.MarshalBinary()
 				require.NoError(t, err)
@@ -370,6 +370,7 @@ func TestScan(t *testing.T) {
 					diagnosticEventXDR: diagnosticEventXDR,
 					txIndex:            cursor.Tx,
 					eventIndex:         cursor.Event,
+					txHash:             hash,
 				})
 				return iterateAll
 			}

--- a/cmd/soroban-rpc/internal/methods/get_events_test.go
+++ b/cmd/soroban-rpc/internal/methods/get_events_test.go
@@ -591,7 +591,8 @@ func TestGetEvents(t *testing.T) {
 				),
 			))
 		}
-		assert.NoError(t, store.IngestEvents(ledgerCloseMetaWithEvents(1, now.Unix(), txMeta...)))
+		ledgerCloseMeta := ledgerCloseMetaWithEvents(1, now.Unix(), txMeta...)
+		assert.NoError(t, store.IngestEvents(ledgerCloseMeta))
 
 		handler := eventsRPCHandler{
 			scanner:      store,
@@ -626,6 +627,7 @@ func TestGetEvents(t *testing.T) {
 				Topic:                    []string{value},
 				Value:                    value,
 				InSuccessfulContractCall: true,
+				TransactionHash:          ledgerCloseMeta.TransactionHash(i).HexString(),
 			})
 		}
 		assert.Equal(t, GetEventsResponse{expected, 1}, results)
@@ -699,7 +701,8 @@ func TestGetEvents(t *testing.T) {
 				),
 			))
 		}
-		assert.NoError(t, store.IngestEvents(ledgerCloseMetaWithEvents(1, now.Unix(), txMeta...)))
+		ledgerCloseMeta := ledgerCloseMetaWithEvents(1, now.Unix(), txMeta...)
+		assert.NoError(t, store.IngestEvents(ledgerCloseMeta))
 
 		number := xdr.Uint64(4)
 		handler := eventsRPCHandler{
@@ -738,6 +741,7 @@ func TestGetEvents(t *testing.T) {
 				Topic:                    []string{counterXdr, value},
 				Value:                    value,
 				InSuccessfulContractCall: true,
+				TransactionHash:          ledgerCloseMeta.TransactionHash(4).HexString(),
 			},
 		}
 		assert.Equal(t, GetEventsResponse{expected, 1}, results)
@@ -792,7 +796,8 @@ func TestGetEvents(t *testing.T) {
 				),
 			),
 		}
-		assert.NoError(t, store.IngestEvents(ledgerCloseMetaWithEvents(1, now.Unix(), txMeta...)))
+		ledgerCloseMeta := ledgerCloseMetaWithEvents(1, now.Unix(), txMeta...)
+		assert.NoError(t, store.IngestEvents(ledgerCloseMeta))
 
 		handler := eventsRPCHandler{
 			scanner:      store,
@@ -832,6 +837,7 @@ func TestGetEvents(t *testing.T) {
 				Topic:                    []string{counterXdr, value},
 				Value:                    value,
 				InSuccessfulContractCall: true,
+				TransactionHash:          ledgerCloseMeta.TransactionHash(3).HexString(),
 			},
 		}
 		assert.Equal(t, GetEventsResponse{expected, 1}, results)
@@ -865,7 +871,8 @@ func TestGetEvents(t *testing.T) {
 				),
 			),
 		}
-		assert.NoError(t, store.IngestEvents(ledgerCloseMetaWithEvents(1, now.Unix(), txMeta...)))
+		ledgerCloseMeta := ledgerCloseMetaWithEvents(1, now.Unix(), txMeta...)
+		assert.NoError(t, store.IngestEvents(ledgerCloseMeta))
 
 		handler := eventsRPCHandler{
 			scanner:      store,
@@ -892,6 +899,7 @@ func TestGetEvents(t *testing.T) {
 				Topic:                    []string{counterXdr},
 				Value:                    counterXdr,
 				InSuccessfulContractCall: true,
+				TransactionHash:          ledgerCloseMeta.TransactionHash(0).HexString(),
 			},
 		}
 		assert.Equal(t, GetEventsResponse{expected, 1}, results)
@@ -913,7 +921,8 @@ func TestGetEvents(t *testing.T) {
 				),
 			))
 		}
-		assert.NoError(t, store.IngestEvents(ledgerCloseMetaWithEvents(1, now.Unix(), txMeta...)))
+		ledgerCloseMeta := ledgerCloseMetaWithEvents(1, now.Unix(), txMeta...)
+		assert.NoError(t, store.IngestEvents(ledgerCloseMeta))
 
 		handler := eventsRPCHandler{
 			scanner:      store,
@@ -947,6 +956,7 @@ func TestGetEvents(t *testing.T) {
 				Topic:                    []string{value},
 				Value:                    value,
 				InSuccessfulContractCall: true,
+				TransactionHash:          ledgerCloseMeta.TransactionHash(i).HexString(),
 			})
 		}
 		assert.Equal(t, GetEventsResponse{expected, 1}, results)
@@ -996,7 +1006,8 @@ func TestGetEvents(t *testing.T) {
 				),
 			),
 		}
-		assert.NoError(t, store.IngestEvents(ledgerCloseMetaWithEvents(5, now.Unix(), txMeta...)))
+		ledgerCloseMeta := ledgerCloseMetaWithEvents(5, now.Unix(), txMeta...)
+		assert.NoError(t, store.IngestEvents(ledgerCloseMeta))
 
 		id := &events.Cursor{Ledger: 5, Tx: 1, Op: 0, Event: 0}
 		handler := eventsRPCHandler{
@@ -1031,6 +1042,7 @@ func TestGetEvents(t *testing.T) {
 				Topic:                    []string{counterXdr},
 				Value:                    expectedXdr,
 				InSuccessfulContractCall: true,
+				TransactionHash:          ledgerCloseMeta.TransactionHash(i).HexString(),
 			})
 		}
 		assert.Equal(t, GetEventsResponse{expected, 5}, results)


### PR DESCRIPTION
### What

Add the transaction hash pertaining to each event in the `getEvents` response

### Why

Fixes https://github.com/stellar/soroban-tools/issues/1182

### Known limitations

It increases the size of the in-memory event storage (but this should be mitigated by #1183 )

It would be good to have specific numbers (@psheth9 is working on it)

