### PR TITLE
fix: embed the init template files in the build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3065,6 +3065,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a82c0bbc10308ed323529fd3c1dce8badda635aa319a5ff0e6466f33b8101e3f"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6227c01b1783cdfee1bcf844eb44594cd16ec71c35305bf1c9fb5aade2735e16"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.39",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb0a25bfbb2d4b4402179c2cf030387d9990857ce08a32592c6238db9fa8665"
+dependencies = [
+ "sha2 0.10.8",
+ "walkdir",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3512,6 +3546,7 @@ dependencies = [
  "rand",
  "regex",
  "rpassword",
+ "rust-embed",
  "sep5",
  "serde",
  "serde-aux",

--- a/cmd/soroban-cli/Cargo.toml
+++ b/cmd/soroban-cli/Cargo.toml
@@ -105,6 +105,7 @@ ureq = {version = "2.9.1", features = ["json"]}
 
 tempfile = "3.8.1"
 toml_edit = "0.21.0"
+rust-embed = "8.2.0"
 # For hyper-tls
 [target.'cfg(unix)'.dependencies]
 openssl = { version = "0.10.55", features = ["vendored"] }

--- a/cmd/soroban-cli/Cargo.toml
+++ b/cmd/soroban-cli/Cargo.toml
@@ -105,7 +105,7 @@ ureq = {version = "2.9.1", features = ["json"]}
 
 tempfile = "3.8.1"
 toml_edit = "0.21.0"
-rust-embed = "8.2.0"
+rust-embed = { version = "8.2.0", features = ["debug-embed"] }
 # For hyper-tls
 [target.'cfg(unix)'.dependencies]
 openssl = { version = "0.10.55", features = ["vendored"] }

--- a/cmd/soroban-cli/src/commands/contract/init.rs
+++ b/cmd/soroban-cli/src/commands/contract/init.rs
@@ -6,7 +6,7 @@ use std::fs::read_to_string;
 use std::num::NonZeroU32;
 use std::path::Path;
 use std::sync::atomic::AtomicBool;
-use std::{env, fs, io};
+use std::{fs, io};
 use toml_edit::{Document, Formatted, InlineTable, TomlError, Value};
 
 const SOROBAN_EXAMPLES_URL: &str = "https://github.com/stellar/soroban-examples.git";
@@ -142,14 +142,6 @@ fn init(
     frontend_template: &String,
     with_examples: &[String],
 ) -> Result<(), Error> {
-    let cli_cmd_root = env!("CARGO_MANIFEST_DIR");
-    let template_dir_path = Path::new(cli_cmd_root)
-        .join("src")
-        .join("utils")
-        .join("contract-init-template");
-
-    println!("template_dir_path: {template_dir_path:?}",);
-
     // create a project dir, and copy the contents of the base template (contract-init-template) into it
     std::fs::create_dir_all(project_path).map_err(|e| {
         eprintln!("Error creating new project directory: {project_path:?}");
@@ -222,6 +214,7 @@ fn copy_template_files(project_path: &Path) -> Result<(), Error> {
             e
         })?;
 
+        println!("➕  Writing {}", &to.to_string_lossy());
         fs::write(&to, file_contents).map_err(|e| {
             eprintln!("Error writing file: {to:?}");
             e


### PR DESCRIPTION
### What

Embed the contract_init_template files in the binary using `rust-embed` to make sure that they are accessible to the `init` command to copy to the user's filesystem.

### Why

Fixes the issue reported here: https://discord.com/channels/897514728459468821/1204799895014346842/1204799895014346842


